### PR TITLE
fix: Use a valid origin in the config check for websockets

### DIFF
--- a/internal/api/handlers/monitor.go
+++ b/internal/api/handlers/monitor.go
@@ -128,7 +128,7 @@ func checkOrigin(origin string, allowedOrigins []string) bool {
 
 func HandleMonitorWS(allowedOrigins []string) http.HandlerFunc {
 	// Do a dry-run of checkorigin, so it can panic if misconfigured now, not on first request
-	_ = checkOrigin("http://example.com:8000", allowedOrigins)
+	_ = checkOrigin("http://localhost", allowedOrigins)
 
 	upgrader := websocket.Upgrader{
 		ReadBufferSize:  1024,

--- a/internal/api/handlers/monitor_test.go
+++ b/internal/api/handlers/monitor_test.go
@@ -41,6 +41,7 @@ func TestCheckOrigin(t *testing.T) {
 	allow("wails://wails")
 	allow("wails://wails:8000")
 	allow("http://wails.localhost")
+	allow("http://localhost")
 	allow("http://example.com:7000")
 	allow("https://blah.com:443")
 	deny("wails://evil.com")


### PR DESCRIPTION
### Motivation

This will silence a spurious warning.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [X] PR addresses a single concern.
- [X] PR title and description are properly filled.
- [X] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [X] Logging is meaningful in case of troubleshooting.
