### PR TITLE
fix: force error on apt update

### DIFF
--- a/debian/arduino-app-cli/etc/apt/apt.conf.d/20updateerrors
+++ b/debian/arduino-app-cli/etc/apt/apt.conf.d/20updateerrors
@@ -1,0 +1,1 @@
+APT::Update::Error-Mode "any";


### PR DESCRIPTION
### Motivation

By default, apt-get update doesn't retunrs any error in the status code if something went wrong during repository update. We want instead to catch this error, which usually means that the board wasn't able to validate the apt repo certificates.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
