### PR TITLE
fix: prevent app-cli to restart adbd

### DIFF
--- a/debian/arduino-app-cli/etc/needrestart/conf.d/arduino-adbd.conf
+++ b/debian/arduino-app-cli/etc/needrestart/conf.d/arduino-adbd.conf
@@ -1,0 +1,3 @@
+# exclude adbd from service that need to be restarted.
+$nrconf{override_rc}{qr(^adbd\.service$)} = 0;
+


### PR DESCRIPTION
### Motivation

The adb is crucial for communicating with the UNO Q via usb, so we should be sure that it will not be restarted, and if it is updated. It is ok to update it on the next restart of the board.

### Change description

Use the very ugly perl syntax to defer the restart of the adbd service.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
