### PR TITLE
fix(pkg/board): make sure to close the cmd in case of error

### DIFF
--- a/pkg/board/remote/adb/adb_nowindows.go
+++ b/pkg/board/remote/adb/adb_nowindows.go
@@ -75,6 +75,7 @@ func adbWriteFile(a *ADBConnection, r io.Reader, pathStr string) error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start command for write file %q: %w", pathStr, err)
 	}
+	// Close cmd regardless of errors happening downstream
 	defer func() { _ = cmd.Wait() }()
 
 	if _, err := io.Copy(stdin, r); err != nil {

--- a/pkg/board/remote/adb/adb_windows.go
+++ b/pkg/board/remote/adb/adb_windows.go
@@ -83,6 +83,7 @@ func adbWriteFile(a *ADBConnection, r io.Reader, pathStr string) error {
 	if err != nil {
 		return fmt.Errorf("failed to start write process %q: %w", pathStr, err)
 	}
+	// Close cmd regardless of errors happening downstream
 	defer func() { _ = cmd.Wait() }()
 
 	if _, err := io.Copy(encoder, r); err != nil {


### PR DESCRIPTION
### Motivation

We need to make sure to always close the cmd process to release all the os resources.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
