### PR TITLE
fix(deb): remove chown of config

### DIFF
--- a/debian/arduino-app-cli/DEBIAN/postinst
+++ b/debian/arduino-app-cli/DEBIAN/postinst
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-chown -R arduino:arduino /home/arduino/.config/arduino-app-cli
 chown -R arduino:arduino /home/arduino/.local/share/arduino-app-cli
 
 systemctl enable arduino-app-cli


### PR DESCRIPTION
### Motivation

postint script fails because the folder .config doesn't exist anymore.
This causes the restart to fail, so the old daemon continues to run

### Change description

removed the command.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
