### PR TITLE
chore: add tests for generating local bricks and handling conflicts

### DIFF
--- a/internal/orchestrator/app/generator/app_generator_test.go
+++ b/internal/orchestrator/app/generator/app_generator_test.go
@@ -144,9 +144,10 @@ func TestGenerateAppBrick(t *testing.T) {
 
 	t.Run("conflict if the folder already exist", func(t *testing.T) {
 		tmpDir := paths.New(t.TempDir())
-		tmpDir.Join("my-brick").MkdirAll()
+		err := tmpDir.Join("my-brick").MkdirAll()
+		require.NoError(t, err)
 
-		err := GenerateLocalBrick(tmpDir, "my-brick", "a-brick-name")
+		err = GenerateLocalBrick(tmpDir, "my-brick", "a-brick-name")
 		require.ErrorIs(t, err, ErrBrickAlreadyExists)
 	})
 }

--- a/internal/orchestrator/app/generator/app_generator_test.go
+++ b/internal/orchestrator/app/generator/app_generator_test.go
@@ -122,21 +122,31 @@ func compareFolders(t *testing.T, actualPath, goldenPath *paths.Path) {
 }
 
 func TestGenerateAppBrick(t *testing.T) {
-	appDir := paths.New(t.TempDir())
+	t.Run("generate local brick for an app", func(t *testing.T) {
+		appDir := paths.New(t.TempDir())
 
-	err := GenerateApp(appDir, app.AppDescriptor{Name: "an-app-with-brick"}, true)
-	require.NoError(t, err)
+		err := GenerateApp(appDir, app.AppDescriptor{Name: "an-app-with-brick"}, true)
+		require.NoError(t, err)
 
-	a := f.Must(app.Load(appDir))
+		a := f.Must(app.Load(appDir))
 
-	err = GenerateLocalBrick(a.GetBricksPath(), "my-brick", "a-brick-name")
-	require.NoError(t, err)
+		err = GenerateLocalBrick(a.GetBricksPath(), "my-brick", "a-brick-name")
+		require.NoError(t, err)
 
-	if os.Getenv("UPDATE_GOLDEN") == "true" {
-		t.Logf("UPDATE_GOLDEN=true: updating  golden files in %s", "testdata/app-with-brick.golden")
-		require.NoError(t, os.RemoveAll("testdata/app-with-brick.golden"))
-		require.NoError(t, os.CopyFS("testdata/app-with-brick.golden", os.DirFS(appDir.String())))
-	} else {
-		compareFolders(t, appDir, paths.New("testdata/app-with-brick.golden"))
-	}
+		if os.Getenv("UPDATE_GOLDEN") == "true" {
+			t.Logf("UPDATE_GOLDEN=true: updating  golden files in %s", "testdata/app-with-brick.golden")
+			require.NoError(t, os.RemoveAll("testdata/app-with-brick.golden"))
+			require.NoError(t, os.CopyFS("testdata/app-with-brick.golden", os.DirFS(appDir.String())))
+		} else {
+			compareFolders(t, appDir, paths.New("testdata/app-with-brick.golden"))
+		}
+	})
+
+	t.Run("conflict if the folder already exist", func(t *testing.T) {
+		tmpDir := paths.New(t.TempDir())
+		tmpDir.Join("my-brick").MkdirAll()
+
+		err := GenerateLocalBrick(tmpDir, "my-brick", "a-brick-name")
+		require.ErrorIs(t, err, ErrBrickAlreadyExists)
+	})
 }


### PR DESCRIPTION
### Motivation
Add unit test to check the api returns conflict if the brick already exists (the folder already exists)

If the brick already exists `StatusCode 409` , the applab must call the `PUT /v1/apps/{appID}/bricks/{brickID}` to add the local brick to the app.yaml

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
