### PR TITLE
system init/cleanup should download/remove services images

### DIFF
--- a/cmd/arduino-app-cli/system/system.go
+++ b/cmd/arduino-app-cli/system/system.go
@@ -62,7 +62,7 @@ func newDownloadImageCmd(cfg config.Configuration) *cobra.Command {
 		Args:   cobra.ExactArgs(0),
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return orchestrator.SystemInit(cmd.Context(), cfg, servicelocator.GetBricksIndex(), servicelocator.GetDockerClient(), orchestrator.SystemInitOptions{
+			return orchestrator.SystemInit(cmd.Context(), cfg, servicelocator.GetBricksIndex(), servicelocator.GetServicesIndex(), servicelocator.GetDockerClient(), orchestrator.SystemInitOptions{
 				OnlyDockerImages:    onlyImages,
 				OnlyPlatformAndLibs: onlyPlatformAndLibraries,
 			})
@@ -162,11 +162,8 @@ func newCleanUpCmd(cfg config.Configuration, docker command.Cli) *cobra.Command 
 		Short: "Removes unused and obsolete application images to free up disk space.",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			bricksindex := servicelocator.GetBricksIndex()
-			platform := servicelocator.GetPlatform()
-
 			feedback.Printf("Running cleanup...")
-			result, err := orchestrator.SystemCleanup(cmd.Context(), cfg, bricksindex, docker, platform)
+			result, err := orchestrator.SystemCleanup(cmd.Context(), cfg, servicelocator.GetBricksIndex(), servicelocator.GetServicesIndex(), docker, servicelocator.GetPlatform())
 			if err != nil {
 				return err
 			}

--- a/internal/orchestrator/provision_test.go
+++ b/internal/orchestrator/provision_test.go
@@ -496,7 +496,6 @@ services:
 
 func TestProvisionAppComposeOverridesFile(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	// staticStore := store.NewStaticStore(cfg.AssetsDir().String())
 	tempDirectory := t.TempDir()
 	var env = map[string]string{}
 	type services struct {

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -280,28 +280,11 @@ func getAllSupportedBrickImages(bricksIndex *bricksindex.BricksIndex) ([]string,
 		if !ok {
 			continue
 		}
-		content, err := composeFile.ReadFile()
+		images, err := extractImagesFromCompose(composeFile)
 		if err != nil {
 			return nil, err
 		}
-		prj, err := loader.LoadWithContext(
-			context.Background(),
-			types.ConfigDetails{
-				ConfigFiles: []types.ConfigFile{{Content: content}},
-				Environment: types.NewMapping(os.Environ()),
-			},
-			func(o *loader.Options) { o.SetProjectName("test", false) },
-		)
-		if err != nil {
-			return nil, err
-		}
-		for _, v := range prj.Services {
-			for _, prefix := range imagePrefixes {
-				if strings.HasPrefix(v.Image, prefix) {
-					result = append(result, v.Image)
-				}
-			}
-		}
+		result = append(result, images...)
 	}
 
 	return f.Uniq(result), nil
@@ -314,31 +297,42 @@ func getAllSupportedBrickServiceImages(serviceIndex *servicesindex.ServicesIndex
 		if !ok {
 			continue
 		}
-		content, err := composeFile.ReadFile()
+		images, err := extractImagesFromCompose(composeFile)
 		if err != nil {
 			return nil, err
 		}
-		prj, err := loader.LoadWithContext(
-			context.Background(),
-			types.ConfigDetails{
-				ConfigFiles: []types.ConfigFile{{Content: content}},
-				Environment: types.NewMapping(os.Environ()),
-			},
-			func(o *loader.Options) { o.SetProjectName("test", false) },
-		)
-		if err != nil {
-			return nil, err
-		}
-		for _, v := range prj.Services {
-			for _, prefix := range imagePrefixes {
-				if strings.HasPrefix(v.Image, prefix) {
-					result = append(result, v.Image)
-				}
-			}
-		}
+		result = append(result, images...)
 	}
 
 	return f.Uniq(result), nil
+}
+
+func extractImagesFromCompose(composeFile *paths.Path) ([]string, error) {
+	var result []string
+
+	content, err := composeFile.ReadFile()
+	if err != nil {
+		return nil, err
+	}
+	prj, err := loader.LoadWithContext(
+		context.Background(),
+		types.ConfigDetails{
+			ConfigFiles: []types.ConfigFile{{Content: content}},
+			Environment: types.NewMapping(os.Environ()),
+		},
+		func(o *loader.Options) { o.SetProjectName("default", false) },
+	)
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range prj.Services {
+		for _, prefix := range imagePrefixes {
+			if strings.HasPrefix(v.Image, prefix) {
+				result = append(result, v.Image)
+			}
+		}
+	}
+	return result, nil
 }
 
 type SystemCleanupResult struct {

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -48,6 +48,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
 
@@ -78,7 +79,7 @@ func (o SystemInitOptions) Validate() error {
 // SystemInit pulls all the docker images needed for the current version of the software to run and the
 // sketch libraries used in the example apps. Can be used to pre-install docker images/libraries on an
 // empty system, or to update all the docker images/libraries that need it.
-func SystemInit(ctx context.Context, cfg config.Configuration, bricksindex *bricksindex.BricksIndex, docker *command.DockerCli, options SystemInitOptions) error {
+func SystemInit(ctx context.Context, cfg config.Configuration, bricksindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, docker *command.DockerCli, options SystemInitOptions) error {
 	if err := options.Validate(); err != nil {
 		return err
 	}
@@ -117,7 +118,7 @@ func SystemInit(ctx context.Context, cfg config.Configuration, bricksindex *bric
 
 	if downloadDockerImages {
 		// TODO: use progressCB instead of stdout
-		if err := downloadSupportedBricksImages(ctx, cfg, bricksindex, docker, stdout); err != nil {
+		if err := downloadSupportedImages(ctx, cfg, bricksindex, servicesindex, docker, stdout); err != nil {
 			return fmt.Errorf("failed to download container images used in examples: %w", err)
 		}
 	}
@@ -125,13 +126,19 @@ func SystemInit(ctx context.Context, cfg config.Configuration, bricksindex *bric
 	return nil
 }
 
-func downloadSupportedBricksImages(ctx context.Context, cfg config.Configuration, brickindex *bricksindex.BricksIndex, docker *command.DockerCli, stdout io.Writer) error {
+func downloadSupportedImages(ctx context.Context, cfg config.Configuration, brickindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, docker *command.DockerCli, stdout io.Writer) error {
 	imagesToPreinstall := []string{cfg.PythonImage}
-	additionalImages, err := getAllSupportedBrickImage(brickindex)
+	brickImages, err := getAllSupportedBrickImages(brickindex)
 	if err != nil {
 		return err
 	}
-	imagesToPreinstall = append(imagesToPreinstall, additionalImages...)
+	imagesToPreinstall = append(imagesToPreinstall, brickImages...)
+
+	brickServiceImages, err := getAllSupportedBrickServiceImages(servicesindex)
+	if err != nil {
+		return err
+	}
+	imagesToPreinstall = append(imagesToPreinstall, brickServiceImages...)
 
 	pulledImages, err := listImagesAlreadyPulled(ctx, docker.Client())
 	if err != nil {
@@ -266,10 +273,44 @@ func listImagesAlreadyPulled(ctx context.Context, docker dockerClient.APIClient)
 	return result, nil
 }
 
-func getAllSupportedBrickImage(bricksindex *bricksindex.BricksIndex) ([]string, error) {
+func getAllSupportedBrickImages(bricksIndex *bricksindex.BricksIndex) ([]string, error) {
 	var result []string
-	for _, brick := range bricksindex.ListBricks() {
+	for _, brick := range bricksIndex.ListBricks() {
 		composeFile, ok := brick.GetComposeFile()
+		if !ok {
+			continue
+		}
+		content, err := composeFile.ReadFile()
+		if err != nil {
+			return nil, err
+		}
+		prj, err := loader.LoadWithContext(
+			context.Background(),
+			types.ConfigDetails{
+				ConfigFiles: []types.ConfigFile{{Content: content}},
+				Environment: types.NewMapping(os.Environ()),
+			},
+			func(o *loader.Options) { o.SetProjectName("test", false) },
+		)
+		if err != nil {
+			return nil, err
+		}
+		for _, v := range prj.Services {
+			for _, prefix := range imagePrefixes {
+				if strings.HasPrefix(v.Image, prefix) {
+					result = append(result, v.Image)
+				}
+			}
+		}
+	}
+
+	return f.Uniq(result), nil
+}
+
+func getAllSupportedBrickServiceImages(serviceIndex *servicesindex.ServicesIndex) ([]string, error) {
+	var result []string
+	for _, service := range serviceIndex.Services {
+		composeFile, ok := service.GetComposeFile()
 		if !ok {
 			continue
 		}
@@ -314,7 +355,7 @@ func (s SystemCleanupResult) IsEmpty() bool {
 
 // SystemCleanup removes dangling containers and unused images.
 // Also running apps are stopped and removed.
-func SystemCleanup(ctx context.Context, cfg config.Configuration, bricksindex *bricksindex.BricksIndex, docker command.Cli, platform platform.Platform) (SystemCleanupResult, error) {
+func SystemCleanup(ctx context.Context, cfg config.Configuration, bricksindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, docker command.Cli, platform platform.Platform) (SystemCleanupResult, error) {
 	var result SystemCleanupResult
 
 	// Remove running app
@@ -345,7 +386,7 @@ func SystemCleanup(ctx context.Context, cfg config.Configuration, bricksindex *b
 	}
 
 	// Remove unused images
-	containersMustStay, err := getRequiredImages(cfg, bricksindex)
+	containersMustStay, err := getRequiredImages(cfg, bricksindex, servicesindex)
 	if err != nil {
 		return result, err
 	}
@@ -389,15 +430,21 @@ func removeImage(ctx context.Context, docker dockerClient.APIClient, imageName s
 }
 
 // imgages required by the system
-func getRequiredImages(cfg config.Configuration, bricksindex *bricksindex.BricksIndex) ([]string, error) {
-	modelsRunnersContainers, err := getAllSupportedBrickImage(bricksindex)
+func getRequiredImages(cfg config.Configuration, bricksindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex) ([]string, error) {
+	bricksContainers, err := getAllSupportedBrickImages(bricksindex)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse models runner images: %w", err)
+		return nil, fmt.Errorf("failed to parse bricks runner images: %w", err)
 	}
 
-	requiredImages := make([]string, 0, 1+len(modelsRunnersContainers))
+	bricksServiceContainers, err := getAllSupportedBrickServiceImages(servicesindex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse brick services images: %w", err)
+	}
+
+	requiredImages := make([]string, 0, 1+len(bricksContainers)+len(bricksServiceContainers))
 	requiredImages = append(requiredImages, cfg.PythonImage)
-	requiredImages = append(requiredImages, modelsRunnersContainers...)
+	requiredImages = append(requiredImages, bricksContainers...)
+	requiredImages = append(requiredImages, bricksServiceContainers...)
 
 	return requiredImages, nil
 }

--- a/internal/orchestrator/system_test.go
+++ b/internal/orchestrator/system_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/arduino/go-paths-helper"
 	dockerCommand "github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api/types/image"
@@ -69,4 +70,63 @@ func getDockerClient(t *testing.T) dockerClient.APIClient {
 	err = d.Initialize(flags.NewClientOptions())
 	require.NoError(t, err)
 	return d.Client()
+}
+
+func TestExtractImagesFromCompose(t *testing.T) {
+	oldPrefixes := imagePrefixes
+	imagePrefixes = []string{"ghcr.io/bcmi-labs/", "public.ecr.aws/arduino/", "ghcr.io/arduino/", "influxdb"}
+	defer func() { imagePrefixes = oldPrefixes }()
+
+	tests := []struct {
+		name           string
+		composePath    *paths.Path
+		expectedImages []string
+		wantErr        bool
+	}{
+		{
+			name:           "valid compose with supported images",
+			composePath:    paths.New("testdata", "composes", "service_compose_valid.yaml"),
+			expectedImages: []string{"ghcr.io/arduino/app-bricks/ollama-models-runner:dev-next"},
+			wantErr:        false,
+		},
+		{
+			name:        "invalid compose",
+			composePath: paths.New("testdata", "composes", "service_compose_invalid.yaml"),
+			wantErr:     true,
+		},
+		{
+			name:           "no matching prefixes",
+			composePath:    paths.New("testdata", "composes", "service_compose_no_prefix_match.yaml"),
+			expectedImages: nil,
+			wantErr:        false,
+		},
+		{
+			name:        "multiple services with mixed prefixes",
+			composePath: paths.New("testdata", "composes", "service_compose_multiple.yaml"),
+			expectedImages: []string{
+				"ghcr.io/arduino/app-bricks/genie-models-runner:dev-next",
+				"ghcr.io/arduino/app-bricks/audio-analytics-models-runner:dev-next",
+			},
+			wantErr: false,
+		},
+		{
+			name:        "file not found",
+			composePath: paths.New("testdata", "composes", "does_not_exist.yaml"),
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got, err := extractImagesFromCompose(tt.composePath)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.ElementsMatch(t, tt.expectedImages, got)
+			}
+		})
+	}
 }

--- a/internal/orchestrator/testdata/composes/service_compose_invalid.yaml
+++ b/internal/orchestrator/testdata/composes/service_compose_invalid.yaml
@@ -1,0 +1,3 @@
+services:
+  ollama-models-runner:
+    image: [unclosed bracket

--- a/internal/orchestrator/testdata/composes/service_compose_multiple.yaml
+++ b/internal/orchestrator/testdata/composes/service_compose_multiple.yaml
@@ -1,0 +1,7 @@
+services:
+  genie-models-runner:
+    image: ghcr.io/arduino/app-bricks/genie-models-runner:dev-next
+  audio-analytics-runner:
+    image: ghcr.io/arduino/app-bricks/audio-analytics-models-runner:dev-next
+  some-other-service:
+    image: alpine:latest

--- a/internal/orchestrator/testdata/composes/service_compose_no_prefix_match.yaml
+++ b/internal/orchestrator/testdata/composes/service_compose_no_prefix_match.yaml
@@ -1,0 +1,3 @@
+services:
+  app:
+    image: alpine:latest

--- a/internal/orchestrator/testdata/composes/service_compose_valid.yaml
+++ b/internal/orchestrator/testdata/composes/service_compose_valid.yaml
@@ -1,0 +1,3 @@
+services:
+  ollama-models-runner:
+    image: ghcr.io/arduino/app-bricks/ollama-models-runner:dev-next


### PR DESCRIPTION
### Motivation

The system init command should also download all the Docker images in services and download them

https://github.com/arduino/arduino-app-cli/blob/90a0b4dee6c2f300e9adf0fcfa8384d289bc97e3/internal/orchestrator/system.go#L130

The system cleanup command should verify that old image of old services are correctly removed.

https://github.com/arduino/arduino-app-cli/blob/90a0b4dee6c2f300e9adf0fcfa8384d289bc97e3/internal/orchestrator/system.go#L269

### Change description

- add func to pull services images during system init
- add func to remove services images during system cleanup
- general renaming refactoring


### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
