### PR TITLE
feat: Remove misleading `fqbn` sketch build profile key from App template

### DIFF
--- a/internal/orchestrator/app/generator/app_template/sketch/sketch.yaml
+++ b/internal/orchestrator/app/generator/app_template/sketch/sketch.yaml
@@ -1,6 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
     libraries:

--- a/internal/orchestrator/app/generator/testdata/app-all.golden/sketch/sketch.yaml
+++ b/internal/orchestrator/app/generator/testdata/app-all.golden/sketch/sketch.yaml
@@ -1,6 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
     libraries:

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1187,8 +1187,8 @@ func compileUploadSketch(
 				response = "Error: " + msg.Error.String()
 			case *rpc.InitResponse_Profile:
 				response = fmt.Sprintf(
-					"Sketch profile configured: FQBN=%q, Port=%q",
-					msg.Profile.GetFqbn(),
+					"Sketch profile configured: Name=%q, Port=%q",
+					msg.Profile.GetName(),
 					msg.Profile.GetPort(),
 				)
 			}


### PR DESCRIPTION
### Motivation

When a new App is generated, it contains a sketch which in turn contains a [build profile](https://arduino.github.io/arduino-cli/dev/sketch-project-file/#build-profiles). Previously, the `fqbn` key of this build profile was set to `arduino:zephyr:unoq`. Since the build profile is indeed used to control the dependencies of the sketch, the user would be led to also believe that the FQBN specified in the build profile is used when compiling and uploading the sketch. This is not so. An FQBN is instead hardcoded into the compilation and upload code (https://github.com/arduino/arduino-app-cli/pull/12):

https://github.com/arduino/arduino-app-cli/blob/51dab70346f2080179b869194049e5dfe7e86f0a/internal/orchestrator/orchestrator.go#L1209

https://github.com/arduino/arduino-app-cli/blob/51dab70346f2080179b869194049e5dfe7e86f0a/internal/orchestrator/orchestrator.go#L1256

This means the `fqbn` key in the build profile has absolutely no effect.

The obvious problem with this is that it will lead the advanced user to believe they can configure the FQBN used by App Lab via the `fqbn` key of the build profile. For example, they might wish to use the `arduino:zephyr:unoq:flash_mode=flash,wait_linux_boot=no` FQBN (https://github.com/arduino/ArduinoCore-zephyr/commit/8119c2bf68f5d1eb81d9b0560df972170d76ca7c) in cases where the sketch code is not reliant on the immediate availability of the Linux machine and they do not wish for the execution of the sketch program to be delayed after power on.

Even more confusing is the fact that the `arduino:zephyr:unoq:flash_mode=ram` FQBN used when uploading is different from the FQBN the default build profile would lead the user to believe is in use (since [the default value of the `flash_mode` custom board option is `flash`](https://github.com/arduino/ArduinoCore-zephyr/blob/0.52.0/boards.txt#L543) NOT `ram`, and thus the `arduino:zephyr:unoq` used in the template is equivalent to `arduino:zephyr:unoq:flash_mode=flash`).

### Change description

Remove the unused and misleading `fqbn` key from the generated build profile. This will better communicate the actual situation to the user.

### Additional Notes

Related: https://forum.arduino.cc/t/issues-witho-monitor-and-bridge/1416857

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
