### PR TITLE
feat: add FullPath field to Brick struct

### DIFF
--- a/internal/orchestrator/app/app.go
+++ b/internal/orchestrator/app/app.go
@@ -322,6 +322,7 @@ func load(brickPath *paths.Path) (b bricksindex.Brick, err error) {
 		composeFile = brickComposeFile
 	}
 	brick.Source = "App"
+	brick.FullPath = brickPath
 	brick.ComposeFile = composeFile
 	brick.ReadmeFile = brickPath.Join("README.md")
 	brick.ExamplesPath = brickPath.Join("examples")

--- a/internal/orchestrator/app/app_test.go
+++ b/internal/orchestrator/app/app_test.go
@@ -94,11 +94,12 @@ func TestLoad(t *testing.T) {
 		assert.Nil(t, sketchPath)
 	})
 
-	t.Run("it loads an app with missing main python file", func(t *testing.T) {
+	t.Run("it loads an app with local bricks", func(t *testing.T) {
 		app, err := Load(paths.New("testdata/AppWithLocalBricks"))
 		assert.NoError(t, err)
 		assert.NotEmpty(t, app)
 		assert.Len(t, app.LocalBricks, 1)
+		assert.Equal(t, f.Must(filepath.Abs("testdata/AppWithLocalBricks/bricks/my-first-brick")), app.LocalBricks[0].FullPath.String())
 		assert.Equal(t, "my-first-brick", app.LocalBricks[0].ID)
 		assert.Equal(t, "My First Brick", app.LocalBricks[0].Name)
 		assert.Equal(t, "App", app.LocalBricks[0].Source)

--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -92,6 +92,7 @@ type Brick struct {
 
 	Source string `yaml:"-"`
 
+	FullPath     *paths.Path `yaml:"-"`
 	ComposeFile  *paths.Path `yaml:"-"` // brick_compose.yaml file path, optional
 	ReadmeFile   *paths.Path `yaml:"-"` // README.md file path, optional
 	ExamplesPath *paths.Path `yaml:"-"` // code examples folder path, optional
@@ -185,6 +186,7 @@ func Load(path *paths.Path) (*BricksIndex, error) {
 			return nil, err
 		}
 		yamlIndex.Bricks[i].Source = "Arduino"
+		yamlIndex.Bricks[i].FullPath = path
 		yamlIndex.Bricks[i].ComposeFile = path.Join("compose", namespace, brickName, "brick_compose.yaml")
 		yamlIndex.Bricks[i].ReadmeFile = path.Join("docs", namespace, brickName, "README.md")
 		yamlIndex.Bricks[i].ExamplesPath = path.Join("examples", namespace, brickName)

--- a/internal/orchestrator/bricksindex/bricks_index_test.go
+++ b/internal/orchestrator/bricksindex/bricks_index_test.go
@@ -284,6 +284,8 @@ func TestLoadBrickYamlBrickIndex(t *testing.T) {
 
 		brick, found := bricksIndex.FindBrickByID("arduino:a-good-brick")
 		require.True(t, found)
+		assert.Equal(t, paths.New("testdata/0.4.8"), brick.FullPath)
+
 		content, err := brick.GetReadmeFile()
 		require.NoError(t, err)
 		require.Equal(t, "# i-am-a-readme-file", content)

--- a/internal/orchestrator/bricksindex/bricks_index_test.go
+++ b/internal/orchestrator/bricksindex/bricks_index_test.go
@@ -270,7 +270,7 @@ func TestBricksIndexYAMLFormats(t *testing.T) {
 				require.Contains(t, err.Error(), tc.expectedError)
 			} else {
 				require.NoError(t, err)
-				assert.True(t, cmp.Equal(index.BuiltInBricks, tc.expectedBricks, cmpopts.IgnoreFields(Brick{}, "Source", "ComposeFile", "ReadmeFile", "ExamplesPath", "DocsAPIPath")), cmp.Diff(index.BuiltInBricks, tc.expectedBricks, cmpopts.IgnoreFields(Brick{}, "Source", "ComposeFile", "ReadmeFile", "ExamplesPath", "DocsAPIPath")))
+				assert.True(t, cmp.Equal(index.BuiltInBricks, tc.expectedBricks, cmpopts.IgnoreFields(Brick{}, "FullPath", "Source", "ComposeFile", "ReadmeFile", "ExamplesPath", "DocsAPIPath")), cmp.Diff(index.BuiltInBricks, tc.expectedBricks, cmpopts.IgnoreFields(Brick{}, "Source", "ComposeFile", "ReadmeFile", "ExamplesPath", "DocsAPIPath")))
 			}
 		})
 	}


### PR DESCRIPTION
### Motivation
Having the fullPath of the brick is useful during the brick renaming of a local brick.


### Change description

Added a `fullPath` to the `Brick` instance with the fill path of the brick
- for yaml index, it points to the asset folder
- for the local index to the local brick index inside the app

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
