### PR TITLE
Pass the information CONFIGURED_CARRIERS to the bricks container

### DIFF
--- a/internal/orchestrator/linuxConfig/carrier.go
+++ b/internal/orchestrator/linuxConfig/carrier.go
@@ -1,0 +1,27 @@
+// This file is part of arduino-app-cli.
+//
+// Copyright (C) Arduino s.r.l. and/or its affiliated companies
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package linuxconfig
+
+type Carrier struct {
+	CarrierName    string `json:"carrier_name"`
+	CurrentEnabled bool   `json:"current_enabled"`
+}
+
+type CarrierStatusOutput struct {
+	Carriers []Carrier `json:"carriers"`
+}

--- a/internal/orchestrator/linuxConfig/linuxConfig.go
+++ b/internal/orchestrator/linuxConfig/linuxConfig.go
@@ -28,8 +28,7 @@ import (
 
 const linuxConfigTool = "arduino-linux-config"
 
-func GetEnabledCarriers() ([]string, error) {
-
+func GetEnabledCarriers(ctx context.Context) ([]string, error) {
 	if _, err := exec.LookPath(linuxConfigTool); err != nil {
 		return nil, fmt.Errorf("arduino-linux-config tool not found in PATH: %w", err)
 	}
@@ -39,7 +38,7 @@ func GetEnabledCarriers() ([]string, error) {
 		return nil, fmt.Errorf("failed to create process 'arduino-linux-config carrier show': %w", err)
 	}
 
-	stdout, stderr, err := cmd.RunAndCaptureOutput(context.Background())
+	stdout, stderr, err := cmd.RunAndCaptureOutput(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute 'arduino-linux-config carrier show': %w\nstderr: %s", err, string(stderr))
 	}

--- a/internal/orchestrator/linuxConfig/linuxConfig.go
+++ b/internal/orchestrator/linuxConfig/linuxConfig.go
@@ -1,0 +1,53 @@
+// This file is part of arduino-app-cli.
+//
+// Copyright (C) Arduino s.r.l. and/or its affiliated companies
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package linuxconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+const linuxConfigTool = "arduino-linux-config"
+
+func CarrierShow() (*CarrierStatusOutput, error) {
+	if _, err := exec.LookPath(linuxConfigTool); err != nil {
+		return nil, fmt.Errorf("arduino-linux-config tool not found in PATH: %w", err)
+	}
+
+	cmd := exec.Command(linuxConfigTool, "carrier", "show", "--format", "json")
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute 'arduino-linux-config carrier show': %w\nstderr: %s", err, stderr.String())
+	}
+
+	// 3. parsing JSON
+	var result CarrierStatusOutput
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON from 'arduino-linux-config carrier show': %w\noutput: %s", err, out.String())
+	}
+
+	return &result, nil
+}

--- a/internal/orchestrator/linuxConfig/linuxConfig.go
+++ b/internal/orchestrator/linuxConfig/linuxConfig.go
@@ -18,36 +18,42 @@
 package linuxconfig
 
 import (
-	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
+
+	"github.com/arduino/go-paths-helper"
 )
 
 const linuxConfigTool = "arduino-linux-config"
 
-func CarrierShow() (*CarrierStatusOutput, error) {
+func GetEnabledCarriers() ([]string, error) {
+
 	if _, err := exec.LookPath(linuxConfigTool); err != nil {
 		return nil, fmt.Errorf("arduino-linux-config tool not found in PATH: %w", err)
 	}
 
-	cmd := exec.Command(linuxConfigTool, "carrier", "show", "--format", "json")
-
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
+	cmd, err := paths.NewProcess(nil, linuxConfigTool, "carrier", "show", "--format", "json")
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute 'arduino-linux-config carrier show': %w\nstderr: %s", err, stderr.String())
+		return nil, fmt.Errorf("failed to create process 'arduino-linux-config carrier show': %w", err)
 	}
 
-	// 3. parsing JSON
-	var result CarrierStatusOutput
-	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
-		return nil, fmt.Errorf("failed to parse JSON from 'arduino-linux-config carrier show': %w\noutput: %s", err, out.String())
+	stdout, stderr, err := cmd.RunAndCaptureOutput(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute 'arduino-linux-config carrier show': %w\nstderr: %s", err, string(stderr))
 	}
 
-	return &result, nil
+	var carriersStatus CarrierStatusOutput
+	if err := json.Unmarshal(stdout, &carriersStatus); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON from 'arduino-linux-config carrier show': %w\noutput: %s", err, string(stdout))
+	}
+
+	var enabled []string
+	for _, c := range carriersStatus.Carriers {
+		if c.CurrentEnabled {
+			enabled = append(enabled, c.CarrierName)
+		}
+	}
+	return enabled, nil
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -46,6 +46,7 @@ import (
 	appgenerator "github.com/arduino/arduino-app-cli/internal/orchestrator/app/generator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	linuxconfig "github.com/arduino/arduino-app-cli/internal/orchestrator/linuxConfig"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/peripherals"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
@@ -258,7 +259,7 @@ func getAppEnvironmentVariables(app app.ArduinoApp, brickIndex *bricksindex.Bric
 		envs["VIDEO_DEVICE"] = videoDevices[0]
 	}
 
-	mediaCarriers, err := peripherals.GetConfiguredCarriers()
+	mediaCarriers, err := linuxconfig.GetEnabledCarriers()
 	if err != nil {
 		slog.Warn("unable to get configured carriers", slog.String("error", err.Error()))
 	} else if len(mediaCarriers) > 0 {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -258,9 +258,13 @@ func getAppEnvironmentVariables(app app.ArduinoApp, brickIndex *bricksindex.Bric
 		envs["VIDEO_DEVICE"] = videoDevices[0]
 	}
 
-	if mediaCarriers := peripherals.GetMediaCarriers(); len(mediaCarriers) > 0 {
-		envs["CONNECTED_CARRIERS"] = strings.Join(mediaCarriers, ",")
+	mediaCarriers, err := peripherals.GetConfiguredCarriers()
+	if err != nil {
+		slog.Warn("unable to get configured carriers", slog.String("error", err.Error()))
+	} else if len(mediaCarriers) > 0 {
+		envs["CONFIGURED_CARRIERS"] = strings.Join(mediaCarriers, ",")
 	}
+
 	if hostIP, err := helpers.GetHostIP(); err == nil {
 		envs["HOST_IP"] = hostIP
 	} else {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -166,7 +166,7 @@ func StartApp(
 	}
 
 	if appToStart.MainPythonFile != nil {
-		envs := getAppEnvironmentVariables(appToStart, bricksIndex, modelsIndex)
+		envs := getAppEnvironmentVariables(ctx, appToStart, bricksIndex, modelsIndex)
 
 		cb(StreamMessage{data: "python provisioning"})
 		provisionStartProgress := float32(0.0)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -231,7 +231,7 @@ func StartApp(
 // - model configuration variables (variables defined in the model configuration)
 // - brick instance variables (variables defined in the app.yaml for the brick instance)
 // In addition, it adds some useful environment variables like APP_HOME and HOST_IP.
-func getAppEnvironmentVariables(app app.ArduinoApp, brickIndex *bricksindex.BricksIndex, modelsIndex *modelsindex.ModelsIndex) helpers.EnvVars {
+func getAppEnvironmentVariables(ctx context.Context, app app.ArduinoApp, brickIndex *bricksindex.BricksIndex, modelsIndex *modelsindex.ModelsIndex) helpers.EnvVars {
 	envs := make(helpers.EnvVars)
 
 	for _, brick := range app.Descriptor.Bricks {
@@ -259,7 +259,7 @@ func getAppEnvironmentVariables(app app.ArduinoApp, brickIndex *bricksindex.Bric
 		envs["VIDEO_DEVICE"] = videoDevices[0]
 	}
 
-	mediaCarriers, err := linuxconfig.GetEnabledCarriers()
+	mediaCarriers, err := linuxconfig.GetEnabledCarriers(ctx)
 	if err != nil {
 		slog.Warn("unable to get configured carriers", slog.String("error", err.Error()))
 	} else if len(mediaCarriers) > 0 {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -644,7 +644,7 @@ models:
 	modelIndex, err := modelsindex.Load(platform.GetPlatform(nil), cfg.AssetsDir(), nil)
 	require.NoError(t, err)
 
-	env := getAppEnvironmentVariables(appDesc, bricksIndex, modelIndex)
+	env := getAppEnvironmentVariables(t.Context(), appDesc, bricksIndex, modelIndex)
 	require.Equal(t, cfg.AppsDir().Join("app1").String(), env["APP_HOME"])
 	require.Equal(t, "/models/ootb/ei/yolo-x-nano.eim", env["EI_OBJ_DETECTION_MODEL"])
 	require.Equal(t, "/home/arduino/.arduino-bricks/models", env["CUSTOM_MODEL_PATH"])
@@ -725,7 +725,7 @@ models:
 	modelIndex, err := modelsindex.Load(platform.GetPlatform(nil), cfg.AssetsDir(), nil)
 	require.NoError(t, err)
 
-	env := getAppEnvironmentVariables(appDesc, bricksIndex, modelIndex)
+	env := getAppEnvironmentVariables(t.Context(), appDesc, bricksIndex, modelIndex)
 	require.Equal(t, cfg.AppsDir().Join("app1").String(), env["APP_HOME"])
 	require.Equal(t, "/home/arduino/.arduino-bricks/models/face-det.eim", env["EI_OBJ_DETECTION_MODEL"])
 	require.Equal(t, "/home/arduino/.arduino-bricks/models", env["CUSTOM_MODEL_PATH"])
@@ -808,7 +808,7 @@ models:
 	modelIndex, err := modelsindex.Load(platform.GetPlatform(nil), cfg.AssetsDir(), nil)
 	require.NoError(t, err)
 
-	env := getAppEnvironmentVariables(appDesc, bricksIndex, modelIndex)
+	env := getAppEnvironmentVariables(t.Context(), appDesc, bricksIndex, modelIndex)
 	require.Equal(t, "/models/path/obj.eim", env["EI_OBJ_DETECTION_MODEL"])
 	require.Equal(t, "/models/path/video.eim", env["EI_V_OBJ_DETECTION_MODEL"])
 	require.Equal(t, "/default/video/value", env["MY_VIDEO_ENV"])

--- a/internal/orchestrator/peripherals/devices.go
+++ b/internal/orchestrator/peripherals/devices.go
@@ -27,8 +27,6 @@ import (
 	"strings"
 
 	"github.com/arduino/go-paths-helper"
-
-	linuxconfig "github.com/arduino/arduino-app-cli/internal/orchestrator/linuxConfig"
 )
 
 type AvailableDevices struct {
@@ -189,25 +187,4 @@ func HasVirtualDevice(deviceClass DeviceClass, devices []string) bool {
 		}
 	}
 	return false
-}
-
-func GetConfiguredCarriers() ([]string, error) {
-	return getConfiguredCarriers(linuxconfig.CarrierShow)
-}
-
-type carrierShowFn func() (*linuxconfig.CarrierStatusOutput, error)
-
-func getConfiguredCarriers(carrierShow carrierShowFn) ([]string, error) {
-	carriersStatus, err := carrierShow()
-	if err != nil {
-		return nil, fmt.Errorf("unable to get configured carriers: %w", err)
-	}
-
-	var enabled []string
-	for _, c := range carriersStatus.Carriers {
-		if c.CurrentEnabled {
-			enabled = append(enabled, c.CarrierName)
-		}
-	}
-	return enabled, nil
 }

--- a/internal/orchestrator/peripherals/devices.go
+++ b/internal/orchestrator/peripherals/devices.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 
 	"github.com/arduino/go-paths-helper"
+
+	linuxconfig "github.com/arduino/arduino-app-cli/internal/orchestrator/linuxConfig"
 )
 
 type AvailableDevices struct {
@@ -189,8 +191,23 @@ func HasVirtualDevice(deviceClass DeviceClass, devices []string) bool {
 	return false
 }
 
-// TODO: call arduino-linux-config to detect connected and enabled media carriers.
-// For now returns empty slice — CONNECTED_CARRIERS will not be set in the environment.
-func GetMediaCarriers() []string {
-	return []string{}
+func GetConfiguredCarriers() ([]string, error) {
+	return getConfiguredCarriers(linuxconfig.CarrierShow)
+}
+
+type carrierShowFn func() (*linuxconfig.CarrierStatusOutput, error)
+
+func getConfiguredCarriers(carrierShow carrierShowFn) ([]string, error) {
+	carriersStatus, err := carrierShow()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get configured carriers: %w", err)
+	}
+
+	var enabled []string
+	for _, c := range carriersStatus.Carriers {
+		if c.CurrentEnabled {
+			enabled = append(enabled, c.CarrierName)
+		}
+	}
+	return enabled, nil
 }

--- a/internal/orchestrator/peripherals/devices_test.go
+++ b/internal/orchestrator/peripherals/devices_test.go
@@ -18,10 +18,13 @@
 package peripherals
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	linuxconfig "github.com/arduino/arduino-app-cli/internal/orchestrator/linuxConfig"
 )
 
 func TestSortV4LVideoDevices(t *testing.T) {
@@ -115,6 +118,65 @@ func TestContainsVirtualDevice(t *testing.T) {
 			got := HasVirtualDevice(tt.deviceClass, tt.devices)
 			if got != tt.want {
 				t.Errorf("HasVirtualDevice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetConfiguredCarriers(t *testing.T) {
+	tests := []struct {
+		name             string
+		mockOutput       *linuxconfig.CarrierStatusOutput
+		mockErr          error
+		expectedCarriers []string
+		wantErr          bool
+	}{
+		{
+			name: "enabled carriers are returned",
+			mockOutput: &linuxconfig.CarrierStatusOutput{
+				Carriers: []linuxconfig.Carrier{
+					{CarrierName: "carrier1", CurrentEnabled: true},
+					{CarrierName: "carrier2", CurrentEnabled: false},
+					{CarrierName: "carrier3", CurrentEnabled: true},
+				},
+			},
+			expectedCarriers: []string{"carrier1", "carrier3"},
+		},
+		{
+			name: "no enabled carriers returns nil",
+			mockOutput: &linuxconfig.CarrierStatusOutput{
+				Carriers: []linuxconfig.Carrier{
+					{CarrierName: "carrier1", CurrentEnabled: false},
+					{CarrierName: "carrier2", CurrentEnabled: false},
+				},
+			},
+			expectedCarriers: nil,
+		},
+		{
+			name:             "empty carrier list returns nil",
+			mockOutput:       &linuxconfig.CarrierStatusOutput{Carriers: []linuxconfig.Carrier{}},
+			expectedCarriers: nil,
+		},
+		{
+			name:    "error from CarrierShow is propagated",
+			mockErr: fmt.Errorf("tool not found"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := func() (*linuxconfig.CarrierStatusOutput, error) {
+				return tt.mockOutput, tt.mockErr
+			}
+
+			carriers, err := getConfiguredCarriers(mock)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedCarriers, carriers)
 			}
 		})
 	}

--- a/internal/orchestrator/peripherals/devices_test.go
+++ b/internal/orchestrator/peripherals/devices_test.go
@@ -18,13 +18,10 @@
 package peripherals
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	linuxconfig "github.com/arduino/arduino-app-cli/internal/orchestrator/linuxConfig"
 )
 
 func TestSortV4LVideoDevices(t *testing.T) {
@@ -118,65 +115,6 @@ func TestContainsVirtualDevice(t *testing.T) {
 			got := HasVirtualDevice(tt.deviceClass, tt.devices)
 			if got != tt.want {
 				t.Errorf("HasVirtualDevice() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestGetConfiguredCarriers(t *testing.T) {
-	tests := []struct {
-		name             string
-		mockOutput       *linuxconfig.CarrierStatusOutput
-		mockErr          error
-		expectedCarriers []string
-		wantErr          bool
-	}{
-		{
-			name: "enabled carriers are returned",
-			mockOutput: &linuxconfig.CarrierStatusOutput{
-				Carriers: []linuxconfig.Carrier{
-					{CarrierName: "carrier1", CurrentEnabled: true},
-					{CarrierName: "carrier2", CurrentEnabled: false},
-					{CarrierName: "carrier3", CurrentEnabled: true},
-				},
-			},
-			expectedCarriers: []string{"carrier1", "carrier3"},
-		},
-		{
-			name: "no enabled carriers returns nil",
-			mockOutput: &linuxconfig.CarrierStatusOutput{
-				Carriers: []linuxconfig.Carrier{
-					{CarrierName: "carrier1", CurrentEnabled: false},
-					{CarrierName: "carrier2", CurrentEnabled: false},
-				},
-			},
-			expectedCarriers: nil,
-		},
-		{
-			name:             "empty carrier list returns nil",
-			mockOutput:       &linuxconfig.CarrierStatusOutput{Carriers: []linuxconfig.Carrier{}},
-			expectedCarriers: nil,
-		},
-		{
-			name:    "error from CarrierShow is propagated",
-			mockErr: fmt.Errorf("tool not found"),
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mock := func() (*linuxconfig.CarrierStatusOutput, error) {
-				return tt.mockOutput, tt.mockErr
-			}
-
-			carriers, err := getConfiguredCarriers(mock)
-
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expectedCarriers, carriers)
 			}
 		})
 	}


### PR DESCRIPTION
### Motivation

The CONFIGURED_CARRIERS environment variable will pass the information to the containers/brick if any carrier (i.e. Media Carrier) has been configured by the user with the `arduino-linux-config` CLI.

Note: we do not really know if the carrier is connected, but the user has said it is.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
