### PR TITLE
feat: Override compose file definition by platform

### DIFF
--- a/cmd/arduino-app-cli/app/logs.go
+++ b/cmd/arduino-app-cli/app/logs.go
@@ -80,6 +80,7 @@ func logsHandler(ctx context.Context, app app.ArduinoApp, tail *uint64, follow, 
 		cfg,
 		servicelocator.GetDockerClient(),
 		servicelocator.GetBricksIndex(),
+		servicelocator.GetPlatform(),
 	)
 	if err != nil {
 		feedback.Fatal(err.Error(), feedback.ErrGeneric)

--- a/cmd/arduino-app-cli/system/system.go
+++ b/cmd/arduino-app-cli/system/system.go
@@ -65,7 +65,7 @@ func newDownloadImageCmd(cfg config.Configuration) *cobra.Command {
 			return orchestrator.SystemInit(cmd.Context(), cfg, servicelocator.GetBricksIndex(), servicelocator.GetDockerClient(), orchestrator.SystemInitOptions{
 				OnlyDockerImages:    onlyImages,
 				OnlyPlatformAndLibs: onlyPlatformAndLibraries,
-			})
+			}, servicelocator.GetPlatform())
 		},
 	}
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -84,7 +84,7 @@ func NewHTTPRouter(
 	mux.Handle("GET /v1/apps/events", handlers.HandlerAppStatus(dockerClient, idProvider, cfg))
 	mux.Handle("GET /v1/apps/{appID}", handlers.HandleAppDetails(dockerClient, bricksIndex, idProvider, cfg))
 	mux.Handle("PATCH /v1/apps/{appID}", handlers.HandleAppDetailsEdits(dockerClient, bricksIndex, idProvider, cfg))
-	mux.Handle("GET /v1/apps/{appID}/logs", handlers.HandleAppLogs(dockerClient, idProvider, bricksIndex))
+	mux.Handle("GET /v1/apps/{appID}/logs", handlers.HandleAppLogs(dockerClient, idProvider, bricksIndex, platform))
 	mux.Handle("POST /v1/apps/{appID}/start", handlers.HandleAppStart(dockerClient, provisioner, modelsIndex, bricksIndex, servicesIndex, idProvider, cfg, staticStore, platform))
 	mux.Handle("POST /v1/apps/{appID}/stop", handlers.HandleAppStop(dockerClient, idProvider, platform))
 	mux.Handle("POST /v1/apps/{appID}/clone", handlers.HandleAppClone(dockerClient, idProvider, cfg))

--- a/internal/api/handlers/app_logs.go
+++ b/internal/api/handlers/app_logs.go
@@ -30,6 +30,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
+	"github.com/arduino/arduino-app-cli/internal/platform"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
@@ -37,6 +38,7 @@ func HandleAppLogs(
 	dockerClient command.Cli,
 	idProvider *app.IDProvider,
 	bricksIndex *bricksindex.BricksIndex,
+	platform platform.Platform,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := idProvider.IDFromBase64(r.PathValue("appID"))
@@ -95,7 +97,7 @@ func HandleAppLogs(
 			BrickID string `json:"brick_id,omitempty"`
 			Message string `json:"message"`
 		}
-		messagesIter, err := orchestrator.AppLogs(r.Context(), app, appLogsRequest, dockerClient, bricksIndex)
+		messagesIter, err := orchestrator.AppLogs(r.Context(), app, appLogsRequest, dockerClient, bricksIndex, platform)
 		if err != nil {
 			sseStream.SendError(render.SSEErrorData{
 				Code:    render.InternalServiceErr,

--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -97,14 +97,21 @@ type Brick struct {
 
 	Source string `yaml:"-"`
 
-	FullPath     *paths.Path `yaml:"-"`
-	ComposeFile  *paths.Path `yaml:"-"` // brick_compose.yaml file path, optional
-	ReadmeFile   *paths.Path `yaml:"-"` // README.md file path, optional
-	ExamplesPath *paths.Path `yaml:"-"` // code examples folder path, optional
-	DocsAPIPath  *paths.Path `yaml:"-"` // API docs file path, optional
+	FullPath               *paths.Path             `yaml:"-"`
+	ComposeFile            *paths.Path             `yaml:"-"` // brick_compose.yaml file path, optional
+	ByPlatformComposeFiles *map[string]*paths.Path `yaml:"-"` // platform-specific compose files, optional
+	ReadmeFile             *paths.Path             `yaml:"-"` // README.md file path, optional
+	ExamplesPath           *paths.Path             `yaml:"-"` // code examples folder path, optional
+	DocsAPIPath            *paths.Path             `yaml:"-"` // API docs file path, optional
 }
 
-func (b Brick) GetComposeFile() (*paths.Path, bool) {
+func (b Brick) GetComposeFile(platform platform.Platform) (*paths.Path, bool) {
+	if b.ByPlatformComposeFiles != nil {
+		if path, ok := (*b.ByPlatformComposeFiles)[platform.BoardName]; ok && path != nil && !path.NotExist() {
+			return path, true
+		}
+	}
+	// Fallback to the default compose file if platform-specific one is not found
 	if b.ComposeFile == nil || b.ComposeFile.NotExist() {
 		return nil, false
 	}

--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -202,10 +202,32 @@ func Load(platform platform.Platform, path *paths.Path) (*BricksIndex, error) {
 		}
 		yamlIndex.Bricks[i].Source = "Arduino"
 		yamlIndex.Bricks[i].FullPath = path
-		yamlIndex.Bricks[i].ComposeFile = path.Join("compose", namespace, brickName, "brick_compose.yaml")
 		yamlIndex.Bricks[i].ReadmeFile = path.Join("docs", namespace, brickName, "README.md")
 		yamlIndex.Bricks[i].ExamplesPath = path.Join("examples", namespace, brickName)
 		yamlIndex.Bricks[i].DocsAPIPath = path.Join("api-docs", namespace, "app_bricks", brickName, "API.md")
+		// Load main compose file and, if present, platform-specific compose files
+		yamlIndex.Bricks[i].ComposeFile = path.Join("compose", namespace, brickName, "brick_compose.yaml")
+		// Search from platform specific files. Name syntax: brick_compose.<platform>.yaml, e.g. brick_compose.ventunoq.yaml
+		if dirEntries, err := yamlIndex.Bricks[i].ComposeFile.Parent().ReadDir(); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("cannot read compose directory for brick %s: %w", yamlIndex.Bricks[i].ID, err)
+		} else {
+			byPlatformComposeFiles := make(map[string]*paths.Path)
+			for _, entry := range dirEntries {
+				if entry.IsDir() {
+					continue
+				}
+				if entry.HasPrefix("brick_compose.") && entry.HasSuffix(".yaml") {
+					platformName := strings.TrimSuffix(strings.TrimPrefix(entry.Base(), "brick_compose."), ".yaml")
+					byPlatformComposeFiles[platformName] = yamlIndex.Bricks[i].ComposeFile.Parent().Join(entry.Base())
+				}
+			}
+			if len(byPlatformComposeFiles) > 0 {
+				yamlIndex.Bricks[i].ByPlatformComposeFiles = &byPlatformComposeFiles
+			}
+		}
 	}
 
 	yamlIndex.Bricks = slices.DeleteFunc(yamlIndex.Bricks, func(brick Brick) bool {

--- a/internal/orchestrator/bricksindex/bricks_index_test.go
+++ b/internal/orchestrator/bricksindex/bricks_index_test.go
@@ -290,7 +290,7 @@ func TestLoadBrickYamlBrickIndex(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "# i-am-a-readme-file", content)
 
-		compose, found := brick.GetComposeFile()
+		compose, found := brick.GetComposeFile(platform.GetPlatform(nil))
 		require.True(t, found)
 		require.Equal(t, paths.New("testdata/0.4.8/compose/arduino/a-good-brick/brick_compose.yaml"), compose)
 

--- a/internal/orchestrator/bricksindex/bricks_index_test.go
+++ b/internal/orchestrator/bricksindex/bricks_index_test.go
@@ -328,7 +328,7 @@ func TestLoadBrickYamlBrickIndex(t *testing.T) {
 			bricksIndex, err := Load(platform.Platform{BoardName: ""}, paths.New("testdata/0.4.8"))
 			require.NoError(t, err)
 			bricks := bricksIndex.ListBricks()
-			require.Len(t, bricks, 2)
+			require.Len(t, bricks, 3)
 		})
 
 		t.Run("foo-board", func(t *testing.T) {
@@ -336,15 +336,36 @@ func TestLoadBrickYamlBrickIndex(t *testing.T) {
 			bricksIndex, err := Load(platform, paths.New("testdata/0.4.8"))
 			require.NoError(t, err)
 			bricks := bricksIndex.ListBricks()
-			require.Len(t, bricks, 2)
+			require.Len(t, bricks, 3)
 		})
 		t.Run("another-board", func(t *testing.T) {
 			platform := platform.Platform{BoardName: "another-board"}
 			bricksIndex, err := Load(platform, paths.New("testdata/0.4.8"))
 			require.NoError(t, err)
 			bricks := bricksIndex.ListBricks()
-			require.Len(t, bricks, 1)
+			require.Len(t, bricks, 2)
 		})
+	})
+
+	t.Run("get by platform compose files", func(t *testing.T) {
+		// Force a Ventunoq platform to test the retrieval of platform-specific compose file
+		ventunoq := platform.Platform{
+			FQBN:        "arduino:zephyr:ventunoq",
+			PlatformID:  "arduino:zephyr",
+			BoardName:   "ventunoq",
+			CompileJobs: 0, // unlimited
+		}
+		bricksIndex, err := Load(ventunoq, paths.New("testdata/0.4.8"))
+		require.NoError(t, err)
+
+		brick, found := bricksIndex.FindBrickByID("arduino:a-good-brick-by-platform")
+		require.True(t, found)
+		assert.Equal(t, paths.New("testdata/0.4.8"), brick.FullPath)
+
+		compose, found := brick.GetComposeFile(ventunoq)
+		require.True(t, found)
+		require.Equal(t, paths.New("testdata/0.4.8/compose/arduino/a-good-brick-by-platform/brick_compose.ventunoq.yaml"), compose)
+
 	})
 }
 

--- a/internal/orchestrator/bricksindex/testdata/0.4.8/bricks-list.yaml
+++ b/internal/orchestrator/bricksindex/testdata/0.4.8/bricks-list.yaml
@@ -7,3 +7,6 @@ bricks:
   description: "This is another good brick that does even better things."
   supported_boards:
      - foo-board
+- id: arduino:a-good-brick-by-platform
+  name: A Good Brick that is only good for some platforms
+  description: "This is a good brick that does good things but for a specific platform."

--- a/internal/orchestrator/bricksindex/testdata/0.4.8/compose/arduino/a-good-brick-by-platform/brick_compose.ventunoq.yaml
+++ b/internal/orchestrator/bricksindex/testdata/0.4.8/compose/arduino/a-good-brick-by-platform/brick_compose.ventunoq.yaml
@@ -1,0 +1,1 @@
+# i-am-a-compose-file for VENTUNOQ

--- a/internal/orchestrator/bricksindex/testdata/0.4.8/compose/arduino/a-good-brick-by-platform/brick_compose.yaml
+++ b/internal/orchestrator/bricksindex/testdata/0.4.8/compose/arduino/a-good-brick-by-platform/brick_compose.yaml
@@ -1,0 +1,1 @@
+# i-am-a-compose-file

--- a/internal/orchestrator/logs.go
+++ b/internal/orchestrator/logs.go
@@ -38,6 +38,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/helpers"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
+	"github.com/arduino/arduino-app-cli/internal/platform"
 )
 
 type AppLogsRequest struct {
@@ -59,6 +60,7 @@ func AppLogs(
 	req AppLogsRequest,
 	dockerCli command.Cli,
 	bricksIndex *bricksindex.BricksIndex,
+	platform platform.Platform,
 ) (iter.Seq[LogMessage], error) {
 	if app.MainPythonFile == nil {
 		return helpers.EmptyIter[LogMessage](), nil
@@ -79,7 +81,7 @@ func AppLogs(
 			slog.Warn("brick not valid", slog.String("brick_id", brick.ID))
 			continue
 		}
-		composeFilePath, found := brick.GetComposeFile()
+		composeFilePath, found := brick.GetComposeFile(platform)
 		if !found {
 			slog.Warn("brick compose id not valid", slog.String("brick_id", brick.ID))
 			continue

--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -258,7 +258,7 @@ func generateMainComposeFile(
 		}
 
 		// 3. Retrieve the brick_compose.yaml file.
-		composeFilePath, ok := idxBrick.GetComposeFile()
+		composeFilePath, ok := idxBrick.GetComposeFile(platform)
 		if !ok {
 			continue
 		}

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -78,7 +78,7 @@ func (o SystemInitOptions) Validate() error {
 // SystemInit pulls all the docker images needed for the current version of the software to run and the
 // sketch libraries used in the example apps. Can be used to pre-install docker images/libraries on an
 // empty system, or to update all the docker images/libraries that need it.
-func SystemInit(ctx context.Context, cfg config.Configuration, bricksindex *bricksindex.BricksIndex, docker *command.DockerCli, options SystemInitOptions) error {
+func SystemInit(ctx context.Context, cfg config.Configuration, bricksindex *bricksindex.BricksIndex, docker *command.DockerCli, options SystemInitOptions, platform platform.Platform) error {
 	if err := options.Validate(); err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func SystemInit(ctx context.Context, cfg config.Configuration, bricksindex *bric
 
 	if downloadDockerImages {
 		// TODO: use progressCB instead of stdout
-		if err := downloadSupportedBricksImages(ctx, cfg, bricksindex, docker, stdout); err != nil {
+		if err := downloadSupportedBricksImages(ctx, cfg, bricksindex, docker, stdout, platform); err != nil {
 			return fmt.Errorf("failed to download container images used in examples: %w", err)
 		}
 	}
@@ -125,9 +125,9 @@ func SystemInit(ctx context.Context, cfg config.Configuration, bricksindex *bric
 	return nil
 }
 
-func downloadSupportedBricksImages(ctx context.Context, cfg config.Configuration, brickindex *bricksindex.BricksIndex, docker *command.DockerCli, stdout io.Writer) error {
+func downloadSupportedBricksImages(ctx context.Context, cfg config.Configuration, brickindex *bricksindex.BricksIndex, docker *command.DockerCli, stdout io.Writer, platform platform.Platform) error {
 	imagesToPreinstall := []string{cfg.PythonImage}
-	additionalImages, err := getAllSupportedBrickImage(brickindex)
+	additionalImages, err := getAllSupportedBrickImage(brickindex, platform)
 	if err != nil {
 		return err
 	}
@@ -266,10 +266,10 @@ func listImagesAlreadyPulled(ctx context.Context, docker dockerClient.APIClient)
 	return result, nil
 }
 
-func getAllSupportedBrickImage(bricksindex *bricksindex.BricksIndex) ([]string, error) {
+func getAllSupportedBrickImage(bricksindex *bricksindex.BricksIndex, platform platform.Platform) ([]string, error) {
 	var result []string
 	for _, brick := range bricksindex.ListBricks() {
-		composeFile, ok := brick.GetComposeFile()
+		composeFile, ok := brick.GetComposeFile(platform)
 		if !ok {
 			continue
 		}
@@ -345,7 +345,7 @@ func SystemCleanup(ctx context.Context, cfg config.Configuration, bricksindex *b
 	}
 
 	// Remove unused images
-	containersMustStay, err := getRequiredImages(cfg, bricksindex)
+	containersMustStay, err := getRequiredImages(cfg, bricksindex, platform)
 	if err != nil {
 		return result, err
 	}
@@ -389,8 +389,8 @@ func removeImage(ctx context.Context, docker dockerClient.APIClient, imageName s
 }
 
 // imgages required by the system
-func getRequiredImages(cfg config.Configuration, bricksindex *bricksindex.BricksIndex) ([]string, error) {
-	modelsRunnersContainers, err := getAllSupportedBrickImage(bricksindex)
+func getRequiredImages(cfg config.Configuration, bricksindex *bricksindex.BricksIndex, platform platform.Platform) ([]string, error) {
+	modelsRunnersContainers, err := getAllSupportedBrickImage(bricksindex, platform)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse models runner images: %w", err)
 	}


### PR DESCRIPTION
### Motivation

Allow to override compose files by platform.
If for a defined platform (e.g. `ventunoq`) is defined a specific brick compose (e.g. `brick_compose.ventunoq.yaml`), this compose will be used instead of the default one.


### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
