### PR TITLE
Pass the information CONNECTED_CARRIERS to the bricks container

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -312,6 +312,9 @@ func getAppEnvironmentVariables(app app.ArduinoApp, brickIndex *bricksindex.Bric
 		envs["VIDEO_DEVICE"] = videoDevices[0]
 	}
 
+	if mediaCarriers := peripherals.GetMediaCarriers(); len(mediaCarriers) > 0 {
+		envs["CONNECTED_CARRIERS"] = strings.Join(mediaCarriers, ",")
+	}
 	if hostIP, err := helpers.GetHostIP(); err == nil {
 		envs["HOST_IP"] = hostIP
 	} else {

--- a/internal/orchestrator/peripherals/devices.go
+++ b/internal/orchestrator/peripherals/devices.go
@@ -188,3 +188,9 @@ func HasVirtualDevice(deviceClass DeviceClass, devices []string) bool {
 	}
 	return false
 }
+
+// TODO: call arduino-linux-config to detect connected and enabled media carriers.
+// For now returns empty slice — CONNECTED_CARRIERS will not be set in the environment.
+func GetMediaCarriers() []string {
+	return []string{}
+}


### PR DESCRIPTION
### Motivation

The brick containers need to know if a media carrier is connected, so that they can search for cameras and devices attached to it. Passing a flag it only if the carrier is connected is not possible, but we know if the carrier has been fully enabled.

The environment variable added to the docker compose and sent to the containers:
`CONNECTED_CARRIERS=media-carrier`
### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
