### PR TITLE
EI client: add x-api-key header  to the CORS

### DIFF
--- a/cmd/arduino-app-cli/daemon/daemon.go
+++ b/cmd/arduino-app-cli/daemon/daemon.go
@@ -92,6 +92,7 @@ func httpHandler(ctx context.Context, cfg config.Configuration, daemonPort, vers
 			"Accept",
 			"Authorization",
 			"Content-Type",
+			"X-API-Key",
 		},
 		MaxAgeInSeconds: 86400,
 		ResponseHeaders: []string{},


### PR DESCRIPTION
### Motivation
Add header in order to let the api call reach the daemon

