### PR TITLE
fix: app-bricks-examples repo name

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -116,7 +116,7 @@ tasks:
           TMP_PATH="$(mktemp -d)"
           DEST_PATH="debian/arduino-app-cli/home/arduino/.local/share/arduino-app-cli/"
           echo "Cloning arduino/app-bricks-example into temporary directory ${TMP_PATH}..."
-          git clone --depth 1 --branch "{{ .EXAMPLE_VERSION }}" https://github.com/arduino/app-bricks-example "${TMP_PATH}"
+          git clone --depth 1 --branch "{{ .EXAMPLE_VERSION }}" https://github.com/arduino/app-bricks-examples "${TMP_PATH}"
           rm -rf "${DEST_PATH}/examples"
           mkdir -p "${DEST_PATH}"
           mv "${TMP_PATH}/examples" "${DEST_PATH}"


### PR DESCRIPTION
### Motivation

It seems that now the repo is called `examples` and not `example`.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
