### PR TITLE
fix: force app stop also if it isn't running

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -388,16 +388,6 @@ func stopAppWithCmd(ctx context.Context, docker command.Cli, app app.ArduinoApp,
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
-		appStatus, err := getAppStatus(ctx, docker, app)
-		if err != nil {
-			yield(StreamMessage{error: err})
-			return
-		}
-		if appStatus.Status != StatusStarting && appStatus.Status != StatusRunning {
-			yield(StreamMessage{data: fmt.Sprintf("app %q is not running", app.Name)})
-			return
-		}
-
 		if !yield(StreamMessage{data: fmt.Sprintf("Stopping app %q", app.Name)}) {
 			return
 		}
@@ -413,7 +403,16 @@ func stopAppWithCmd(ctx context.Context, docker command.Cli, app app.ArduinoApp,
 		})
 
 		if app.MainSketchPath != nil {
-			// TODO: check that the app sketch is running before attempting to stop it.
+			// Before stopping the microcontroller we want to make sure that the app was running.
+			appStatus, err := getAppStatus(ctx, docker, app)
+			if err != nil {
+				yield(StreamMessage{error: err})
+				return
+			}
+			if appStatus.Status != StatusStarting && appStatus.Status != StatusRunning {
+				yield(StreamMessage{data: fmt.Sprintf("app %q is not running", app.Name)})
+				return
+			}
 
 			if err := micro.Disable(); err != nil {
 				yield(StreamMessage{error: err})


### PR DESCRIPTION
### Motivation

Fix an issue introduced in a recent change https://github.com/arduino/arduino-app-cli/pull/84, which was preventing a user from forcing stop to an application that was partially running, due to an error in the python code.

### Change description

The PR checks if the app is running only before stopping the microcontroler, which is a shared resource with other apps, and was causing a weird bug for which stopping any application was making another running app crash.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
