### PR TITLE
fix: update reconnection flow (mutex)

### DIFF
--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -50,9 +50,7 @@ func New() *Service {
 // It filters the packages using the provided matcher function.
 // It returns a slice of UpgradablePackage or an error if the command fails.
 func (s *Service) ListUpgradablePackages(ctx context.Context, matcher func(update.UpgradablePackage) bool) ([]update.UpgradablePackage, error) {
-	if !s.lock.TryLock() {
-		return nil, update.ErrOperationAlreadyInProgress
-	}
+	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	// Attempt to fix dpkg database in case an upgrade was interrupted in the middle.
@@ -76,10 +74,7 @@ func (s *Service) ListUpgradablePackages(ctx context.Context, matcher func(updat
 // It publishes events to subscribers during the upgrade process.
 // It returns an error if the upgrade is already in progress or if the upgrade command fails.
 func (s *Service) UpgradePackages(ctx context.Context, packages []update.PackageInfo, eventCB update.EventCallback) error {
-	if !s.lock.TryLock() {
-		return update.ErrOperationAlreadyInProgress
-	}
-
+	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	// At the end of the upgrade, always try to restart the services (that need it).

--- a/internal/update/arduino/arduino.go
+++ b/internal/update/arduino/arduino.go
@@ -50,9 +50,7 @@ func NewArduinoPlatformUpdater(platform platform.Platform, versionConstraint sem
 
 // ListUpgradablePackages implements ServiceUpdater.
 func (a *ArduinoPlatformUpdater) ListUpgradablePackages(ctx context.Context, _ func(update.UpgradablePackage) bool) ([]update.UpgradablePackage, error) {
-	if !a.lock.TryLock() {
-		return nil, update.ErrOperationAlreadyInProgress
-	}
+	a.lock.Lock()
 	defer a.lock.Unlock()
 
 	logrus.SetLevel(logrus.ErrorLevel) // Reduce the log level of arduino-cli
@@ -177,9 +175,7 @@ func selectBestVersion(available []string, installed *semver.Version, constraint
 
 // UpgradePackages implements ServiceUpdater.
 func (a *ArduinoPlatformUpdater) UpgradePackages(ctx context.Context, packages []update.PackageInfo, eventCB update.EventCallback) error {
-	if !a.lock.TryLock() {
-		return update.ErrOperationAlreadyInProgress
-	}
+	a.lock.Lock()
 	defer a.lock.Unlock()
 
 	if len(packages) == 0 {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -58,7 +57,8 @@ type ServiceUpdater interface {
 }
 
 type Manager struct {
-	isUpgrading                  atomic.Bool
+	isUgradingMutex              sync.RWMutex
+	isUpgrading                  bool
 	debUpdateService             ServiceUpdater
 	arduinoPlatformUpdateService ServiceUpdater
 
@@ -75,9 +75,12 @@ func NewManager(debUpdateService ServiceUpdater, arduinoPlatformUpdateService Se
 }
 
 func (m *Manager) ListUpgradablePackages(ctx context.Context, matcher func(UpgradablePackage) bool) ([]UpgradablePackage, error) {
-	if m.isUpgrading.Load() {
+	m.isUgradingMutex.RLock()
+	if m.isUpgrading {
+		defer m.isUgradingMutex.RUnlock()
 		return nil, ErrOperationAlreadyInProgress
 	}
+	m.isUgradingMutex.RUnlock()
 
 	// Make sure to be connected to the internet, before checking for updates.
 	// This is needed because the checks below work also when offline (using cached data).
@@ -133,12 +136,19 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 		}
 	}
 
-	if !m.isUpgrading.CompareAndSwap(false, true) {
+	m.isUgradingMutex.Lock()
+	defer m.isUgradingMutex.Unlock()
+	if m.isUpgrading {
 		return ErrOperationAlreadyInProgress
 	}
-	go func() {
-		defer m.isUpgrading.Store(false)
+	m.isUpgrading = true
 
+	go func() {
+		defer func() {
+			m.isUgradingMutex.Lock()
+			defer m.isUgradingMutex.Unlock()
+			m.isUpgrading = false
+		}()
 		// We are launching on purpose the update sequentially. The reason is that
 		// the deb pkgs restart the orchestrator, and if we run in parallel the
 		// update of the cores we will end up with inconsistent state, or
@@ -165,10 +175,13 @@ func (b *Manager) Subscribe() chan Event {
 	eventCh := make(chan Event, 100)
 
 	// return a closed channel if there isn't an update in progress, to avoid subscribers to wait for events that will never come.
-	if !b.isUpgrading.Load() {
+	b.isUgradingMutex.RLock()
+	if !b.isUpgrading {
+		defer b.isUgradingMutex.RUnlock()
 		close(eventCh)
 		return eventCh
 	}
+	b.isUgradingMutex.RUnlock()
 
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -173,16 +173,6 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 // Subscribe creates a new channel for receiving APT events.
 func (b *Manager) Subscribe() chan Event {
 	eventCh := make(chan Event, 100)
-
-	// return a closed channel if there isn't an update in progress, to avoid subscribers to wait for events that will never come.
-	b.isUgradingMutex.RLock()
-	if !b.isUpgrading {
-		defer b.isUgradingMutex.RUnlock()
-		close(eventCh)
-		return eventCh
-	}
-	b.isUgradingMutex.RUnlock()
-
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.subs[eventCh] = struct{}{}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -57,8 +58,8 @@ type ServiceUpdater interface {
 }
 
 type Manager struct {
-	isUgradingMutex              sync.RWMutex
-	isUpgrading                  bool
+	lock                         sync.Mutex
+	isUpgrading                  atomic.Bool
 	debUpdateService             ServiceUpdater
 	arduinoPlatformUpdateService ServiceUpdater
 
@@ -75,12 +76,9 @@ func NewManager(debUpdateService ServiceUpdater, arduinoPlatformUpdateService Se
 }
 
 func (m *Manager) ListUpgradablePackages(ctx context.Context, matcher func(UpgradablePackage) bool) ([]UpgradablePackage, error) {
-	m.isUgradingMutex.RLock()
-	if m.isUpgrading {
-		defer m.isUgradingMutex.RUnlock()
+	if m.isUpgrading.Load() {
 		return nil, ErrOperationAlreadyInProgress
 	}
-	m.isUgradingMutex.RUnlock()
 
 	// Make sure to be connected to the internet, before checking for updates.
 	// This is needed because the checks below work also when offline (using cached data).
@@ -136,19 +134,14 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 		}
 	}
 
-	m.isUgradingMutex.Lock()
-	defer m.isUgradingMutex.Unlock()
-	if m.isUpgrading {
+	if !m.lock.TryLock() {
 		return ErrOperationAlreadyInProgress
 	}
-	m.isUpgrading = true
-
+	m.isUpgrading.Store(true)
 	go func() {
-		defer func() {
-			m.isUgradingMutex.Lock()
-			defer m.isUgradingMutex.Unlock()
-			m.isUpgrading = false
-		}()
+		defer m.lock.Unlock()
+		defer m.isUpgrading.Store(false)
+
 		// We are launching on purpose the update sequentially. The reason is that
 		// the deb pkgs restart the orchestrator, and if we run in parallel the
 		// update of the cores we will end up with inconsistent state, or

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -76,6 +76,7 @@ func NewManager(debUpdateService ServiceUpdater, arduinoPlatformUpdateService Se
 }
 
 func (m *Manager) ListUpgradablePackages(ctx context.Context, matcher func(UpgradablePackage) bool) ([]UpgradablePackage, error) {
+	// Atomically check if an upgrade operation is already in progress. See https://github.com/arduino/arduino-app-cli/issues/381.
 	if m.isUpgrading.Load() {
 		return nil, ErrOperationAlreadyInProgress
 	}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -57,7 +58,7 @@ type ServiceUpdater interface {
 }
 
 type Manager struct {
-	lock                         sync.Mutex
+	isUpgrading                  atomic.Bool
 	debUpdateService             ServiceUpdater
 	arduinoPlatformUpdateService ServiceUpdater
 
@@ -74,10 +75,9 @@ func NewManager(debUpdateService ServiceUpdater, arduinoPlatformUpdateService Se
 }
 
 func (m *Manager) ListUpgradablePackages(ctx context.Context, matcher func(UpgradablePackage) bool) ([]UpgradablePackage, error) {
-	if !m.lock.TryLock() {
+	if m.isUpgrading.Load() {
 		return nil, ErrOperationAlreadyInProgress
 	}
-	defer m.lock.Unlock()
 
 	// Make sure to be connected to the internet, before checking for updates.
 	// This is needed because the checks below work also when offline (using cached data).
@@ -133,12 +133,11 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 		}
 	}
 
-	if !m.lock.TryLock() {
+	if !m.isUpgrading.CompareAndSwap(false, true) {
 		return ErrOperationAlreadyInProgress
 	}
-
 	go func() {
-		defer m.lock.Unlock()
+		defer m.isUpgrading.Store(false)
 
 		// We are launching on purpose the update sequentially. The reason is that
 		// the deb pkgs restart the orchestrator, and if we run in parallel the
@@ -164,6 +163,13 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 // Subscribe creates a new channel for receiving APT events.
 func (b *Manager) Subscribe() chan Event {
 	eventCh := make(chan Event, 100)
+
+	// return a closed channel if there isn't an update in progress, to avoid subscribers to wait for events that will never come.
+	if !b.isUpgrading.Load() {
+		close(eventCh)
+		return eventCh
+	}
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.subs[eventCh] = struct{}{}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,3 +1,20 @@
+// This file is part of arduino-app-cli.
+//
+// Copyright (C) Arduino s.r.l. and/or its affiliated companies
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package update
 
 import (

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,319 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockServiceUpdater struct {
+	checkFn func(ctx context.Context, matcher func(UpgradablePackage) bool) ([]UpgradablePackage, error)
+	applyFn func(ctx context.Context, packages []PackageInfo, eventCB EventCallback) error
+}
+
+func (m *mockServiceUpdater) ListUpgradablePackages(ctx context.Context, matcher func(UpgradablePackage) bool) ([]UpgradablePackage, error) {
+	if m.checkFn != nil {
+		return m.checkFn(ctx, matcher)
+	}
+	return nil, nil
+}
+
+func (m *mockServiceUpdater) UpgradePackages(ctx context.Context, pkgs []PackageInfo, cb EventCallback) error {
+	if m.applyFn != nil {
+		return m.applyFn(ctx, pkgs, cb)
+	}
+	return nil
+}
+
+func newTestManager(deb, arduino ServiceUpdater) *Manager {
+	return &Manager{
+		debUpdateService:             deb,
+		arduinoPlatformUpdateService: arduino,
+		subs:                         make(map[chan Event]struct{}),
+	}
+}
+
+func TestManagerListUpgradablePackages(t *testing.T) {
+	tests := []struct {
+		name           string
+		svc1Packages   []UpgradablePackage
+		svc1Err        error
+		svc2Packages   []UpgradablePackage
+		svc2Err        error
+		expectErr      bool
+		expectPackages int
+	}{
+		{
+			name:           "both services return packages",
+			svc1Packages:   []UpgradablePackage{{Name: "pkg1", FromVersion: "1.0", ToVersion: "2.0"}},
+			svc2Packages:   []UpgradablePackage{{Name: "pkg2", FromVersion: "0.1", ToVersion: "0.2"}},
+			expectPackages: 2,
+		},
+		{
+			name:           "only deb service returns packages",
+			svc1Packages:   []UpgradablePackage{{Name: "pkg1", FromVersion: "1.0", ToVersion: "2.0"}},
+			svc2Packages:   nil,
+			expectPackages: 1,
+		},
+		{
+			name:           "only arduino service returns packages",
+			svc1Packages:   nil,
+			svc2Packages:   []UpgradablePackage{{Name: "pkg2", FromVersion: "0.1", ToVersion: "0.2"}},
+			expectPackages: 1,
+		},
+		{
+			name:           "both services return no packages",
+			svc1Packages:   nil,
+			svc2Packages:   nil,
+			expectPackages: 0,
+		},
+		{
+			name:      "deb service fails",
+			svc1Err:   errors.New("network error"),
+			expectErr: true,
+		},
+		{
+			name:      "arduino service fails",
+			svc2Err:   errors.New("network error"),
+			expectErr: true,
+		},
+		{
+			name:      "both services fail",
+			svc1Err:   errors.New("error 1"),
+			svc2Err:   errors.New("error 2"),
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc1 := &mockServiceUpdater{
+				checkFn: func(ctx context.Context, matcher func(UpgradablePackage) bool) ([]UpgradablePackage, error) {
+					return tc.svc1Packages, tc.svc1Err
+				},
+			}
+			svc2 := &mockServiceUpdater{
+				checkFn: func(ctx context.Context, matcher func(UpgradablePackage) bool) ([]UpgradablePackage, error) {
+					return tc.svc2Packages, tc.svc2Err
+				},
+			}
+			m := newTestManager(svc1, svc2)
+
+			results, err := m.ListUpgradablePackages(context.Background(), nil)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, results, tc.expectPackages)
+		})
+	}
+}
+
+func TestManagerListUpgradablePackagesMultipleConcurrentChecks(t *testing.T) {
+	var svc1Calls, svc2Calls atomic.Int32
+	svc1 := &mockServiceUpdater{
+		checkFn: func(ctx context.Context, matcher func(UpgradablePackage) bool) ([]UpgradablePackage, error) {
+			svc1Calls.Add(1)
+			time.Sleep(50 * time.Millisecond)
+			return []UpgradablePackage{{Name: "pkg1"}}, nil
+		},
+	}
+	svc2 := &mockServiceUpdater{
+		checkFn: func(ctx context.Context, matcher func(UpgradablePackage) bool) ([]UpgradablePackage, error) {
+			svc2Calls.Add(1)
+			time.Sleep(50 * time.Millisecond)
+			return []UpgradablePackage{{Name: "pkg2"}}, nil
+		},
+	}
+	m := newTestManager(svc1, svc2)
+
+	const n = 5
+	var wg sync.WaitGroup
+	wg.Add(n)
+	errs := make([]error, n)
+	for i := range n {
+		go func(idx int) {
+			defer wg.Done()
+			_, errs[idx] = m.ListUpgradablePackages(context.Background(), nil)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoErrorf(t, err, "goroutine %d returned unexpected error", i)
+	}
+	assert.Equal(t, int32(n), svc1Calls.Load(), "svc1 call count mismatch")
+	assert.Equal(t, int32(n), svc2Calls.Load(), "svc2 call count mismatch")
+
+	// Now start an upgrade and verify check returns ErrOperationAlreadyInProgress
+	started := make(chan struct{})
+	svc1.applyFn = func(ctx context.Context, pkgs []PackageInfo, cb EventCallback) error {
+		return nil
+	}
+	svc2.applyFn = func(ctx context.Context, pkgs []PackageInfo, cb EventCallback) error {
+		close(started)
+		time.Sleep(200 * time.Millisecond)
+		return nil
+	}
+
+	err := m.UpgradePackages(context.Background(), []UpgradablePackage{{Type: Debian, Name: "pkg1", ToVersion: "2.0"}})
+	require.NoError(t, err, "unexpected error starting upgrade")
+	<-started
+
+	_, err = m.ListUpgradablePackages(context.Background(), nil)
+	require.ErrorIs(t, err, ErrOperationAlreadyInProgress, "expected ErrOperationAlreadyInProgress during upgrade")
+
+	// Wait for upgrade goroutine to finish
+	time.Sleep(300 * time.Millisecond)
+
+	// After upgrade completes, check should work again
+	_, err = m.ListUpgradablePackages(context.Background(), nil)
+	require.NoError(t, err, "unexpected error after upgrade completed")
+}
+
+func TestManagerUpgradePackages(t *testing.T) {
+	tests := []struct {
+		name       string
+		packages   []UpgradablePackage
+		svc1Err    error
+		svc2Err    error
+		expectEvts []EventType // expected last event type from broadcast
+	}{
+		{
+			name:       "both services upgrade successfully",
+			packages:   []UpgradablePackage{{Type: Arduino, Name: "arduino:zephyr", ToVersion: "2.0"}, {Type: Debian, Name: "pkg1", ToVersion: "1.1"}},
+			expectEvts: []EventType{DoneEvent},
+		},
+		{
+			name:       "arduino service fails, deb succeeds",
+			packages:   []UpgradablePackage{{Type: Arduino, Name: "arduino:zephyr", ToVersion: "2.0"}, {Type: Debian, Name: "pkg1", ToVersion: "1.1"}},
+			svc1Err:    errors.New("arduino upgrade failed"),
+			expectEvts: []EventType{ErrorEvent, DoneEvent}, // should continue to deb upgrade and complete
+		},
+		{
+			name:     "deb service fails",
+			packages: []UpgradablePackage{{Type: Debian, Name: "pkg1", ToVersion: "1.1"}},
+			svc2Err:  errors.New("deb upgrade failed"),
+			// FIXME: we should alwas return Done?
+			expectEvts: []EventType{ErrorEvent},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc1 := &mockServiceUpdater{
+				applyFn: func(ctx context.Context, pkgs []PackageInfo, cb EventCallback) error {
+					return tc.svc1Err
+				},
+			}
+			svc2 := &mockServiceUpdater{
+				applyFn: func(ctx context.Context, pkgs []PackageInfo, cb EventCallback) error {
+					return tc.svc2Err
+				},
+			}
+			m := newTestManager(svc2, svc1) // deb first, arduino second
+
+			ch := m.Subscribe()
+			defer m.Unsubscribe(ch)
+
+			err := m.UpgradePackages(context.Background(), tc.packages)
+			require.NoError(t, err, "unexpected error starting upgrade")
+
+			// Collect the last event
+			timeout := time.After(1 * time.Second)
+			var events []EventType
+		loop:
+			for {
+				select {
+				case ev := <-ch:
+					events = append(events, ev.Type)
+					if ev.Type == DoneEvent {
+						break loop
+					}
+				case <-timeout:
+					break loop
+				}
+			}
+
+			assert.Equal(t, tc.expectEvts, events, "unexpected event sequence")
+		})
+	}
+}
+
+func TestManagerUpgradePackagesConcurrentUpgradeReturnsError(t *testing.T) {
+	started := make(chan struct{})
+	svc1 := &mockServiceUpdater{
+		applyFn: func(ctx context.Context, pkgs []PackageInfo, cb EventCallback) error {
+			close(started)
+			time.Sleep(200 * time.Millisecond)
+			return nil
+		},
+	}
+	svc2 := &mockServiceUpdater{
+		applyFn: func(ctx context.Context, pkgs []PackageInfo, cb EventCallback) error {
+			return nil
+		},
+	}
+	m := newTestManager(svc1, svc2)
+
+	pkgs := []UpgradablePackage{{Type: Debian, Name: "pkg1", ToVersion: "2.0"}}
+
+	err := m.UpgradePackages(context.Background(), pkgs)
+	assert.NoError(t, err, "first upgrade should start without error")
+	<-started
+
+	// Second upgrade should fail
+	err = m.UpgradePackages(context.Background(), pkgs)
+	assert.ErrorIs(t, err, ErrOperationAlreadyInProgress, "expected ErrOperationAlreadyInProgress for concurrent upgrade")
+}
+
+func TestManagerSubscribeReceivesUpgradeEvents(t *testing.T) {
+	svc1 := &mockServiceUpdater{
+		applyFn: func(ctx context.Context, pkgs []PackageInfo, cb EventCallback) error {
+			cb(NewDataEvent(StartEvent, "starting arduino"))
+			cb(NewDataEvent(UpgradeLineEvent, "upgrading arduino"))
+			return nil
+		},
+	}
+	svc2 := &mockServiceUpdater{
+		applyFn: func(ctx context.Context, pkgs []PackageInfo, cb EventCallback) error {
+			cb(NewDataEvent(StartEvent, "starting deb"))
+			cb(NewDataEvent(UpgradeLineEvent, "upgrading deb"))
+			return nil
+		},
+	}
+	m := newTestManager(svc2, svc1) // deb, arduino
+
+	ch := m.Subscribe()
+	defer m.Unsubscribe(ch)
+
+	pkgs := []UpgradablePackage{
+		{Type: Arduino, Name: "arduino:zephyr", ToVersion: "2.0"},
+		{Type: Debian, Name: "pkg1", ToVersion: "1.1"},
+	}
+	err := m.UpgradePackages(context.Background(), pkgs)
+	assert.NoError(t, err, "unexpected error starting upgrade")
+
+	var events []Event
+	timeout := time.After(2 * time.Second)
+	// 2 from arduino + 2 from deb + 1 DoneEvent = 5
+	for range 5 {
+		select {
+		case ev := <-ch:
+			events = append(events, ev)
+		case <-timeout:
+			t.Fatalf("timeout waiting for events, got %d: %v", len(events), events)
+		}
+	}
+
+	assert.Len(t, events, 5, "expected 5 events")
+	assert.Equal(t, StartEvent, events[0].Type, "expected first event to be StartEvent")
+	assert.Equal(t, DoneEvent, events[len(events)-1].Type, "expected first event to be StartEvent")
+}


### PR DESCRIPTION
### Motivation

The system update has a set of inconsistencies that make the reconnection to an ongoing update buggy.

First of all, the `update/check` operation shouldn't lock the upgrade operation; multiple parties could call the check without getting an `OPERATION_IN_PROGRESS`. Indeed, this error means that an `update/apply` is in progress not a check. The upgrade operation is the real locking operation that should return an error in case another upgrade operation is in progress.

~Second, the `system/events` stream should immediately return if there isn't any upgrade operation in progress, which will prevent having a stale SSE event that never returns.~

### Change description

1. Remove the global lock and use instead an atomic, which allows to check the status of the upgrade without changing it
2. Make only the manager returning the `OPERATION_IN_PROGRESS` the two update services, only use a global lock.
~3. Substribe method returns a closed channel if no events will ever arrive~

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.

