### PR TITLE
refactor: remove description field from local brick creation

### DIFF
--- a/internal/api/handlers/app_brick_create.go
+++ b/internal/api/handlers/app_brick_create.go
@@ -33,8 +33,7 @@ import (
 )
 
 type AppLocalBrickCreateRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Name string `json:"name"`
 }
 
 type AppLocalBrickCreateResponse struct {

--- a/internal/api/handlers/app_brick_create.go
+++ b/internal/api/handlers/app_brick_create.go
@@ -72,7 +72,7 @@ func HandleAppLocalBrickCreate(idProvider *app.IDProvider) http.HandlerFunc {
 			return
 		}
 
-		err = generator.GenerateLocalBrick(a.GetBricksPath(), id, req.Name, req.Description)
+		err = generator.GenerateLocalBrick(a.GetBricksPath(), id, req.Name)
 		if err != nil {
 			if errors.Is(err, generator.ErrBrickAlreadyExists) {
 				render.EncodeResponse(w, http.StatusConflict, models.ErrorResponse{Details: fmt.Sprintf("a brick with the same id '%s' already exists", id)})

--- a/internal/orchestrator/app/generator/app_generator.go
+++ b/internal/orchestrator/app/generator/app_generator.go
@@ -231,7 +231,7 @@ var fsBrick embed.FS
 
 var ErrBrickAlreadyExists = fmt.Errorf("brick already exists")
 
-func GenerateLocalBrick(basePath *paths.Path, id string, name, description string) error {
+func GenerateLocalBrick(basePath *paths.Path, id string, name string) error {
 	brickDir := basePath.Join(id)
 	if brickDir.Exist() {
 		return fmt.Errorf("%w: %q", ErrBrickAlreadyExists, id)
@@ -248,9 +248,8 @@ func GenerateLocalBrick(basePath *paths.Path, id string, name, description strin
 	}
 
 	data := brickData{
-		ID:          id,
-		Name:        name,
-		Description: description,
+		ID:   id,
+		Name: name,
 	}
 
 	generateBrickConfig := func(brickDir *paths.Path, data brickData) error {

--- a/internal/orchestrator/app/generator/app_generator_test.go
+++ b/internal/orchestrator/app/generator/app_generator_test.go
@@ -129,7 +129,7 @@ func TestGenerateAppBrick(t *testing.T) {
 
 	a := f.Must(app.Load(appDir))
 
-	err = GenerateLocalBrick(a.GetBricksPath(), "my-brick", "a-brick-name", "a-brick-description")
+	err = GenerateLocalBrick(a.GetBricksPath(), "my-brick", "a-brick-name")
 	require.NoError(t, err)
 
 	if os.Getenv("UPDATE_GOLDEN") == "true" {

--- a/internal/orchestrator/app/generator/brick_template/README.md.template
+++ b/internal/orchestrator/app/generator/brick_template/README.md.template
@@ -1,3 +1,1 @@
 # {{ .Name }}
-
-{{ .Description }}

--- a/internal/orchestrator/app/generator/brick_template/brick_config.yaml.template
+++ b/internal/orchestrator/app/generator/brick_template/brick_config.yaml.template
@@ -1,3 +1,2 @@
 id: {{ .ID }}
 name: {{ .Name  }}
-description: {{ .Description }}

--- a/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/README.md
+++ b/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/README.md
@@ -1,3 +1,1 @@
 # a-brick-name
-
-a-brick-description

--- a/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/brick_config.yaml
+++ b/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/brick_config.yaml
@@ -1,3 +1,2 @@
 id: my-brick
 name: a-brick-name
-description: a-brick-description


### PR DESCRIPTION
### Motivation
By design, when a local brick is created, there is no need to specify its description.

### Change description

Remove the description parameter from the api

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
