### PR TITLE
feat(import/export): support zip on stdin/stdout

### DIFF
--- a/cmd/arduino-app-cli/app/export.go
+++ b/cmd/arduino-app-cli/app/export.go
@@ -42,10 +42,7 @@ func newExportCmd(cfg config.Configuration) *cobra.Command {
 		Use:   "export app_path [output_path]",
 		Short: "Export an existing Arduino App to a zip file",
 		Long: `Export an existing Arduino App to a zip file.
-
-Arguments:
-  app_path      Path to the Arduino App.
-  output_path   Path to the output zip file or directory. Use '-' to write to stdout.`,
+Use '-' as output_path to write the zip to stdout.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return cmd.Help()

--- a/cmd/arduino-app-cli/app/import.go
+++ b/cmd/arduino-app-cli/app/import.go
@@ -37,9 +37,7 @@ func newImportCmd(cfg config.Configuration) *cobra.Command {
 		Use:   "import zip_path",
 		Short: "Import an Arduino App from a zip file",
 		Long: `Import an Arduino App from a zip file.
-
-Arguments:
-  zip_path   Path to the input zip file. Use '-' to read from stdin.`,
+Use '-' as zip_path to read the zip from stdin.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return cmd.Help()


### PR DESCRIPTION
### Motivation

Take the application zip as input in the import and export commands.

### Change description

This allows import and export applications via adb or ssh from the board:

```
adb shell arduino-app-cli app export user:blink - > my-blink.zip
adb shell arduino-app-cli app import - < my-blink.zip
```

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
