### PR TITLE
fix: use compatible instead

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -33,7 +33,7 @@ type Platform struct {
 func GetPlatform() Platform {
 	codeName := getCodeName()
 	switch codeName {
-	case "Imola":
+	case "imola":
 		slog.Debug("detected platform", "codeName", codeName)
 		return Platform{
 			codeName:   codeName,
@@ -72,8 +72,8 @@ func getCodeName() string {
 }
 
 func getCodeNameInternal(fs fs.FS) string {
-	trimAll := func(s []byte) []byte {
-		return bytes.Trim(s, " \n\t\r\x00")
+	trimAndLower := func(s []byte) []byte {
+		return bytes.ToLower(bytes.Trim(s, " \n\t\r\x00"))
 	}
 
 	readFile := func(path string) ([]byte, error) {
@@ -82,22 +82,20 @@ func getCodeNameInternal(fs fs.FS) string {
 			return nil, err
 		}
 		defer f.Close()
-
-		if buf, err := io.ReadAll(f); err != nil {
-			return nil, err
-		} else {
-			return buf, nil
-		}
+		return io.ReadAll(f)
 	}
 
 	if buf, err := readFile("sys/class/dmi/id/product_name"); err == nil {
-		return string(trimAll(buf))
-	} else if buf, err := readFile("sys/firmware/devicetree/base/model"); err == nil {
-		if idx := bytes.LastIndex(buf, []byte(",")); idx != -1 {
-			return string(trimAll(buf[idx+1:]))
-		}
-		if idx := bytes.LastIndex(buf, []byte(" ")); idx != -1 {
-			return string(trimAll(buf[idx+1:]))
+		return string(trimAndLower(buf))
+	} else if buf, err := readFile("sys/firmware/devicetree/base/compatible"); err == nil {
+		compatibles := bytes.Split(buf, []byte{'\x00'})
+		if len(compatibles) > 0 {
+			compatible := compatibles[0]
+			if idx := bytes.Index(compatibles[0], []byte{','}); idx != -1 {
+				return string(trimAndLower(compatible[idx+1:]))
+			} else {
+				return string(trimAndLower(compatible))
+			}
 		}
 	}
 

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -18,29 +18,29 @@ func TestGetCodeName(t *testing.T) {
 			files: fstest.MapFS{
 				"sys/class/dmi/id/product_name": {Data: []byte("  Foo \n")},
 			},
-			want: "Foo",
+			want: "foo",
 		},
 		{
 			name: "product_name exists and model exists",
 			files: fstest.MapFS{
-				"sys/class/dmi/id/product_name":      {Data: []byte("  Foo \n")},
-				"sys/firmware/devicetree/base/model": {Data: []byte("Arduino SA,Bar")},
+				"sys/class/dmi/id/product_name":           {Data: []byte("foo \n")},
+				"sys/firmware/devicetree/base/compatible": {Data: []byte("arduino,foo")},
 			},
-			want: "Foo",
+			want: "foo",
 		},
 		{
-			name: "model with comma",
+			name: "single compatible",
 			files: fstest.MapFS{
-				"sys/firmware/devicetree/base/model": {Data: []byte("Arduino SA,Bar")},
+				"sys/firmware/devicetree/base/compatible": {Data: []byte("arduino,bar")},
 			},
-			want: "Bar",
+			want: "bar",
 		},
 		{
-			name: "model with space",
+			name: "multiple compatibles",
 			files: fstest.MapFS{
-				"sys/firmware/devicetree/base/model": {Data: []byte("Arduino Foo")},
+				"sys/firmware/devicetree/base/compatible": {Data: []byte("arduino,bar\x00some,other")},
 			},
-			want: "Foo",
+			want: "bar",
 		},
 		{
 			name:  "no files",


### PR DESCRIPTION
### Motivation

Use device tree compatible instead of the model field. 

### Change description

<!-- What does your code do? -->

### Additional Notes

- here is the dts of unoq/imola  https://github.com/torvalds/linux/blob/master/arch/arm64/boot/dts/qcom/qrb2210-arduino-imola.dts

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
