### PR TITLE
chore: edit `config.go` when the `generate:assets` task runs on Windows

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -232,7 +232,7 @@ tasks:
       - cmd: rm -rf {{.TMPDIR}}
       - cmd: echo "Updating the runnerVersion in config.go to '{{.RUNNER_VERSION}}'"
       - cmd: sed -i "{{.sed_replacement}}" internal/orchestrator/config/config.go
-        platforms: [linux]
+        platforms: [linux, windows]
       - cmd: sed -i '' "{{.sed_replacement}}" internal/orchestrator/config/config.go
         platforms: [darwin]
 


### PR DESCRIPTION
### Motivation
Edit `config.go` when the `generate:assets` task runs on Windows.
<!-- Why this pull request? -->

### Change description

<!-- What does your code do? -->

### Additional Notes
Tested locally on my Windows machine. The Linux `cmd` works correctly.
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
