### PR TITLE
fix: burn bootloader at first boot

### DIFF
--- a/debian/arduino-app-cli/DEBIAN/postinst
+++ b/debian/arduino-app-cli/DEBIAN/postinst
@@ -3,3 +3,4 @@
 chown -R arduino:arduino /home/arduino/.local/share/arduino-app-cli
 
 systemctl enable arduino-app-cli
+systemctl enable arduino-burn-bootloader

--- a/debian/arduino-app-cli/DEBIAN/prerm
+++ b/debian/arduino-app-cli/DEBIAN/prerm
@@ -1,3 +1,4 @@
 #!/bin/sh
 
 systemctl disable arduino-app-cli
+systemctl disable arduino-burn-bootloader

--- a/debian/arduino-app-cli/etc/systemd/system/arduino-burn-bootloader.service
+++ b/debian/arduino-app-cli/etc/systemd/system/arduino-burn-bootloader.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Burn arduino zephyr bootloader on first boot
+After=fs-local.target
+ConditionPathExists=!/home/arduino/.local/share/arduino-app-cli/bootloader_burned.flag
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+User=arduino
+Group=arduino
+ExecStart=/usr/bin/arduino-cli burn-bootloader -b arduino:zephyr:unoq -P jlink
+ExecStartPost=/bin/mkdir -p /home/arduino/.local/share/arduino-app-cli
+ExecStartPost=/bin/touch /home/arduino/.local/share/arduino-app-cli/bootloader_burned.flag
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### Motivation

We need to be sure that he zephyr bootloader on the board is aligned with the version of the core installed. After a fresh installation of the OS, the core installed might be different from the bootloader on the micro, so we need to reflash it.

### Change description

Add a new service that runs only the first boot to flash the bootloader.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
