### PR TITLE
feat: remove `require_container` support. Show deprecation notice.

### DIFF
--- a/internal/orchestrator/app/testdata/AppWithLocalBricks/bricks/my-first-brick/brick_config.yaml
+++ b/internal/orchestrator/app/testdata/AppWithLocalBricks/bricks/my-first-brick/brick_config.yaml
@@ -1,4 +1,3 @@
 id: my-first-brick
 name: My First Brick
 description: "This is my first brick"
-require_container: true

--- a/internal/orchestrator/bricks/bricks_test.go
+++ b/internal/orchestrator/bricks/bricks_test.go
@@ -389,7 +389,6 @@ bricks:
 - id: arduino:object_detection
   name: Object Detection
   description: Detect objects in images using a pre-trained model
-  require_container: true
   require_model: true
   mount_devices_into_container: true
   ports: ["8000"]

--- a/internal/orchestrator/bricks/testdata/bricks-list.yaml
+++ b/internal/orchestrator/bricks/testdata/bricks-list.yaml
@@ -2,7 +2,6 @@ bricks:
 - id: arduino:arduino_cloud
   name: Arduino Cloud
   description: Connects to Arduino Cloud
-  require_container: false
   require_model: false
   mount_devices_into_container: false
   ports: []
@@ -16,7 +15,6 @@ bricks:
   name: Database - SQL
   description: Simplified database storage layer for Arduino sensor data using SQLite
     local database.
-  require_container: false
   require_model: false
   mount_devices_into_container: false
   ports: []

--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -85,6 +85,7 @@ type Brick struct {
 	SupportedBoards           []string                  `yaml:"supported_boards,omitempty"`
 	Category                  string                    `yaml:"category,omitempty"`
 	RequiresDisplay           string                    `yaml:"requires_display,omitempty"`
+    // Deprecated
 	RequireContainer          bool                      `yaml:"require_container"` // Deprecated
 	RequireModel              bool                      `yaml:"require_model"`
 	Variables                 []BrickVariable           `yaml:"variables,omitempty"`

--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -79,13 +79,13 @@ func (v BrickVariable) IsRequired() bool {
 }
 
 type Brick struct {
-	ID                        string                    `yaml:"id"`
-	Name                      string                    `yaml:"name"`
-	Description               string                    `yaml:"description"`
-	SupportedBoards           []string                  `yaml:"supported_boards,omitempty"`
-	Category                  string                    `yaml:"category,omitempty"`
-	RequiresDisplay           string                    `yaml:"requires_display,omitempty"`
-    // Deprecated
+	ID              string   `yaml:"id"`
+	Name            string   `yaml:"name"`
+	Description     string   `yaml:"description"`
+	SupportedBoards []string `yaml:"supported_boards,omitempty"`
+	Category        string   `yaml:"category,omitempty"`
+	RequiresDisplay string   `yaml:"requires_display,omitempty"`
+	// Deprecated : the field `require_container` is deprecated, you can remove it from the brick config. It will be ignored if present.
 	RequireContainer          bool                      `yaml:"require_container"` // Deprecated
 	RequireModel              bool                      `yaml:"require_model"`
 	Variables                 []BrickVariable           `yaml:"variables,omitempty"`

--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"log/slog"
 	"os"
 	"slices"
 	"strings"
@@ -84,7 +85,7 @@ type Brick struct {
 	SupportedBoards           []string                  `yaml:"supported_boards,omitempty"`
 	Category                  string                    `yaml:"category,omitempty"`
 	RequiresDisplay           string                    `yaml:"requires_display,omitempty"`
-	RequireContainer          bool                      `yaml:"require_container"`
+	RequireContainer          bool                      `yaml:"require_container"` // Deprecated
 	RequireModel              bool                      `yaml:"require_model"`
 	Variables                 []BrickVariable           `yaml:"variables,omitempty"`
 	Ports                     []string                  `yaml:"ports,omitempty"`
@@ -187,6 +188,9 @@ func Load(platform platform.Platform, path *paths.Path) (*BricksIndex, error) {
 		namespace, brickName, err := parseBrickID(yamlIndex.Bricks[i].ID)
 		if err != nil {
 			return nil, err
+		}
+		if yamlIndex.Bricks[i].RequireContainer {
+			slog.Warn("the field `require_container` is deprecated. You can remove it from the brick config", "brick_id", yamlIndex.Bricks[i].ID)
 		}
 		yamlIndex.Bricks[i].Source = "Arduino"
 		yamlIndex.Bricks[i].FullPath = path

--- a/internal/orchestrator/bricksindex/bricks_index_test.go
+++ b/internal/orchestrator/bricksindex/bricks_index_test.go
@@ -213,7 +213,6 @@ func TestBricksIndexYAMLFormats(t *testing.T) {
   name: Complex Brick
   description: A complex test brick
   category: storage
-  require_container: true
   require_model: true
   mount_devices_into_container: true
   model_name: a-complex-model
@@ -236,7 +235,6 @@ func TestBricksIndexYAMLFormats(t *testing.T) {
 					Description:               "A complex test brick",
 					Category:                  "storage",
 					RequiresDisplay:           "",
-					RequireContainer:          true,
 					RequireModel:              true,
 					RequiredDevices:           []peripherals.DeviceClass{peripherals.CameraClass},
 					MountDevicesIntoContainer: true,

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -464,7 +464,6 @@ bricks:
     \ images and returns the predicted class label, bounding-boxes and confidence\
     \ score.\nBrick is designed to work with pre-trained models provided by framework\
     \ or with custom object detection models trained on Edge Impulse platform. \n"
-  require_container: true
   require_model: true
   ports: []
   category: video
@@ -547,7 +546,6 @@ bricks:
     \ images and returns the predicted class label, bounding-boxes and confidence\
     \ score.\nBrick is designed to work with pre-trained models provided by framework\
     \ or with custom object detection models trained on Edge Impulse platform. \n"
-  require_container: true
   require_model: true
   category: video
   model_name: yolox-object-detection

--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -257,12 +257,6 @@ func generateMainComposeFile(
 			brickServices[id] = *idxService
 		}
 
-		// The following code is needed only if the brick requires a container.
-		// In case it doesn't we just skip to the next one.
-		if !idxBrick.RequireContainer {
-			continue
-		}
-
 		// 3. Retrieve the brick_compose.yaml file.
 		composeFilePath, ok := idxBrick.GetComposeFile()
 		if !ok {
@@ -274,6 +268,10 @@ func generateMainComposeFile(
 		svcs, err := extractServicesFromComposeFile(composeFilePath)
 		if err != nil {
 			slog.Error("loading brick_compose", slog.String("brick_id", brick.ID), slog.String("path", composeFilePath.String()), slog.Any("error", err))
+			continue
+		}
+
+		if len(svcs) == 0 {
 			continue
 		}
 

--- a/internal/orchestrator/provision_test.go
+++ b/internal/orchestrator/provision_test.go
@@ -81,14 +81,12 @@ bricks:
   name: Database Storage - SQLStore
   description: Simplified database storage layer for Arduino sensor data using SQLite
     local database.
-  require_container: false
   require_model: false
   ports: []
   category: storage
 - id: arduino:video_object_detection
   name: Object Detection
   description: "Brick for object detection using a pre-trained model."
-  require_container: true
   require_model: true
   mount_devices_into_container: true
   ports: []
@@ -338,7 +336,6 @@ bricks:
   name: Database Storage - Time Series Store
   description: Simplified time series database storage layer for Arduino sensor samples
     built on top of InfluxDB.
-  require_container: true
   require_model: false
   ports: []
   category: storage
@@ -509,7 +506,6 @@ bricks:
   name: Database Storage - Time Series Store
   description: Simplified time series database storage layer for Arduino sensor samples
     built on top of InfluxDB.
-  require_container: true
   require_model: false
   ports: []
   category: storage
@@ -664,7 +660,6 @@ bricks:
 - id: arduino:video_object_detection
   name: Object Detection
   description: "Brick for object detection using a pre-trained model."
-  require_container: false
   require_model: false
   ports: []
   category: video

--- a/internal/orchestrator/testdata/archive/bricks-list.yaml
+++ b/internal/orchestrator/testdata/archive/bricks-list.yaml
@@ -3,7 +3,6 @@ bricks:
   name: Database - SQL
   description: Simplified database storage layer for Arduino sensor data using SQLite
     local database.
-  require_container: false
   require_model: false
   mount_devices_into_container: false
   ports: []
@@ -22,7 +21,6 @@ bricks:
     models trained on the Edge Impulse platform.
 
     '
-  require_container: true
   require_model: true
   mount_devices_into_container: true
   ports: []
@@ -50,7 +48,6 @@ bricks:
 - id: arduino:arduino_cloud
   name: Arduino Cloud
   description: Connects to Arduino Cloud
-  require_container: false
   require_model: false
   mount_devices_into_container: false
   ports: []
@@ -66,7 +63,6 @@ bricks:
   name: WebUI - HTML
   description: A user interface based on HTML and JavaScript that can rely on additional
     APIs and a WebSocket exposed by a web server.
-  require_container: false
   require_model: false
   mount_devices_into_container: false
   ports:
@@ -77,7 +73,6 @@ bricks:
   name: Cloud LLM
   description: Cloud LLM Brick enables seamless integration with cloud-based Large
     Language Models (LLMs) for advanced AI capabilities in your Arduino projects.
-  require_container: false
   require_model: false
   mount_devices_into_container: false
   ports: []
@@ -98,7 +93,6 @@ bricks:
     own custom anomaly detections models trained on the Edge Impulse platform.
 
     '
-  require_container: true
   require_model: true
   mount_devices_into_container: false
   ports: []
@@ -132,7 +126,6 @@ bricks:
     models trained on the Edge Impulse platform.
 
     '
-  require_container: true
   require_model: true
   mount_devices_into_container: true
   ports: []
@@ -160,7 +153,6 @@ bricks:
 - id: arduino:streamlit_ui
   name: WebUI - Streamlit
   description: A simplified user interface based on Streamlit and Python.
-  require_container: false
   require_model: false
   mount_devices_into_container: false
   ports:
@@ -176,7 +168,6 @@ bricks:
     custom audio classification models trained on Edge Impulse platform.
 
     '
-  require_container: true
   require_model: true
   mount_devices_into_container: false
   ports: []
@@ -208,7 +199,6 @@ bricks:
     custom motion classification models trained on the Edge Impulse platform.
 
     '
-  require_container: true
   require_model: true
   mount_devices_into_container: false
   ports: []
@@ -231,7 +221,6 @@ bricks:
   name: Database - Time Series
   description: Simplified time series database storage layer for Arduino sensor samples
     built on top of InfluxDB.
-  require_container: true
   require_model: false
   mount_devices_into_container: false
   ports: []
@@ -257,7 +246,6 @@ bricks:
   name: Weather Forecast
   description: Online weather forecast module for Arduino using open-meteo.com geolocation
     and weather APIs. Requires an internet connection.
-  require_container: false
   require_model: false
   mount_devices_into_container: false
   ports: []
@@ -268,7 +256,6 @@ bricks:
     \ images to identify unusual patterns and returns detected anomalies with bounding\
     \ boxes. \nSupports pre-trained models provided by the framework or custom anomaly\
     \ detection models trained on the Edge Impulse platform. \n"
-  require_container: true
   require_model: true
   mount_devices_into_container: false
   ports: []
@@ -293,7 +280,6 @@ bricks:
     \ images and returns the predicted class label, bounding-boxes and confidence\
     \ score.\nBrick is designed to work with pre-trained models provided by framework\
     \ or with custom object detection models trained on Edge Impulse platform. \n"
-  require_container: true
   require_model: true
   mount_devices_into_container: false
   ports: []
@@ -316,7 +302,6 @@ bricks:
   name: Wave Generator
   description: Continuous wave generator for audio synthesis. Generates sine, square,
     sawtooth, and triangle waveforms with smooth frequency and amplitude transitions.
-  require_container: false
   require_model: false
   mount_devices_into_container: false
   ports: []
@@ -330,7 +315,6 @@ bricks:
     It classifies text as positive, negative, or neutral.
 
     '
-  require_container: false
   require_model: false
   mount_devices_into_container: false
   ports: []
@@ -341,7 +325,6 @@ bricks:
     \ images and returns the predicted class label and confidence score.\nBrick is\
     \ designed to work with pre-trained models provided by framework or with custom\
     \ image classification models trained on Edge Impulse platform. \n"
-  require_container: true
   require_model: true
   mount_devices_into_container: false
   ports: []
@@ -363,7 +346,6 @@ bricks:
 - id: arduino:camera_code_detection
   name: Camera Code Detection
   description: Scans a camera for barcodes and QR codes
-  require_container: false
   require_model: false
   mount_devices_into_container: false
   ports: []
@@ -379,7 +361,6 @@ bricks:
     custom audio classification models trained on Edge Impulse platform.
 
     '
-  require_container: true
   require_model: true
   mount_devices_into_container: false
   ports: []


### PR DESCRIPTION
### Motivation
The `require_container` is a boolean field defined in the `brick_config.yam` file.
The value is only used by app-cli to generate the compose files if the require_container is true

To simplify the "local brick" creation, we could reduce the number of files to be edited to create a brick with a container.
Currenlty, a brick with a container requires two steps:
- add the `require_contatiner:tue" in the `brick_config.yaml` file
- add the service in the `brick_compose.yaml` file

### Change description

Remove the `require_container` from the `brick_config.yaml`. 
Show a deprecation notice if the brick contains a `require_container`

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
