### PR TITLE
Update the local libray index

### DIFF
--- a/internal/update/arduino/arduino.go
+++ b/internal/update/arduino/arduino.go
@@ -86,7 +86,7 @@ func (a *ArduinoPlatformUpdater) ListUpgradablePackages(ctx context.Context, _ f
 		slog.Debug("downloading library index", "progress", curr.GetMessage())
 	})
 
-	req := &rpc.UpdateLibrariesIndexRequest{Instance: inst, UpdateIfOlderThanSecs: 0}
+	req := &rpc.UpdateLibrariesIndexRequest{Instance: inst}
 	if err := srv.UpdateLibrariesIndex(req, streamLibIndex); err != nil {
 		slog.Warn("error updating library index, skipping", slog.String("error", err.Error()))
 	}


### PR DESCRIPTION
### Motivation

closes #104

The library-index (located in `/home/arduino/.arduino15/library_index.json`) is installed on the board with the latest version available at the time the Debian image was created.

The library index is updated by the `arduino-app-cli` only when a new library is added.  
See https://github.com/arduino/arduino-app-cli/pull/50 

The compilation of an example fails if the "add library" was never executed,

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
