### PR TITLE
fix: panic on command print

### DIFF
--- a/cmd/arduino-app-cli/main.go
+++ b/cmd/arduino-app-cli/main.go
@@ -55,6 +55,8 @@ func run(configuration cfg.Configuration) error {
 			if !ok {
 				feedback.Fatal(i18n.Tr("Invalid output format: %s", format), feedback.ErrBadArgument)
 			}
+			feedback.SetFormat(format)
+
 			logLevel, err := ParseLogLevel(logLevelStr)
 			if err != nil {
 				feedback.FatalError(err, feedback.ErrBadArgument)


### PR DESCRIPTION
On the last pr, we removed by mistake to set the setformat, which made a panic on some calls of `feedback` like `feedback.OutputStreams`.