### PR TITLE
chore: fix the task `api:docs` command

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -99,7 +99,7 @@ tasks:
   api:docs:
     desc: Open api docs
     cmds:
-      - python3 -m http.server 8000 -d docs
+      - python3 -m http.server 8000 -d internal/api/docs/
 
   build-deb:
     desc: Build debian package


### PR DESCRIPTION
### Motivation
The open api docs was not served locally.

### Change description

Serve the folder `internal/api/docs/` where the open api definition is located.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
