### PR TITLE
feat: stop auto-restart containers

### DIFF
--- a/cmd/arduino-app-cli/daemon/daemon.go
+++ b/cmd/arduino-app-cli/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jub0bs/cors"
 	"github.com/spf13/cobra"
 
+	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/app"
 	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/internal/servicelocator"
 	"github.com/arduino/arduino-app-cli/internal/api"
 	"github.com/arduino/arduino-app-cli/internal/httprecover"
@@ -41,6 +42,10 @@ func NewDaemonCmd(cfg config.Configuration, version string) *cobra.Command {
 		Short: "Run the Arduino App CLI as an HTTP daemon",
 		Run: func(cmd *cobra.Command, args []string) {
 			daemonPort, _ := cmd.Flags().GetString("port")
+
+			if err := stopArduinoFailingApps(cmd.Context(), cfg); err != nil {
+				slog.Warn("Failed to stop containers", "error", err.Error())
+			}
 
 			// start the default app in the background
 			go func() {
@@ -144,4 +149,36 @@ func httpHandler(ctx context.Context, cfg config.Configuration, daemonPort, vers
 	_ = httpSrv.Shutdown(ctx)
 	cancel()
 	slog.Info("HTTP server shut down", slog.String("address", address))
+}
+
+// stopArduinoFailingApps force stop of arduino apps with container in auto-restart.
+func stopArduinoFailingApps(ctx context.Context, config config.Configuration) error {
+	docker := servicelocator.GetDockerClient()
+
+	listOpts := orchestrator.ListAppRequest{
+		ShowApps: true, ShowExamples: true,
+		StatusFilter: orchestrator.StatusFailed,
+	}
+	apps, err := orchestrator.ListApps(ctx, docker, listOpts, servicelocator.GetAppIDProvider(), config)
+	if err != nil {
+		return err
+	}
+	slog.Info("Found apps with failed status", "count", len(apps.Apps))
+
+	for _, appInfo := range apps.Apps {
+		app, err := app.Load(appInfo.ID.ToPath().String())
+		if err != nil {
+			slog.Warn("Failed to load app", "appID", appInfo.ID.String(), "error", err.Error())
+			continue
+		}
+
+		slog.Info("Stopping app container", "appID", appInfo.ID.String())
+		for event := range orchestrator.StopApp(ctx, docker, servicelocator.GetPlatform(), app) {
+			if event.IsError() {
+				slog.Warn("Failed to stop app", "appID", appInfo.ID.String(), "error", event.GetError().Error())
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Motivation

If some brick containers use the `restart: on-failure` polices, we need to make sure to stop them at startup to avoid issues.
 
### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
