### PR TITLE
fix: change error logging for missing brick compose files

### DIFF
--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -260,14 +260,13 @@ func generateMainComposeFile(
 		// 3. Retrieve the brick_compose.yaml file.
 		composeFilePath, ok := idxBrick.GetComposeFile()
 		if !ok {
-			slog.Error("brick compose not found", slog.String("brick_id", brick.ID))
 			continue
 		}
 
 		// 4. Retrieve the compose services names.
 		svcs, err := extractServicesFromComposeFile(composeFilePath)
 		if err != nil {
-			slog.Error("loading brick_compose", slog.String("brick_id", brick.ID), slog.String("path", composeFilePath.String()), slog.Any("error", err))
+			slog.Warn("loading brick_compose", slog.String("brick_id", brick.ID), slog.String("path", composeFilePath.String()), slog.Any("error", err))
 			continue
 		}
 


### PR DESCRIPTION
### Motivation
After #357  if a brick does not require a container, the code tries to read the compose file and log an error
`ERROR brick compose not found brick_id=arduino:web_ui` 

BUT the web_ui does not require a compose file by definition.

### Change description
Removed the logged error.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
