### PR TITLE
fix(update): always try to restart the app-cli daemon

### DIFF
--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -83,7 +83,8 @@ func (s *Service) UpgradePackages(ctx context.Context, names []string) (<-chan u
 		defer s.lock.Unlock()
 		defer close(eventsCh)
 
-		// We try anyway to restart the service.
+		// At the end of the upgrade, always try to restart the services (that need it).
+		// This makes sure key services are restarted even if an error happens in the upgrade steps (for examples container images download).
 		defer func() {
 			eventsCh <- update.NewDataEvent(update.RestartEvent, "Upgrade completed. Restarting ...")
 


### PR DESCRIPTION
### Motivation

We want to always try to restart the `arduino-app-cli` daemon, no matter what happened.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
