### PR TITLE
fix: update reconnection flow

### DIFF
--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -50,9 +50,7 @@ func New() *Service {
 // It filters the packages using the provided matcher function.
 // It returns a slice of UpgradablePackage or an error if the command fails.
 func (s *Service) ListUpgradablePackages(ctx context.Context, matcher func(update.UpgradablePackage) bool) ([]update.UpgradablePackage, error) {
-	if !s.lock.TryLock() {
-		return nil, update.ErrOperationAlreadyInProgress
-	}
+	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	// Attempt to fix dpkg database in case an upgrade was interrupted in the middle.
@@ -76,10 +74,7 @@ func (s *Service) ListUpgradablePackages(ctx context.Context, matcher func(updat
 // It publishes events to subscribers during the upgrade process.
 // It returns an error if the upgrade is already in progress or if the upgrade command fails.
 func (s *Service) UpgradePackages(ctx context.Context, packages []update.PackageInfo, eventCB update.EventCallback) error {
-	if !s.lock.TryLock() {
-		return update.ErrOperationAlreadyInProgress
-	}
-
+	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	// At the end of the upgrade, always try to restart the services (that need it).

--- a/internal/update/arduino/arduino.go
+++ b/internal/update/arduino/arduino.go
@@ -50,9 +50,7 @@ func NewArduinoPlatformUpdater(platform platform.Platform, versionConstraint sem
 
 // ListUpgradablePackages implements ServiceUpdater.
 func (a *ArduinoPlatformUpdater) ListUpgradablePackages(ctx context.Context, _ func(update.UpgradablePackage) bool) ([]update.UpgradablePackage, error) {
-	if !a.lock.TryLock() {
-		return nil, update.ErrOperationAlreadyInProgress
-	}
+	a.lock.Lock()
 	defer a.lock.Unlock()
 
 	logrus.SetLevel(logrus.ErrorLevel) // Reduce the log level of arduino-cli
@@ -177,9 +175,7 @@ func selectBestVersion(available []string, installed *semver.Version, constraint
 
 // UpgradePackages implements ServiceUpdater.
 func (a *ArduinoPlatformUpdater) UpgradePackages(ctx context.Context, packages []update.PackageInfo, eventCB update.EventCallback) error {
-	if !a.lock.TryLock() {
-		return update.ErrOperationAlreadyInProgress
-	}
+	a.lock.Lock()
 	defer a.lock.Unlock()
 
 	if len(packages) == 0 {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -163,13 +163,6 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 // Subscribe creates a new channel for receiving APT events.
 func (b *Manager) Subscribe() chan Event {
 	eventCh := make(chan Event, 100)
-
-	// return a closed channel if there isn't an update in progress, to avoid subscribers to wait for events that will never come.
-	if !b.isUpgrading.Load() {
-		close(eventCh)
-		return eventCh
-	}
-
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.subs[eventCh] = struct{}{}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -57,7 +58,7 @@ type ServiceUpdater interface {
 }
 
 type Manager struct {
-	lock                         sync.Mutex
+	isUpgrading                  atomic.Bool
 	debUpdateService             ServiceUpdater
 	arduinoPlatformUpdateService ServiceUpdater
 
@@ -74,10 +75,9 @@ func NewManager(debUpdateService ServiceUpdater, arduinoPlatformUpdateService Se
 }
 
 func (m *Manager) ListUpgradablePackages(ctx context.Context, matcher func(UpgradablePackage) bool) ([]UpgradablePackage, error) {
-	if !m.lock.TryLock() {
+	if m.isUpgrading.Load() {
 		return nil, ErrOperationAlreadyInProgress
 	}
-	defer m.lock.Unlock()
 
 	// Make sure to be connected to the internet, before checking for updates.
 	// This is needed because the checks below work also when offline (using cached data).
@@ -133,12 +133,11 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 		}
 	}
 
-	if !m.lock.TryLock() {
+	if !m.isUpgrading.CompareAndSwap(false, true) {
 		return ErrOperationAlreadyInProgress
 	}
-
 	go func() {
-		defer m.lock.Unlock()
+		defer m.isUpgrading.Store(false)
 
 		// We are launching on purpose the update sequentially. The reason is that
 		// the deb pkgs restart the orchestrator, and if we run in parallel the
@@ -164,6 +163,13 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 // Subscribe creates a new channel for receiving APT events.
 func (b *Manager) Subscribe() chan Event {
 	eventCh := make(chan Event, 100)
+
+	// return a closed channel if there isn't an update in progress, to avoid subscribers to wait for events that will never come.
+	if !b.isUpgrading.Load() {
+		close(eventCh)
+		return eventCh
+	}
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.subs[eventCh] = struct{}{}


### PR DESCRIPTION
### Motivation

The system update has a set of inconsistencies that make the reconnection to an ongoing update buggy.

First of all, the `update/check` operation shouldn't lock the upgrade operation; multiple parties could call the check without getting an `OPERATION_IN_PROGRESS`. Indeed, this error means that an `update/apply` is in progress not a check. The upgrade operation is the real locking operation that should return an error in case another upgrade operation is in progress.

~Second, the `system/events` stream should immediately return if there isn't any upgrade operation in progress, which will prevent having a stale SSE event that never returns.~

### Change description

1. Remove the global lock and use instead an atomic, which allows to check the status of the upgrade without changing it
2. Make only the manager returning the `OPERATION_IN_PROGRESS` the two update services, only use a global lock.
~3. Substribe method returns a closed channel if no events will ever arrive~

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
