### PR TITLE
chore: remove unused libraries in empty app

### DIFF
--- a/internal/orchestrator/app/generator/app_template/sketch/sketch.yaml
+++ b/internal/orchestrator/app/generator/app_template/sketch/sketch.yaml
@@ -3,8 +3,4 @@ profiles:
     platforms:
       - platform: arduino:zephyr
     libraries:
-      - MsgPack (0.4.2)
-      - DebugLog (0.8.4)
-      - ArxContainer (0.7.0)
-      - ArxTypeTraits (0.3.1)
 default_profile: default

--- a/internal/orchestrator/app/generator/testdata/app-all.golden/sketch/sketch.yaml
+++ b/internal/orchestrator/app/generator/testdata/app-all.golden/sketch/sketch.yaml
@@ -3,8 +3,4 @@ profiles:
     platforms:
       - platform: arduino:zephyr
     libraries:
-      - MsgPack (0.4.2)
-      - DebugLog (0.8.4)
-      - ArxContainer (0.7.0)
-      - ArxTypeTraits (0.3.1)
 default_profile: default


### PR DESCRIPTION
### Motivation

We should ~use the same sketch template of the Arduino IDE2 and~ remove not used libraries in the profile.

### Change description

<!-- What does your code do? -->

### Additional Notes

- waits for https://github.com/arduino/arduino-app-cli/pull/35

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
