### PR TITLE
Hotfix the missing required device for the Theremin example

### DIFF
--- a/debian/arduino-app-cli/home/arduino/.local/share/arduino-app-cli/assets/0.6.0/bricks-list.yaml
+++ b/debian/arduino-app-cli/home/arduino/.local/share/arduino-app-cli/assets/0.6.0/bricks-list.yaml
@@ -93,6 +93,8 @@ bricks:
   mount_devices_into_container: false
   ports: []
   category: audio
+  required_devices:
+  - speaker
 - id: arduino:image_classification
   name: Image Classification
   description: "Brick for image classification using a pre-trained model. It processes\


### PR DESCRIPTION
Hotfix the missing required device for the Theremin example.
This changes directly an auto-generated file, a complete fix will come in about 1 day, as a new version of the examples.

The brick was missing this part:
```
  required_devices:
  - speaker
```
And so the Theremin example, when launched without a USB speaker connected, would fail silently.