### PR TITLE
Add leds control functions.

### DIFF
--- a/internal/orchestrator/helpers.go
+++ b/internal/orchestrator/helpers.go
@@ -203,48 +203,39 @@ const (
 	ledBrightnessTarget ledTarget = "brightness"
 )
 
-type ledTrigger string
-
 const (
-	ledTriggerNone    ledTrigger = "none"
-	ledTriggerDefault ledTrigger = "default"
+	noneTrigger    string = "none"
+	defaultTrigger string = "default"
 )
 
-func setLeds(leds paths.PathList, target ledTarget, value string) error {
-	for _, ledPath := range leds {
-		ledPath = ledPath.Join(string(target))
-		if !ledPath.Exist() {
-			return fmt.Errorf("LED path %s does not exist", ledPath)
-		}
-		if err := ledPath.WriteFile([]byte(value)); err != nil {
-			return fmt.Errorf("failed to set LED %s to %s: %w", ledPath, target, err)
-		}
+func setLeds(ledPath *paths.Path, target ledTarget, value string) error {
+	ledPath = ledPath.Join(string(target))
+	if !ledPath.Exist() {
+		return fmt.Errorf("LED path %s does not exist", ledPath)
+	}
+	if err := ledPath.WriteFile([]byte(value)); err != nil {
+		return fmt.Errorf("failed to set LED %s to %s: %w", ledPath, target, err)
 	}
 	return nil
 }
 
 func setLedsToUserControlledMode(platform platform.Platform) error {
-	if err := setLeds(platform.Linux.StatusLeds, ledTriggerTarget, string(ledTriggerNone)); err != nil {
-		return err
-	}
-	if err := setLeds(platform.Linux.UserLeds, ledTriggerTarget, string(ledTriggerNone)); err != nil {
-		return err
+	for _, led := range slices.Concat(platform.Linux.StatusLeds, platform.Linux.UserLeds) {
+		if err := setLeds(led, ledTriggerTarget, noneTrigger); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 func restoreLedsState(platform platform.Platform) error {
-	if err := setLeds(platform.Linux.StatusLeds, ledBrightnessTarget, string("0")); err != nil {
-		return err
-	}
-	if err := setLeds(platform.Linux.UserLeds, ledBrightnessTarget, string("0")); err != nil {
-		return err
-	}
-	if err := setLeds(platform.Linux.StatusLeds, ledTriggerTarget, string(ledTriggerDefault)); err != nil {
-		return err
-	}
-	if err := setLeds(platform.Linux.UserLeds, ledTriggerTarget, string(ledTriggerDefault)); err != nil {
-		return err
+	for _, led := range slices.Concat(platform.Linux.StatusLeds, platform.Linux.UserLeds) {
+		if err := setLeds(led, ledBrightnessTarget, string("0")); err != nil {
+			return err
+		}
+		if err := setLeds(led, ledTriggerTarget, defaultTrigger); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/orchestrator/helpers.go
+++ b/internal/orchestrator/helpers.go
@@ -196,22 +196,55 @@ func GetCustomErrorFomDockerEvent(message string) error {
 	return nil
 }
 
-type LedTrigger string
+type ledTarget string
 
 const (
-	LedTriggerNone    LedTrigger = "none"
-	LedTriggerDefault LedTrigger = "default"
+	ledTriggerTarget    ledTarget = "trigger"
+	ledBrightnessTarget ledTarget = "brightness"
 )
 
-func setStatusLeds(platform platform.Platform, trigger LedTrigger) error {
-	for _, ledPath := range platform.Linux.StatusLeds {
-		ledPath = ledPath.Join("trigger")
+type ledTrigger string
+
+const (
+	ledTriggerNone    ledTrigger = "none"
+	ledTriggerDefault ledTrigger = "default"
+)
+
+func setLeds(leds paths.PathList, target ledTarget, value string) error {
+	for _, ledPath := range leds {
+		ledPath = ledPath.Join(string(target))
 		if !ledPath.Exist() {
 			return fmt.Errorf("LED path %s does not exist", ledPath)
 		}
-		if err := ledPath.WriteFile([]byte(trigger)); err != nil {
-			return fmt.Errorf("failed to set LED %s to %s: %w", ledPath, trigger, err)
+		if err := ledPath.WriteFile([]byte(value)); err != nil {
+			return fmt.Errorf("failed to set LED %s to %s: %w", ledPath, target, err)
 		}
+	}
+	return nil
+}
+
+func setLedsToUserControlledMode(platform platform.Platform) error {
+	if err := setLeds(platform.Linux.StatusLeds, ledTriggerTarget, string(ledTriggerNone)); err != nil {
+		return err
+	}
+	if err := setLeds(platform.Linux.UserLeds, ledTriggerTarget, string(ledTriggerNone)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func restoreLedsState(platform platform.Platform) error {
+	if err := setLeds(platform.Linux.StatusLeds, ledBrightnessTarget, string("0")); err != nil {
+		return err
+	}
+	if err := setLeds(platform.Linux.UserLeds, ledBrightnessTarget, string("0")); err != nil {
+		return err
+	}
+	if err := setLeds(platform.Linux.StatusLeds, ledTriggerTarget, string(ledTriggerDefault)); err != nil {
+		return err
+	}
+	if err := setLeds(platform.Linux.UserLeds, ledTriggerTarget, string(ledTriggerDefault)); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/orchestrator/helpers.go
+++ b/internal/orchestrator/helpers.go
@@ -220,7 +220,7 @@ func setLeds(ledPath *paths.Path, target ledTarget, value string) error {
 }
 
 func setLedsToUserControlledMode(platform platform.Platform) error {
-	for _, led := range slices.Concat(platform.Linux.StatusLeds, platform.Linux.UserLeds) {
+	for _, led := range platform.Linux.BoardLeds {
 		if err := setLeds(led, ledTriggerTarget, noneTrigger); err != nil {
 			return err
 		}
@@ -229,7 +229,7 @@ func setLedsToUserControlledMode(platform platform.Platform) error {
 }
 
 func restoreLedsState(platform platform.Platform) error {
-	for _, led := range slices.Concat(platform.Linux.StatusLeds, platform.Linux.UserLeds) {
+	for _, led := range platform.Linux.BoardLeds {
 		if err := setLeds(led, ledBrightnessTarget, string("0")); err != nil {
 			return err
 		}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -157,7 +157,7 @@ func StartApp(
 			return
 		}
 
-		if err := setStatusLeds(platform, LedTriggerNone); err != nil {
+		if err := setLedsToUserControlledMode(platform); err != nil {
 			slog.Debug("unable to set status leds", slog.String("error", err.Error()))
 		}
 
@@ -327,7 +327,7 @@ func stopAppWithCmd(ctx context.Context, docker command.Cli, platform platform.P
 		if !yield(StreamMessage{data: message}) {
 			return
 		}
-		if err := setStatusLeds(platform, LedTriggerDefault); err != nil {
+		if err := restoreLedsState(platform); err != nil {
 			slog.Debug("unable to set status leds", slog.String("error", err.Error()))
 		}
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1020,21 +1020,13 @@ func getCurrentUser() string {
 
 // addLedControl adds bindings for led control if the paths exist.
 func addLedControl(platform platform.Platform, volumes []volume) []volume {
-	for _, path := range platform.Linux.UserLeds {
-		if path.Exist() {
+	for _, led := range platform.Linux.BoardLeds {
+
+		if led.Exist() {
 			volumes = append(volumes, volume{
 				Type:   "bind",
-				Source: path.String(),
-				Target: path.String(),
-			})
-		}
-	}
-	for _, path := range platform.Linux.StatusLeds {
-		if path.Exist() {
-			volumes = append(volumes, volume{
-				Type:   "bind",
-				Source: path.String(),
-				Target: path.String(),
+				Source: led.String(),
+				Target: led.String(),
 			})
 		}
 	}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -38,8 +38,7 @@ type Platform struct {
 	PlatformID  string `json:"-"`
 	CompileJobs int32  `json:"-"`
 	Linux       struct {
-		UserLeds   paths.PathList
-		StatusLeds paths.PathList
+		BoardLeds paths.PathList
 	} `json:"-"`
 	Micro struct {
 		ResetPin GpioPin
@@ -56,16 +55,16 @@ func GetPlatform(dir *paths.Path) Platform {
 			FQBN:       "arduino:zephyr:unoq",
 			PlatformID: "arduino:zephyr",
 			BoardName:  "unoq",
-			Linux: struct{ UserLeds, StatusLeds paths.PathList }{
-				StatusLeds: paths.NewPathList(
-					"/sys/class/leds/blue:bt",
-					"/sys/class/leds/green:wlan",
-					"/sys/class/leds/red:panic",
-				),
-				UserLeds: paths.NewPathList(
+			Linux: struct{ BoardLeds paths.PathList }{
+				BoardLeds: paths.NewPathList(
+					// LED 1
 					"/sys/class/leds/blue:user",
 					"/sys/class/leds/green:user",
 					"/sys/class/leds/red:user",
+					// LED 2
+					"/sys/class/leds/blue:bt",
+					"/sys/class/leds/green:wlan",
+					"/sys/class/leds/red:panic",
 				),
 			},
 			CompileJobs: 2,
@@ -78,10 +77,9 @@ func GetPlatform(dir *paths.Path) Platform {
 			FQBN:       "arduino:zephyr:ventunoq",
 			PlatformID: "arduino:zephyr",
 			BoardName:  "ventunoq",
-			Linux: struct{ UserLeds, StatusLeds paths.PathList }{
+			Linux: struct{ BoardLeds paths.PathList }{
 				// TODO: add leds paths
-				StatusLeds: paths.NewPathList(),
-				UserLeds:   paths.NewPathList(),
+				BoardLeds: paths.NewPathList(),
 			},
 			CompileJobs: 0, // unlimited
 			Micro: struct{ ResetPin GpioPin }{


### PR DESCRIPTION
### Motivation

System leds are not properly reset after usage

Steps to reproduce:
- open and run the "Color your Leds" app
- stop the app
The  two system leds retain its value. The expected behavior is that system leds go back to their initial state (bt, wifi, panic)

After the fix:
- open and run the "Color your Leds" app
- stop the app
- the leds are reset to their default value
- run a test switch on and off the bluetooth light, and a ping will make the wifi led to blink:

```
# bluetooth on
sudo bluetoothctl power on
sleep 1
# bluetooth off
sudo bluetoothctl power off
sleep 1
# wifi should blink
sudo ping -c7 -i 0.5 8.8.8.8
sleep 1
# bluetooth on
sudo bluetoothctl power on

```

### Change description

The change is a brightness and trigger set to default values.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
