### PR TITLE
fix(cli): autocomplete also folders name

### DIFF
--- a/cmd/arduino-app-cli/completion/completion.go
+++ b/cmd/arduino-app-cli/completion/completion.go
@@ -95,7 +95,7 @@ func ApplicationNamesWithFilterFunc(cfg config.Configuration, filter func(apps o
 				res = append(res, cmdutil.IDToAlias(a.ID))
 			}
 		}
-		return res, cobra.ShellCompDirectiveNoFileComp
+		return res, cobra.ShellCompDirectiveDefault
 	}
 }
 


### PR DESCRIPTION
### Motivation

All cli commanda with an app parameter allow specifying apps with the IDs, e.g., `user:my-app`, or by their path. So the autocompletion should also suggest paths.
 
### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
