### PR TITLE
fix: install a library missing from local library-index

### DIFF
--- a/internal/orchestrator/sketch_libs.go
+++ b/internal/orchestrator/sketch_libs.go
@@ -53,7 +53,6 @@ func AddSketchLibrary(ctx context.Context, app app.ArduinoApp, libRef LibraryRel
 	// update the local library index after a certain time, to avoid if a library is added to the sketch but the local library index is not update, the compile can fail (because the lib is not found)
 	req := &rpc.UpdateLibrariesIndexRequest{Instance: inst, UpdateIfOlderThanSecs: int64(indexUpdateInterval.Seconds())}
 	if err := srv.UpdateLibrariesIndex(req, stream); err != nil {
-		// ignore the error because a missing connection should not stop the user from adding a library.
 		slog.Warn("error updating library index, skipping", slog.String("error", err.Error()))
 	}
 


### PR DESCRIPTION
### Motivation
Fix #45.

If a library is installed on the board, but it is not present in the local `library_index`, the installation fails because it is not found.

This can happen when a library is added to the public library registry, but the local index on the board is not updated.

The manual solution is to launch the command `arduino-cli lib update-index` on the board.

### Change description 
- When a library is added, if the local library index has expired, the local library index is updated by running `arduino-cli lib update-index`
-  The local library-index expires in `10 minutes` 


### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
