### PR TITLE
fix(localbrick): fails if the folder brick is removed

### DIFF
--- a/internal/orchestrator/app/app.go
+++ b/internal/orchestrator/app/app.go
@@ -275,8 +275,6 @@ func truncateDescription(s string, max int) string {
 	return s
 }
 
-var LocalBrickSource = "App"
-
 func loadBricksFromFolder(dir *paths.Path) []bricksindex.Brick {
 	if dir == nil || !dir.Exist() {
 		slog.Debug("App does not contain a bricks folder, skipping loading app bricks", "path", dir)
@@ -323,7 +321,7 @@ func load(brickPath *paths.Path) (b bricksindex.Brick, err error) {
 	if brickComposeFile.Exist() {
 		composeFile = brickComposeFile
 	}
-	brick.Source = LocalBrickSource
+	brick.Source = "App"
 	brick.FullPath = brickPath
 	brick.ComposeFile = composeFile
 	brick.ReadmeFile = brickPath.Join("README.md")

--- a/internal/orchestrator/app/app.go
+++ b/internal/orchestrator/app/app.go
@@ -275,6 +275,8 @@ func truncateDescription(s string, max int) string {
 	return s
 }
 
+var LocalBrickSource = "App"
+
 func loadBricksFromFolder(dir *paths.Path) []bricksindex.Brick {
 	if dir == nil || !dir.Exist() {
 		slog.Debug("App does not contain a bricks folder, skipping loading app bricks", "path", dir)
@@ -321,7 +323,7 @@ func load(brickPath *paths.Path) (b bricksindex.Brick, err error) {
 	if brickComposeFile.Exist() {
 		composeFile = brickComposeFile
 	}
-	brick.Source = "App"
+	brick.Source = LocalBrickSource
 	brick.FullPath = brickPath
 	brick.ComposeFile = composeFile
 	brick.ReadmeFile = brickPath.Join("README.md")

--- a/internal/orchestrator/bricks/bricks.go
+++ b/internal/orchestrator/bricks/bricks.go
@@ -444,7 +444,7 @@ func (s *Service) BrickDelete(
 	appCurrent *app.ArduinoApp,
 	id string,
 ) error {
-	if !slices.ContainFunc(appCurrent.Descriptor.Bricks, func(b app.Brick) bool { return b.ID == id }) {
+	if !slices.ContainsFunc(appCurrent.Descriptor.Bricks, func(b app.Brick) bool { return b.ID == id }) {
 		return ErrBrickNotFound
 	}
 

--- a/internal/orchestrator/bricks/bricks.go
+++ b/internal/orchestrator/bricks/bricks.go
@@ -77,14 +77,19 @@ func (s *Service) List() (BrickListResult, error) {
 func (s *Service) AppBrickInstancesList(a *app.ArduinoApp) (AppBrickInstancesResult, error) {
 	res := AppBrickInstancesResult{BrickInstances: make([]BrickInstance, len(a.Descriptor.Bricks))}
 	for i, brickInstance := range a.Descriptor.Bricks {
+		slog.Info("searching brick", "brickID", brickInstance.ID, "appID", a.FullPath)
 		brick, found := s.bricksIndex.WithAppBricks(a.LocalBricks).FindBrickByID(brickInstance.ID)
 		if !found {
-			if brick.Source == app.LocalBrickSource {
-				slog.Warn("Skipping local brick.", "brickID", brickInstance.ID)
-				continue
+			slog.Warn("brick not found. Skip", "brickID", brickInstance.ID, "appID", a.FullPath)
+			res.BrickInstances[i] = BrickInstance{
+				ID:     brickInstance.ID,
+				Name:   brickInstance.ID, // the name is not present because the brick is not found, but we want to return the ID to allow the user to understand which brick is missing and fix it
+				Status: "not found",
 			}
-			return AppBrickInstancesResult{}, fmt.Errorf("brick not found with id %s", brickInstance.ID)
+			continue
 		}
+
+		slog.Info("brick found", "brickID", brickInstance.ID, "appID", a.FullPath, "brickName", brick.Name)
 
 		variablesMap, configVariables := getInstanceBrickConfigVariableDetails(brick, brickInstance.Variables)
 
@@ -443,7 +448,7 @@ func (s *Service) BrickDelete(
 	appCurrent *app.ArduinoApp,
 	id string,
 ) error {
-	if _, present := s.bricksIndex.WithAppBricks(appCurrent.LocalBricks).FindBrickByID(id); !present {
+	if slices.IndexFunc(appCurrent.Descriptor.Bricks, func(b app.Brick) bool { return b.ID == id }) == -1 {
 		return ErrBrickNotFound
 	}
 

--- a/internal/orchestrator/bricks/bricks.go
+++ b/internal/orchestrator/bricks/bricks.go
@@ -444,7 +444,7 @@ func (s *Service) BrickDelete(
 	appCurrent *app.ArduinoApp,
 	id string,
 ) error {
-	if slices.IndexFunc(appCurrent.Descriptor.Bricks, func(b app.Brick) bool { return b.ID == id }) == -1 {
+	if !slices.ContainFunc(appCurrent.Descriptor.Bricks, func(b app.Brick) bool { return b.ID == id }) {
 		return ErrBrickNotFound
 	}
 

--- a/internal/orchestrator/bricks/bricks.go
+++ b/internal/orchestrator/bricks/bricks.go
@@ -77,19 +77,15 @@ func (s *Service) List() (BrickListResult, error) {
 func (s *Service) AppBrickInstancesList(a *app.ArduinoApp) (AppBrickInstancesResult, error) {
 	res := AppBrickInstancesResult{BrickInstances: make([]BrickInstance, len(a.Descriptor.Bricks))}
 	for i, brickInstance := range a.Descriptor.Bricks {
-		slog.Info("searching brick", "brickID", brickInstance.ID, "appID", a.FullPath)
 		brick, found := s.bricksIndex.WithAppBricks(a.LocalBricks).FindBrickByID(brickInstance.ID)
 		if !found {
-			slog.Warn("brick not found. Skip", "brickID", brickInstance.ID, "appID", a.FullPath)
 			res.BrickInstances[i] = BrickInstance{
 				ID:     brickInstance.ID,
-				Name:   brickInstance.ID, // the name is not present because the brick is not found, but we want to return the ID to allow the user to understand which brick is missing and fix it
-				Status: "not found",
+				Name:   brickInstance.ID, // using the ID as name to avoid empty UI element
+				Status: "not_found",
 			}
 			continue
 		}
-
-		slog.Info("brick found", "brickID", brickInstance.ID, "appID", a.FullPath, "brickName", brick.Name)
 
 		variablesMap, configVariables := getInstanceBrickConfigVariableDetails(brick, brickInstance.Variables)
 

--- a/internal/orchestrator/bricks/bricks.go
+++ b/internal/orchestrator/bricks/bricks.go
@@ -79,6 +79,10 @@ func (s *Service) AppBrickInstancesList(a *app.ArduinoApp) (AppBrickInstancesRes
 	for i, brickInstance := range a.Descriptor.Bricks {
 		brick, found := s.bricksIndex.WithAppBricks(a.LocalBricks).FindBrickByID(brickInstance.ID)
 		if !found {
+			if brick.Source == app.LocalBrickSource {
+				slog.Warn("Skipping local brick.", "brickID", brickInstance.ID)
+				continue
+			}
 			return AppBrickInstancesResult{}, fmt.Errorf("brick not found with id %s", brickInstance.ID)
 		}
 

--- a/internal/orchestrator/bricks/bricks_test.go
+++ b/internal/orchestrator/bricks/bricks_test.go
@@ -808,7 +808,7 @@ func TestAppBrickInstancesList(t *testing.T) {
 		validate      func(*testing.T, AppBrickInstancesResult)
 	}{
 		{
-			name: "Error - Brick not found in Index",
+			name: "Brick not found in Index",
 			app: &app.ArduinoApp{
 				Descriptor: app.AppDescriptor{
 					Bricks: []app.Brick{
@@ -816,7 +816,14 @@ func TestAppBrickInstancesList(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "brick not found with id arduino:non_existent_brick",
+			validate: func(t *testing.T, res AppBrickInstancesResult) {
+				require.Len(t, res.BrickInstances, 1)
+				brick := res.BrickInstances[0]
+
+				require.Equal(t, "arduino:non_existent_brick", brick.ID)
+				require.Equal(t, "arduino:non_existent_brick", brick.Name)
+				require.Equal(t, "not_found", brick.Status)
+			},
 		},
 		{
 			name: "Success - Empty App",


### PR DESCRIPTION
### Motivation

If the folder of a local brick is removed using the file manager, the following errors occur.
 - the `GET /v1/apps/{appID}/bricks` fails with the error `error="brick not found with id pluto"`
 - the  `DELETE /v1/apps/{appID}/bricks/{brickID}"` fails beacsue the brick is not found 

### Change description
- the get bricks returns the brick id with a status "not found" instead of an error
```
{
  "bricks": [
    {

      "id": "test4",
      "name": "test4",
      "author": "",
      "category": "",
      "status": "not found",
      "require_model": false,
      "compatible_models": null,
      "readme": ""
    }
]
```

- The delete endpoint returns not found only if the brick ID is not found in the `app.yaml` 

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
