### PR TITLE
feat: added support for compose override by-platform

### DIFF
--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -195,10 +195,19 @@ func Load(platform platform.Platform, path *paths.Path) (*BricksIndex, error) {
 		}
 		yamlIndex.Bricks[i].Source = "Arduino"
 		yamlIndex.Bricks[i].FullPath = path
-		yamlIndex.Bricks[i].ComposeFile = path.Join("compose", namespace, brickName, "brick_compose.yaml")
 		yamlIndex.Bricks[i].ReadmeFile = path.Join("docs", namespace, brickName, "README.md")
 		yamlIndex.Bricks[i].ExamplesPath = path.Join("examples", namespace, brickName)
 		yamlIndex.Bricks[i].DocsAPIPath = path.Join("api-docs", namespace, "app_bricks", brickName, "API.md")
+
+		// Load main compose file and, if present, platform-specific compose files
+		composePath := path.Join("compose", namespace, brickName)
+		baseCompose := composePath.Join("brick_compose.yaml")
+		specificCompose := composePath.Join(fmt.Sprintf("brick_compose.%s.yaml", platform.BoardName))
+		if specificCompose.Exist() {
+			yamlIndex.Bricks[i].ComposeFile = specificCompose
+		} else if baseCompose.Exist() {
+			yamlIndex.Bricks[i].ComposeFile = baseCompose
+		}
 	}
 
 	yamlIndex.Bricks = slices.DeleteFunc(yamlIndex.Bricks, func(brick Brick) bool {

--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -200,10 +200,12 @@ func Load(platform platform.Platform, path *paths.Path) (*BricksIndex, error) {
 		yamlIndex.Bricks[i].DocsAPIPath = path.Join("api-docs", namespace, "app_bricks", brickName, "API.md")
 
 		// Load main compose file and, if present, platform-specific compose files
-		composePath := path.Join("compose", namespace, brickName)
-		baseCompose := composePath.Join("brick_compose.yaml")
-		specificCompose := composePath.Join(fmt.Sprintf("brick_compose.%s.yaml", platform.BoardName))
-		if specificCompose.Exist() {
+		var (
+			composePath     = path.Join("compose", namespace, brickName)
+			baseCompose     = composePath.Join("brick_compose.yaml")
+			specificCompose = composePath.Join(fmt.Sprintf("brick_compose.%s.yaml", platform.BoardName))
+		)
+		if platform.BoardName != "" && specificCompose.Exist() {
 			yamlIndex.Bricks[i].ComposeFile = specificCompose
 		} else if baseCompose.Exist() {
 			yamlIndex.Bricks[i].ComposeFile = baseCompose

--- a/internal/orchestrator/bricksindex/bricks_index_test.go
+++ b/internal/orchestrator/bricksindex/bricks_index_test.go
@@ -328,7 +328,7 @@ func TestLoadBrickYamlBrickIndex(t *testing.T) {
 			bricksIndex, err := Load(platform.Platform{BoardName: ""}, paths.New("testdata/0.4.8"))
 			require.NoError(t, err)
 			bricks := bricksIndex.ListBricks()
-			require.Len(t, bricks, 2)
+			require.Len(t, bricks, 3)
 		})
 
 		t.Run("foo-board", func(t *testing.T) {
@@ -336,15 +336,36 @@ func TestLoadBrickYamlBrickIndex(t *testing.T) {
 			bricksIndex, err := Load(platform, paths.New("testdata/0.4.8"))
 			require.NoError(t, err)
 			bricks := bricksIndex.ListBricks()
-			require.Len(t, bricks, 2)
+			require.Len(t, bricks, 3)
 		})
 		t.Run("another-board", func(t *testing.T) {
 			platform := platform.Platform{BoardName: "another-board"}
 			bricksIndex, err := Load(platform, paths.New("testdata/0.4.8"))
 			require.NoError(t, err)
 			bricks := bricksIndex.ListBricks()
-			require.Len(t, bricks, 1)
+			require.Len(t, bricks, 2)
 		})
+	})
+
+	t.Run("get by platform compose files", func(t *testing.T) {
+		// Force a Ventunoq platform to test the retrieval of platform-specific compose file
+		ventunoq := platform.Platform{
+			FQBN:        "arduino:zephyr:ventunoq",
+			PlatformID:  "arduino:zephyr",
+			BoardName:   "ventunoq",
+			CompileJobs: 0, // unlimited
+		}
+		bricksIndex, err := Load(ventunoq, paths.New("testdata/0.4.8"))
+		require.NoError(t, err)
+
+		brick, found := bricksIndex.FindBrickByID("arduino:a-good-brick-by-platform")
+		require.True(t, found)
+		assert.Equal(t, paths.New("testdata/0.4.8"), brick.FullPath)
+
+		compose, found := brick.GetComposeFile()
+		require.True(t, found)
+		require.Equal(t, paths.New("testdata/0.4.8/compose/arduino/a-good-brick-by-platform/brick_compose.ventunoq.yaml"), compose)
+
 	})
 }
 

--- a/internal/orchestrator/bricksindex/testdata/0.4.8/bricks-list.yaml
+++ b/internal/orchestrator/bricksindex/testdata/0.4.8/bricks-list.yaml
@@ -7,3 +7,6 @@ bricks:
   description: "This is another good brick that does even better things."
   supported_boards:
      - foo-board
+- id: arduino:a-good-brick-by-platform
+  name: A Good Brick that is only good for some platforms
+  description: "This is a good brick that does good things but for a specific platform."

--- a/internal/orchestrator/bricksindex/testdata/0.4.8/compose/arduino/a-good-brick-by-platform/brick_compose.ventunoq.yaml
+++ b/internal/orchestrator/bricksindex/testdata/0.4.8/compose/arduino/a-good-brick-by-platform/brick_compose.ventunoq.yaml
@@ -1,0 +1,1 @@
+# i-am-a-compose-file for VENTUNOQ

--- a/internal/orchestrator/bricksindex/testdata/0.4.8/compose/arduino/a-good-brick-by-platform/brick_compose.yaml
+++ b/internal/orchestrator/bricksindex/testdata/0.4.8/compose/arduino/a-good-brick-by-platform/brick_compose.yaml
@@ -1,0 +1,1 @@
+# i-am-a-compose-file

--- a/internal/orchestrator/provision_test.go
+++ b/internal/orchestrator/provision_test.go
@@ -396,6 +396,7 @@ services:
 
 		// Reload index after adding compose file.
 		bricksIndex, err := bricksindex.Load(platform.GetPlatform(nil), cfg.AssetsDir())
+		require.NoError(t, err)
 
 		// Run the provision function to generate the main compose file
 		err = generateMainComposeFile(&app, bricksIndex, servicesIndex, "app-bricks:python-apps-base:dev-latest", cfg, env, unkownPlatform, devices)
@@ -456,6 +457,7 @@ services:
 
 		// Reload index after adding compose file.
 		bricksIndex, err := bricksindex.Load(platform.GetPlatform(nil), cfg.AssetsDir())
+		require.NoError(t, err)
 
 		// Run the provision function to generate the main compose file
 		err = generateMainComposeFile(&app, bricksIndex, servicesIndex, "app-bricks:python-apps-base:dev-latest", cfg, env, unkownPlatform, devices)

--- a/internal/orchestrator/provision_test.go
+++ b/internal/orchestrator/provision_test.go
@@ -394,6 +394,9 @@ services:
 			HasVideoDevice: true,
 		}
 
+		// Reload index after adding compose file.
+		bricksIndex, err := bricksindex.Load(platform.GetPlatform(nil), cfg.AssetsDir())
+
 		// Run the provision function to generate the main compose file
 		err = generateMainComposeFile(&app, bricksIndex, servicesIndex, "app-bricks:python-apps-base:dev-latest", cfg, env, unkownPlatform, devices)
 		require.NoError(t, err, "Failed to generate main compose file")
@@ -450,6 +453,10 @@ services:
 			HasSoundDevice: false,
 			HasVideoDevice: true,
 		}
+
+		// Reload index after adding compose file.
+		bricksIndex, err := bricksindex.Load(platform.GetPlatform(nil), cfg.AssetsDir())
+
 		// Run the provision function to generate the main compose file
 		err = generateMainComposeFile(&app, bricksIndex, servicesIndex, "app-bricks:python-apps-base:dev-latest", cfg, env, unkownPlatform, devices)
 		require.NoError(t, err, "Failed to generate main compose file")


### PR DESCRIPTION
### Motivation

>Allow to override compose files by platform.
If for a defined platform (e.g. ventunoq) is defined a specific brick compose (e.g. brick_compose.ventunoq.yaml), this compose will be used instead of the default one.


### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
