### PR TITLE
feat(pkg/boards): get on board image version

### DIFF
--- a/pkg/board/os_image.go
+++ b/pkg/board/os_image.go
@@ -53,7 +53,7 @@ func parseOSImageVersion(r io.Reader) (string, bool) {
 			continue
 		}
 
-		version := strings.Trim(value, `"' `)
+		version := strings.TrimSpace(value)
 		if version != "" {
 			return version, true
 		}

--- a/pkg/board/os_image_test.go
+++ b/pkg/board/os_image_test.go
@@ -77,7 +77,7 @@ func TestParseOSImageVersion(t *testing.T) {
 	}{
 		{
 			name:     "valid build id",
-			input:    "BUILD_ID=\"20251006-395\"\nVARIANT_ID=xfce",
+			input:    "BUILD_ID=20251006-395\nVARIANT_ID=xfce",
 			expected: "20251006-395",
 			found:    true,
 		},


### PR DESCRIPTION
### Motivation

closes [#41 ](https://github.com/arduino/arduino-flasher-cli/issues/41)
Get the version of the image on the board to know if it supports user preservation when it is not in EDL mode. The equivalent of adb shell 'cat /etc/buildinfo' could be sufficient, but we want to return only the BUILD_ID.
If /etc/buildinfo does not exist, assume it is an R0 image and return it as the default value.

At this level, there is no way to check for EDL mode.
The current behavior is "if the board is detected. It is not in EDL mode."
In any case, this check will be done by the caller.

Change GetOsImageVersion()
Add test if possible
log - INFO

manual test, add the call in main() log - ERROR
### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
