### PR TITLE
feat: add support for `restart: on-failure` bricks

### DIFF
--- a/cmd/arduino-app-cli/daemon/daemon.go
+++ b/cmd/arduino-app-cli/daemon/daemon.go
@@ -158,19 +158,16 @@ func httpHandler(ctx context.Context, cfg config.Configuration, daemonPort, vers
 // stopArduinoContainers stops the Arduino containers that start running automatically when the board boots
 func stopArduinoContainers(ctx context.Context, docker command.Cli) error {
 	containers, err := docker.Client().ContainerList(ctx, container.ListOptions{
-		All:     true,
-		Filters: filters.NewArgs(filters.Arg("label", orchestrator.DockerAppPathLabel)),
+		All:     false,
+		Filters: filters.NewArgs(filters.Arg("label", orchestrator.DockerAppLabel+"=true")),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to list containers: %w", err)
 	}
 	for _, c := range containers {
-		slog.Info("Stopping container", slog.String("ID", c.ID))
-		if c.Status == string(orchestrator.StatusRunning) || c.Status == string(orchestrator.StatusStarting) {
-			err := docker.Client().ContainerStop(ctx, c.ID, container.StopOptions{})
-			if err != nil {
-				return err
-			}
+		slog.Debug("Stopping container", slog.String("ID", c.ID))
+		if err := docker.Client().ContainerStop(ctx, c.ID, container.StopOptions{}); err != nil {
+			slog.Warn("Failed to stop container", "ID", c.ID, "error", err.Error())
 		}
 	}
 	return nil


### PR DESCRIPTION
### Motivation
Add support for `restart: on-failure` bricks. Containers with a `restart: on-failure` policy start running automatically when the board is powered down, since it is considered as a power outage. For this reason, to avoid inconsistencies, containers with the `arduino` label are stopped when the board boots and the `app-cli` daemon starts.
<!-- Why this pull request? -->

### Change description
Stop `arduino` containers when the `app-cli` daemon starts running.
<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
