### PR TITLE
fix(update): skip the dpkg step in case of error

### DIFF
--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -167,24 +167,22 @@ func (s *Service) UpgradePackages(ctx context.Context, names []string) (<-chan u
 // runDpkgConfigureCommand is need in case an upgrade was interrupted in the middle
 // and the dpkg database is in an inconsistent state.
 func runDpkgConfigureCommand(ctx context.Context) error {
-	dpkgCmd, err := paths.NewProcess(nil, "sudo", "dpkg", "--configure", "-a")
+	cmd, err := paths.NewProcess(nil, "sudo", "dpkg", "--configure", "-a")
 	if err != nil {
 		return err
 	}
-	out, err := dpkgCmd.RunAndCaptureCombinedOutput(ctx)
-	if err != nil {
+	if out, err := cmd.RunAndCaptureCombinedOutput(ctx); err != nil {
 		return fmt.Errorf("error running dpkg configure command: %w: %s", err, out)
 	}
 	return nil
 }
 
 func runUpdateCommand(ctx context.Context) error {
-	updateCmd, err := paths.NewProcess(nil, "sudo", "apt-get", "update")
+	cmd, err := paths.NewProcess(nil, "sudo", "apt-get", "update")
 	if err != nil {
 		return err
 	}
-	out, err := updateCmd.RunAndCaptureCombinedOutput(ctx)
-	if err != nil {
+	if out, err := cmd.RunAndCaptureCombinedOutput(ctx); err != nil {
 		return fmt.Errorf("error running apt-get update command: %w: %s", err, out)
 	}
 	return nil
@@ -203,23 +201,24 @@ func runUpgradeCommand(ctx context.Context, names []string) iter.Seq2[string, er
 	args = append(args, names...)
 
 	return func(yield func(string, error) bool) {
-		upgradeCmd, err := paths.NewProcess(env, args...)
+		cmd, err := paths.NewProcess(env, args...)
 		if err != nil {
 			_ = yield("", err)
 			return
 		}
+
 		stdout := orchestrator.NewCallbackWriter(func(line string) {
 			if !yield(line, nil) {
-				err := upgradeCmd.Kill()
-				if err != nil {
+				if err := cmd.Kill(); err != nil {
 					slog.Error("Failed to kill upgrade command", slog.String("error", err.Error()))
 				}
-				return
 			}
 		})
-		upgradeCmd.RedirectStderrTo(stdout)
-		upgradeCmd.RedirectStdoutTo(stdout)
-		if err := upgradeCmd.RunWithinContext(ctx); err != nil {
+		cmd.RedirectStderrTo(stdout)
+		cmd.RedirectStdoutTo(stdout)
+
+		if err := cmd.RunWithinContext(ctx); err != nil {
+			_ = yield("", err)
 			return
 		}
 	}
@@ -228,18 +227,25 @@ func runUpgradeCommand(ctx context.Context, names []string) iter.Seq2[string, er
 
 func runAptCleanCommand(ctx context.Context) iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {
-		cleanCmd, err := paths.NewProcess(nil, "sudo", "apt-get", "clean", "-y")
+		cmd, err := paths.NewProcess(nil, "sudo", "apt-get", "clean", "-y")
 		if err != nil {
 			_ = yield("", err)
 			return
 		}
+
 		stdout := orchestrator.NewCallbackWriter(func(line string) {
-			_ = yield(line, nil)
+			if !yield(line, nil) {
+				if err := cmd.Kill(); err != nil {
+					slog.Error("Failed to kill apt clean command", slog.String("error", err.Error()))
+				}
+			}
 		})
-		cleanCmd.RedirectStderrTo(stdout)
-		cleanCmd.RedirectStdoutTo(stdout)
-		if err := cleanCmd.RunWithinContext(ctx); err != nil {
+		cmd.RedirectStderrTo(stdout)
+		cmd.RedirectStdoutTo(stdout)
+
+		if err := cmd.RunWithinContext(ctx); err != nil {
 			_ = yield("", err)
+			return
 		}
 	}
 }
@@ -251,19 +257,19 @@ func pullDockerImages(ctx context.Context) iter.Seq2[string, error] {
 			_ = yield("", err)
 			return
 		}
+
 		stdout := orchestrator.NewCallbackWriter(func(line string) {
 			if !yield(line, nil) {
-				err := cmd.Kill()
-				if err != nil {
+				if err := cmd.Kill(); err != nil {
 					slog.Error("Failed to kill 'arduino-app-cli system init' command", slog.String("error", err.Error()))
 				}
-				return
 			}
 		})
 		cmd.RedirectStderrTo(stdout)
 		cmd.RedirectStdoutTo(stdout)
-		err = cmd.RunWithinContext(ctx)
-		if err != nil {
+
+		if err = cmd.RunWithinContext(ctx); err != nil {
+			_ = yield("", err)
 			return
 		}
 	}
@@ -280,19 +286,15 @@ func cleanupDockerContainers(ctx context.Context) iter.Seq2[string, error] {
 
 		stdout := orchestrator.NewCallbackWriter(func(line string) {
 			if !yield(line, nil) {
-				err := cmd.Kill()
-				if err != nil {
+				if err := cmd.Kill(); err != nil {
 					slog.Error("Failed to kill 'arduino-app-cli system cleanup' command", slog.String("error", err.Error()))
 				}
-				return
 			}
 		})
-
 		cmd.RedirectStderrTo(stdout)
 		cmd.RedirectStdoutTo(stdout)
 
-		err = cmd.RunWithinContext(ctx)
-		if err != nil {
+		if err = cmd.RunWithinContext(ctx); err != nil {
 			_ = yield("", err)
 			return
 		}
@@ -310,11 +312,7 @@ func restartServices(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	err = needRestartCmd.RunWithinContext(ctx)
-	if err != nil {
-		return err
-	}
-	return nil
+	return needRestartCmd.RunWithinContext(ctx)
 }
 
 func listUpgradablePackages(ctx context.Context, matcher func(update.UpgradablePackage) bool) ([]update.UpgradablePackage, error) {


### PR DESCRIPTION
### Motivation

The dpkg step in system update was meant only to fix the database corruption issue; if it fails, we could still attempt to update the packages.

### Change description

<!-- What does your code do? -->

### Additional Notes

- Fix also an issue that makes the upgrade operation exit without an error.

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
