### PR TITLE
Consider not-an-app a folder without an app.yaml.

### DIFF
--- a/internal/orchestrator/app/find.go
+++ b/internal/orchestrator/app/find.go
@@ -35,7 +35,7 @@ func FindAppsInFolder(pathToExplore *paths.Path) (paths.PathList, error) {
 		paths.FilterDirectories(),
 		paths.FilterOutNames("python", "sketch", ".cache"),
 		paths.NotFilter(IsTmpAppDir),
-		// TODO: DirHasAppDescriptor ?
+		DirHasAppDescriptor,
 	)
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -384,6 +384,25 @@ func TestListApp(t *testing.T) {
 			assert.NotContains(t, b.Name, tmpAppName, "the temporary app should not be in the broken apps list")
 		}
 	})
+
+	t.Run("test nested apps do not produce bogus broken apps in parent dirs", func(t *testing.T) {
+		// https://github.com/arduino/arduino-app-cli/issues/220
+
+		createApp(t, "inside", false, idProvider, cfg)
+		outsideAppDir := cfg.AppsDir().Join("inside")
+		t.Cleanup(func() { _ = outsideAppDir.RemoveAll() })
+
+		nestedAppDir := cfg.AppsDir().Join("nested")
+		require.NoError(t, cfg.AppsDir().Join("nested").Mkdir())
+		t.Cleanup(func() { _ = nestedAppDir.RemoveAll() })
+		require.NoError(t, outsideAppDir.Rename(nestedAppDir.Join("inside")))
+
+		res, err := ListApps(t.Context(), dockerCli, ListAppRequest{
+			ShowApps: true,
+		}, idProvider, cfg)
+		require.NoError(t, err)
+		require.Empty(t, res.BrokenApps)
+	})
 }
 
 func setTestOrchestratorConfig(t *testing.T) config.Configuration {


### PR DESCRIPTION
### Motivation

Reduces the noise in the AppList command.
See https://github.com/arduino/arduino-app-cli/issues/220 for details.

### Change description

Just considers that a folder without an app.yaml is not an app.

### Additional Notes

Fix https://github.com/arduino/arduino-app-cli/issues/220.

### Reviewer checklist

- [X] PR addresses a single concern.
- [X] PR title and description are properly filled.
- [X] Changes will be merged in `main`.
- [X] Changes are covered by tests.
- [X] Logging is meaningful in case of troubleshooting.
