### PR TITLE
(fix) Delete App by path

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -897,15 +897,9 @@ func CloneApp(
 
 func DeleteApp(ctx context.Context, dockerClient command.Cli, app app.ArduinoApp) error {
 
-	runningApp, err := getRunningApp(ctx, dockerClient.Client())
-	if err != nil {
-		return err
-	}
-	if runningApp != nil && runningApp.FullPath.EqualsTo(app.FullPath) {
-		// We try to remove docker related resources at best effort
-		for range StopAndDestroyApp(ctx, dockerClient, app) {
-			// just consume the iterator
-		}
+	// We try to remove docker related resources at best effort
+	for range StopAndDestroyApp(ctx, dockerClient, app) {
+		// just consume the iterator
 	}
 
 	return app.FullPath.RemoveAll()


### PR DESCRIPTION
### Motivation

DeleteApp method should stop and destroy each application selected for deletion by the user.
As of now just starting or restarting app are running or starting. So all the application that are in other status will be deleted (removed) but the resource will be not destroyed. This will create an inconsistent state for the app that will be created with the same name (app path)


