### PR TITLE
Let GetHostIP try harder to find an IP

### DIFF
--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -56,28 +56,40 @@ func GetHostIP() (string, error) {
 		return "", err
 	}
 
-	getIP := func(name string) (string, error) {
-		for _, iface := range ifaces {
-			if iface.Name == name {
-				addrs, err := iface.Addrs()
-				if err != nil {
-					return "", err
-				}
-				for _, addr := range addrs {
-					if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-						return ipnet.IP.String(), nil
-					}
-				}
+	// Collect IP Addresses from all running, non-loopback interfaces
+	found := map[string]string{}
+	for _, iface := range ifaces {
+		// Skip interfaces that are not running or are loopback
+		if iface.Flags&net.FlagRunning == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+				found[iface.Name] = ipnet.IP.String()
+				break
 			}
 		}
-		return "", fmt.Errorf("no IP address found for %s", name)
 	}
 
-	if ip, err := getIP("eth0"); err == nil {
+	// Prefer known interface names like "eth0" or "wlan0"
+	if ip, ok := found["eth0"]; ok {
+		return ip, nil
+	}
+	if ip, ok := found["wlan0"]; ok {
 		return ip, nil
 	}
 
-	return getIP("wlan0")
+	// If no known interfaces, return the first found IP address
+	for _, ip := range found {
+		return ip, nil
+	}
+
+	// If no IP address found, return an error
+	return "", fmt.Errorf("no IP address found")
 }
 
 func ToHumanMiB(bytes int64) string {

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -50,7 +50,51 @@ func ArduinoCLITaskProgressToString(progress *rpc.TaskProgress) string {
 	return data
 }
 
+// getDefaultNetworkInterfaceAndIP attempts to determine the default network interface and its associated IPv4 address
+func getDefaultNetworkInterfaceAndIP() (string, string, error) {
+	conn, err := net.Dial("udp4", "8.8.8.8:80")
+	if err != nil {
+		return "", "", err
+	}
+	defer conn.Close()
+
+	localAddr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok || localAddr.IP == nil {
+		return "", "", fmt.Errorf("unable to determine local address")
+	}
+
+	localIP := localAddr.IP.To4()
+	if localIP == nil {
+		return "", "", fmt.Errorf("default route does not use an IPv4 address")
+	}
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+
+		for _, addr := range addrs {
+			ip := ipv4FromAddr(addr)
+			if ip != nil && ip.Equal(localIP) {
+				return iface.Name, ip.String(), nil
+			}
+		}
+	}
+
+	return "", "", fmt.Errorf("default network interface not found for IP %s", localIP.String())
+}
+
 func GetHostIP() (string, error) {
+	if _, ip, err := getDefaultNetworkInterfaceAndIP(); err == nil {
+		return ip, nil
+	}
+
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return "", err
@@ -68,8 +112,9 @@ func GetHostIP() (string, error) {
 			continue
 		}
 		for _, addr := range addrs {
-			if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-				found[iface.Name] = ipnet.IP.String()
+			// Filter all non-loopback IPv4 addresses
+			if ip := ipv4FromAddr(addr); ip != nil {
+				found[iface.Name] = ip.String()
 				break
 			}
 		}
@@ -90,6 +135,23 @@ func GetHostIP() (string, error) {
 
 	// If no IP address found, return an error
 	return "", fmt.Errorf("no IP address found")
+}
+
+func ipv4FromAddr(addr net.Addr) net.IP {
+	switch value := addr.(type) {
+	case *net.IPNet:
+		if value.IP.IsLoopback() {
+			return nil
+		}
+		return value.IP.To4()
+	case *net.IPAddr:
+		if value.IP.IsLoopback() {
+			return nil
+		}
+		return value.IP.To4()
+	default:
+		return nil
+	}
 }
 
 func ToHumanMiB(bytes int64) string {

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -50,48 +50,29 @@ func ArduinoCLITaskProgressToString(progress *rpc.TaskProgress) string {
 	return data
 }
 
-// getDefaultNetworkInterfaceAndIP attempts to determine the default network interface and its associated IPv4 address
-func getDefaultNetworkInterfaceAndIP() (string, string, error) {
+// getDefaultNetworkInterfaceAndIP attempts to determine the IPv4 address of the default network interface
+func getDefaultNetworkInterfaceAndIP() (string, error) {
 	conn, err := net.Dial("udp4", "8.8.8.8:80")
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 	defer conn.Close()
 
 	localAddr, ok := conn.LocalAddr().(*net.UDPAddr)
 	if !ok || localAddr.IP == nil {
-		return "", "", fmt.Errorf("unable to determine local address")
+		return "", fmt.Errorf("unable to determine local address")
 	}
 
 	localIP := localAddr.IP.To4()
 	if localIP == nil {
-		return "", "", fmt.Errorf("default route does not use an IPv4 address")
+		return "", fmt.Errorf("default route does not use an IPv4 address")
 	}
 
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return "", "", err
-	}
-
-	for _, iface := range ifaces {
-		addrs, err := iface.Addrs()
-		if err != nil {
-			continue
-		}
-
-		for _, addr := range addrs {
-			ip := ipv4FromAddr(addr)
-			if ip != nil && ip.Equal(localIP) {
-				return iface.Name, ip.String(), nil
-			}
-		}
-	}
-
-	return "", "", fmt.Errorf("default network interface not found for IP %s", localIP.String())
+	return localIP.String(), nil
 }
 
 func GetHostIP() (string, error) {
-	if _, ip, err := getDefaultNetworkInterfaceAndIP(); err == nil {
+	if ip, err := getDefaultNetworkInterfaceAndIP(); err == nil {
 		return ip, nil
 	}
 

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -1,0 +1,77 @@
+// This file is part of arduino-app-cli.
+//
+// Copyright (C) Arduino s.r.l. and/or its affiliated companies
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package helpers
+
+import (
+	"net"
+	"testing"
+)
+
+func TestGetHostIP(t *testing.T) {
+	ip, err := GetHostIP()
+	if err != nil {
+		t.Fatalf("GetHostIP returned an error: %v", err)
+	}
+	if ip == "" {
+		t.Fatal("GetHostIP returned an empty string")
+	}
+	t.Logf("GetHostIP returned: %s", ip)
+}
+
+func TestIPv4FromAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		addr net.Addr
+		want string
+	}{
+		{
+			name: "ipv4 from IPNet",
+			addr: &net.IPNet{IP: net.ParseIP("192.168.1.10")},
+			want: "192.168.1.10",
+		},
+		{
+			name: "ipv4 from IPAddr",
+			addr: &net.IPAddr{IP: net.ParseIP("10.0.0.15")},
+			want: "10.0.0.15",
+		},
+		{
+			name: "ignore loopback",
+			addr: &net.IPNet{IP: net.ParseIP("127.0.0.1")},
+		},
+		{
+			name: "ignore ipv6",
+			addr: &net.IPNet{IP: net.ParseIP("2001:db8::1")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ipv4FromAddr(tt.addr)
+			if tt.want == "" {
+				if got != nil {
+					t.Fatalf("ipv4FromAddr() = %v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil || got.String() != tt.want {
+				t.Fatalf("ipv4FromAddr() = %v, want %s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation

We currently only check eth0 and wlan0, but the names could be different; we should check every connected Wi-Fi/ethernet device and get the IP.

### Change description

The new GetHostIP function uses a bunch of techniques to determine the host IP:
1. Tries to open a UDP socket targeting the address `8.8.8.8:80`, then it reads back the local IP address the OS bound this socket to (that should be linked to the default routing interface), and determines which interface has this address.
2. If the above fails, it scans all interfaces and accepts only the non-loopback and running. If `eth0` or `wlan0` are present and have an IP address, those are prioritized; otherwise, the first interface with a running address is returned.

### Additional Notes

Fix #333 

### Reviewer checklist

- [X] PR addresses a single concern.
- [X] PR title and description are properly filled.
- [X] Changes will be merged in `main`.
- [X] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
