### PR TITLE
Download libraries used in examples during system init

### DIFF
--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -510,19 +510,18 @@ func downloadSketchLibsUsedInApp(ctx context.Context, appPath *paths.Path, cli r
 	}
 
 	// Initializing using the profile will force download and install of the missing libraries
-	progressCB := func(r *rpc.InitResponse) error {
-		if p := r.GetInitProgress().GetDownloadProgress(); p != nil {
-			downloadProgressCB(p)
-		}
-		return nil
-	}
 	if err := cli.Init(
 		&rpc.InitRequest{
 			Instance:   cliInstance,
 			SketchPath: sketchPath.String(),
 			Profile:    defaultProfile,
 		},
-		commands.InitStreamResponseToCallbackFunction(ctx, progressCB),
+		commands.InitStreamResponseToCallbackFunction(ctx, func(r *rpc.InitResponse) error {
+			if p := r.GetInitProgress().GetDownloadProgress(); p != nil {
+				downloadProgressCB(p)
+			}
+			return nil
+		}),
 	); err != nil {
 		return fmt.Errorf("could not initialize sketch %s: %w", sketchPath.String(), err)
 	}


### PR DESCRIPTION
### Motivation

Now `system init` downloads and installs libraries used in examples.

### Change description

The libraries are installed in the `internal` section of Arduino CLI's data directory.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [X] PR addresses a single concern.
- [X] PR title and description are properly filled.
- [X] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
