### PR TITLE
fix(pkg/board): handler error in GetCmd creation

### DIFF
--- a/pkg/board/remote/adb/adb.go
+++ b/pkg/board/remote/adb/adb.go
@@ -227,7 +227,6 @@ func (a *ADBConnection) Remove(path string) error {
 
 type ADBCommand struct {
 	cmd *paths.Process
-
 	err error
 }
 


### PR DESCRIPTION
### Motivation

We should return an error if we aren't able to create a process in `adb.GetCmd`.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
