### PR TITLE
[API] Get the resource usage of a model

### DIFF
--- a/internal/orchestrator/models.go
+++ b/internal/orchestrator/models.go
@@ -17,10 +17,14 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 
 	"github.com/arduino/go-paths-helper"
+	yaml "github.com/goccy/go-yaml"
 
 	"github.com/arduino/arduino-app-cli/internal/edgeimpulse"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
@@ -51,8 +55,11 @@ type AIModelItem struct {
 	Bricks             []string          `json:"brick_ids"`
 	Metadata           map[string]string `json:"metadata,omitempty"`
 	ModelConfiguration map[string]string `json:"model_configuration,omitempty"`
+	Resources          Resources         `json:"resources,omitempty"`
 }
-
+type Resources struct {
+	DiskUsageMB int `json:"disk_usage_mb"`
+}
 type AIModelsListRequest struct {
 	FilterByBrickID []string
 }
@@ -85,6 +92,23 @@ func AIModelDetails(modelsIndex *modelsindex.ModelsIndex, id string) (AIModelIte
 	if !found {
 		return AIModelItem{}, false
 	}
+
+	modelDir, err := findModelDirByID(modelsIndex.GetModelsDir(), id)
+	if err != nil {
+		slog.Error("failed to find model directory", "err", err)
+		return AIModelItem{}, false
+	}
+
+	sizeMB, err := getModelSizeMB(modelDir)
+	if err != nil {
+		slog.Error("failed to calculate model size", "err", err)
+		return AIModelItem{}, false
+	}
+
+	modelResource := Resources{
+		DiskUsageMB: int(sizeMB),
+	}
+
 	return AIModelItem{
 		ID:                 model.ID,
 		Name:               model.Name,
@@ -93,7 +117,72 @@ func AIModelDetails(modelsIndex *modelsindex.ModelsIndex, id string) (AIModelIte
 		Bricks:             model.Bricks,
 		Metadata:           model.Metadata,
 		ModelConfiguration: model.ModelConfiguration,
+		Resources:          modelResource,
 	}, true
+}
+
+func findModelDirByID(modelDir *paths.Path, id string) (*paths.Path, error) {
+	var foundDir string
+
+	err := filepath.WalkDir(modelDir.String(), func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != "model.yaml" {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		var descriptor aimodel.ModelDescriptor
+		if err := yaml.Unmarshal(data, &descriptor); err != nil {
+			return err
+		}
+
+		if descriptor.ID == id {
+			foundDir = filepath.Dir(path)
+			return filepath.SkipDir
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if foundDir == "" {
+		return nil, errors.New("model not found with id: " + id)
+	}
+
+	return paths.New(foundDir), nil
+}
+
+func getModelSizeMB(dirPath *paths.Path) (float64, error) {
+	var totalSize int64
+
+	err := filepath.WalkDir(dirPath.String(), func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			totalSize += info.Size()
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	sizeMB := float64(totalSize) / (1024 * 1024)
+	return sizeMB, nil
 }
 
 func InstallEIModel(ctx context.Context, bricksIndex *bricksindex.BricksIndex, eiClient *edgeimpulse.EIClient, modelsDir *paths.Path, projectID int, impulseID int, modelType string, engine string) error {

--- a/internal/orchestrator/modelsindex/models_index.go
+++ b/internal/orchestrator/modelsindex/models_index.go
@@ -66,6 +66,10 @@ type ModelsIndex struct {
 	modelsDir          *paths.Path
 }
 
+func (m *ModelsIndex) GetModelsDir() *paths.Path {
+	return m.modelsDir
+}
+
 func (m *ModelsIndex) GetModels() []AIModel {
 	return m.buildModels()
 }


### PR DESCRIPTION
### Motivation

closes [397](https://github.com/arduino/private-tooling-team/issues/397)

We may add the disk space used by the model. 

The Fe does not the following check
- Get the remaining disk space (total-busy)
- if remaininig + model disk space > board disk space then error

We may add this information in the `GET /v1/models/:id` endpoint. 
For each model, the disk space is calculated.

#### JSON Structure

-  Name: `disk_usage` or `storage_bytes` or `size`
-  type: `integer`, representing model size in bytes

1. nested object. Since these are AI models, we might need to expose other resource requirements in the future
```
{
"id": "my-model-id",
  // ... other **fields**
"resources": {
    "disk_usage_mb": 104857600,  // 100 MB in bytes
  }
}
```

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
