### PR TITLE
Add a missing lock and defer lock acquisition.

### DIFF
--- a/internal/update/arduino/arduino.go
+++ b/internal/update/arduino/arduino.go
@@ -177,6 +177,11 @@ func selectBestVersion(available []string, installed *semver.Version, constraint
 
 // UpgradePackages implements ServiceUpdater.
 func (a *ArduinoPlatformUpdater) UpgradePackages(ctx context.Context, packages []update.PackageInfo, eventCB update.EventCallback) error {
+	if !a.lock.TryLock() {
+		return update.ErrOperationAlreadyInProgress
+	}
+	defer a.lock.Unlock()
+
 	if len(packages) == 0 {
 		return nil
 	}
@@ -191,11 +196,6 @@ func (a *ArduinoPlatformUpdater) UpgradePackages(ctx context.Context, packages [
 	if targetVersion == "" {
 		return fmt.Errorf("target version is empty for package '%s'", pkg.Name)
 	}
-
-	if !a.lock.TryLock() {
-		return update.ErrOperationAlreadyInProgress
-	}
-	defer a.lock.Unlock()
 
 	downloadProgressCB := func(curr *rpc.DownloadProgress) {
 		data := helpers.ArduinoCLIDownloadProgressToString(curr)

--- a/internal/update/arduino/arduino.go
+++ b/internal/update/arduino/arduino.go
@@ -177,10 +177,6 @@ func selectBestVersion(available []string, installed *semver.Version, constraint
 
 // UpgradePackages implements ServiceUpdater.
 func (a *ArduinoPlatformUpdater) UpgradePackages(ctx context.Context, packages []update.PackageInfo, eventCB update.EventCallback) error {
-	if !a.lock.TryLock() {
-		return update.ErrOperationAlreadyInProgress
-	}
-
 	if len(packages) == 0 {
 		return nil
 	}
@@ -196,6 +192,11 @@ func (a *ArduinoPlatformUpdater) UpgradePackages(ctx context.Context, packages [
 		return fmt.Errorf("target version is empty for package '%s'", pkg.Name)
 	}
 
+	if !a.lock.TryLock() {
+		return update.ErrOperationAlreadyInProgress
+	}
+	defer a.lock.Unlock()
+
 	downloadProgressCB := func(curr *rpc.DownloadProgress) {
 		data := helpers.ArduinoCLIDownloadProgressToString(curr)
 		slog.Debug("Download progress", slog.String("download_progress", data))
@@ -206,8 +207,6 @@ func (a *ArduinoPlatformUpdater) UpgradePackages(ctx context.Context, packages [
 		slog.Debug("Task progress", slog.String("task_progress", data))
 		eventCB(update.NewDataEvent(update.UpgradeLineEvent, data))
 	}
-
-	defer a.lock.Unlock()
 
 	eventCB(update.NewDataEvent(update.StartEvent, "Upgrade is starting"))
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -119,9 +119,6 @@ func (m *Manager) ListUpgradablePackages(ctx context.Context, matcher func(Upgra
 }
 
 func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage) error {
-	if !m.lock.TryLock() {
-		return ErrOperationAlreadyInProgress
-	}
 	ctx = context.WithoutCancel(ctx)
 	var debPkgs []PackageInfo
 	var arduinoPlatform []PackageInfo
@@ -134,6 +131,10 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 		default:
 			return fmt.Errorf("unknown package type %s", v.Type)
 		}
+	}
+
+	if !m.lock.TryLock() {
+		return ErrOperationAlreadyInProgress
 	}
 
 	go func() {


### PR DESCRIPTION
### Motivation

The current implementation contains return statements between the lock acquisition and the defer call, causing the resource to remain locked.
This PR moves the lock acquisition to just before the critical section to prevent lock leaks.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
