### PR TITLE
chore: block platform update to 0.53.1

### DIFF
--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -31,6 +31,7 @@ import (
 
 // runnerVersion do not edit, this is generate with `task generate:assets`
 var RunnerVersion = "0.7.3"
+var PlatformVersionConstraint = "<=0.53.1"
 
 type Configuration struct {
 	appsDir                          *paths.Path
@@ -106,7 +107,10 @@ func NewFromEnv() (Configuration, error) {
 		return Configuration{}, fmt.Errorf("invalid LIBRARIES_API_URL: %w", err)
 	}
 
-	constraintStr := cmp.Or(os.Getenv("ARDUINO_APP_CLI__PLATFORM_VERSION_CONSTRAINT"), "<1.0.0")
+	constraintStr := cmp.Or(
+		os.Getenv("ARDUINO_APP_CLI__PLATFORM_VERSION_CONSTRAINT"),
+		PlatformVersionConstraint,
+	)
 
 	edgeImpulseAPIURL := os.Getenv("EDGE_IMPULSE_API_URL")
 	if edgeImpulseAPIURL == "" {


### PR DESCRIPTION
### Motivation

The Zephyr platform will dismiss flash to RAM in the next release, so we will need to prevent update till we implement an alternative solution, like this https://github.com/arduino/arduino-app-cli/pull/254
 
### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
