### PR TITLE
Expose serial number for App-Lab in network mode

### DIFF
--- a/pkg/board/board.go
+++ b/pkg/board/board.go
@@ -182,9 +182,10 @@ func FromFQBN(ctx context.Context, fqbn string) ([]Board, error) {
 		if len(port.GetMatchingBoards()) > 0 {
 			boardName = port.GetMatchingBoards()[0].GetName()
 		}
-		serial := strings.ToLower(port.GetPort().GetHardwareId()) // in windows this is uppercase.
+
 		switch port.GetPort().GetProtocol() {
 		case SerialProtocol:
+			serial := strings.ToLower(port.GetPort().GetHardwareId()) // in windows this is uppercase.
 			// TODO: we should store the board custom name in the product id so we can get it from the discovery service.
 			var customName string
 			if conn, err := adb.FromSerial(serial, ""); err == nil {
@@ -208,6 +209,10 @@ func FromFQBN(ctx context.Context, fqbn string) ([]Board, error) {
 					idx = len(name)
 				}
 				customName = name[:idx]
+			}
+			var serial string
+			if sn, ok := port.GetPort().GetProperties()["serial_number"]; ok {
+				serial = sn
 			}
 
 			boards = append(boards, Board{


### PR DESCRIPTION
### Motivation

A board connected via both USB and Network currently shows up as two separate devices in the board list. This makes it difficult for a client application to know it is the same physical board.

We need a way to "deduplicate" these entries by providing a common identifier, allowing the client to show just one entry for that board.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
