### PR TITLE
bug: do not re-include already added compose paths

### DIFF
--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -267,7 +267,7 @@ func generateMainComposeFile(
 			}
 		}
 
-		composeFiles.Add(composeFilePath)
+		composeFiles.AddIfMissing(composeFilePath)
 		services = append(services, svcs...)
 	}
 


### PR DESCRIPTION
### Motivation

do not re-include already added compose paths

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
