### PR TITLE
feat: flash sketch in ram

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1254,10 +1254,8 @@ func configureMicroInRamMode(
 	inst *rpc.Instance,
 ) error {
 	emptyBinDir := paths.New("/tmp/empty")
-	defer emptyBinDir.RemoveAll()
-	if err := emptyBinDir.MkdirAll(); err != nil {
-		return err
-	}
+	_ = emptyBinDir.MkdirAll()
+	defer func() { _ = emptyBinDir.RemoveAll() }()
 
 	zeros, err := os.Open("/dev/zero")
 	if err != nil {


### PR DESCRIPTION
### Motivation

Arduino apps require that the micro is in sync with the orchestration handled by `arduino-app-cli`. In particular, at boot, we need the micro to wait for the `arduino-app-cli`, and start only to execute the sketch of the default app or some other app decided by the user.

For this reason, we need to use the flash on RAM feature of the `zephyr` platform, which allows. In this way, the micro loses the code at every boot, and the `arduino-app-cli` can reflash it with the correct app at boot.

### Change description

Update the flash mode to RAM, and handle the case in which the micro was previously flashed from the IDE2 with an in-flash sketch.

As a general note, a sketch could be flashed in RAM only if the micro is waiting for a sketch, which means that if there is a sketch already running from the flash, it should be removed by flashing an empty one.

### Change description

<!-- What does your code do? -->

### Additional Notes

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
