### PR TITLE
feat: add by-id folder view for sound subsystem

### DIFF
--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -335,6 +335,16 @@ func generateMainComposeFile(
 			})
 		}
 	}
+	if devices.hasSoundDevice {
+		// If we are adding sound devices, mount also /dev/snd/by-id if it exists to allow access to by-id links
+		if paths.New("/dev/snd/by-id").Exist() {
+			volumes = append(volumes, volume{
+				Type:   "bind",
+				Source: "/dev/snd/by-id",
+				Target: "/dev/snd/by-id",
+			})
+		}
+	}
 
 	volumes = addLedControl(volumes)
 


### PR DESCRIPTION
### Motivation

**alsa** provide a `by-id` view to help keep track of connected devices. Bricks need to use that view to better identify audio devices.

### Change description

mount volume `/dev/snd/by-id` into main python runner container

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
