### PR TITLE
The platform update should not return error if no packages found

### DIFF
--- a/internal/update/arduino/arduino.go
+++ b/internal/update/arduino/arduino.go
@@ -188,6 +188,21 @@ func (a *ArduinoPlatformUpdater) UpgradePackages(ctx context.Context, packages [
 		return update.ErrOperationAlreadyInProgress
 	}
 
+	if len(packages) == 0 {
+		return nil
+	}
+	if len(packages) > 1 {
+		return fmt.Errorf("expected exactly one package to upgrade, got %d", len(packages))
+	}
+	pkg := packages[0]
+	if pkg.Name != "arduino:zephyr" {
+		return fmt.Errorf("unexpected package name '%s': this updater only supports '%s'", pkg.Name, "arduino:zephyr")
+	}
+	targetVersion := pkg.ToVersion
+	if targetVersion == "" {
+		return fmt.Errorf("target version is empty for package '%s'", pkg.Name)
+	}
+
 	downloadProgressCB := func(curr *rpc.DownloadProgress) {
 		data := helpers.ArduinoCLIDownloadProgressToString(curr)
 		slog.Debug("Download progress", slog.String("download_progress", data))
@@ -239,19 +254,6 @@ func (a *ArduinoPlatformUpdater) UpgradePackages(ctx context.Context, packages [
 		downloadProgressCB,
 		taskProgressCB,
 	)
-
-	if len(packages) != 1 {
-		return fmt.Errorf("expected exactly one package to upgrade, got %d", len(packages))
-	}
-	pkg := packages[0]
-	if pkg.Name != "arduino:zephyr" {
-		return fmt.Errorf("unexpected package name '%s': this updater only supports '%s'", pkg.Name, "arduino:zephyr")
-	}
-
-	targetVersion := pkg.ToVersion
-	if targetVersion == "" {
-		return fmt.Errorf("target version is empty for package '%s'", pkg.Name)
-	}
 
 	if err := srv.PlatformInstall(
 		&rpc.PlatformInstallRequest{


### PR DESCRIPTION
### Motivation
During `system update` the cli return an error saying "0 packages found but one was expected", even if there is not platform update. 
If there is no platform update, we should consider the request successfull.

