### PR TITLE
feat: install the meta debian package for the board

### DIFF
--- a/debian/arduino-app-cli/etc/sudoers.d/90-arduino-sysupgrade
+++ b/debian/arduino-app-cli/etc/sudoers.d/90-arduino-sysupgrade
@@ -1,1 +1,1 @@
-%sysupgrade ALL=(ALL) NOPASSWD: /usr/bin/apt-get update, /usr/sbin/needrestart -r a, /usr/bin/dpkg --configure -a, /usr/bin/apt-get install --only-upgrade -y *, /usr/bin/apt-get clean -y, /usr/bin/hostnamectl set-hostname *
+%sysupgrade ALL=(ALL) NOPASSWD: /usr/bin/apt-get update, /usr/sbin/needrestart -r a, /usr/bin/dpkg --configure -a, /usr/bin/apt-get install --only-upgrade -y *, /usr/bin/apt-get install -y *, /usr/bin/apt-get clean -y, /usr/bin/hostnamectl set-hostname *

--- a/debian/arduino-app-cli/etc/sudoers.d/90-arduino-sysupgrade
+++ b/debian/arduino-app-cli/etc/sudoers.d/90-arduino-sysupgrade
@@ -1,1 +1,1 @@
-%sysupgrade ALL=(ALL) NOPASSWD: /usr/bin/apt-get update, /usr/sbin/needrestart -r a, /usr/bin/dpkg --configure -a, /usr/bin/apt-get install --only-upgrade -y *, /usr/bin/apt-get install -y *, /usr/bin/apt-get clean -y, /usr/bin/hostnamectl set-hostname *
+%sysupgrade ALL=(ALL) NOPASSWD: /usr/bin/apt-get update, /usr/sbin/needrestart -r a, /usr/bin/dpkg --configure -a, /usr/bin/apt-get install --only-upgrade -y *, /usr/bin/apt-get install -y arduino-unoq, /usr/bin/apt-get install -y arduino-ventunoq, /usr/bin/apt-get clean -y, /usr/bin/hostnamectl set-hostname *

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -132,7 +132,7 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 }
 
 func downloadSupportedImages(ctx context.Context, cfg config.Configuration, brickindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, docker *command.DockerCli, stdout io.Writer) error {
-	fmt.Fprintf(stdout, "Pulling the latest docker images ...") //
+	fmt.Fprintf(stdout, "Pulling the latest docker images ...")
 	imagesToPreinstall := []string{cfg.PythonImage}
 	brickImages, err := getAllSupportedBrickImages(brickindex, servicesindex)
 	if err != nil {

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -115,7 +115,7 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 	}
 
 	if downloadPlatformAndLibs {
-		fmt.Fprintf(stdout, "Downloading libs and platforms used in examples ...")
+		fmt.Fprintf(stdout, "Downloading libs and platforms used in examples ...\n")
 		if err := downloadLibsAndPlatformsUsedInExamples(ctx, cfg, platform, progressCB); err != nil {
 			return fmt.Errorf("failed to download libs and platforms used in examples: %w", err)
 		}
@@ -132,7 +132,7 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 }
 
 func downloadSupportedImages(ctx context.Context, cfg config.Configuration, brickindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, docker *command.DockerCli, stdout io.Writer) error {
-	fmt.Fprintf(stdout, "Pulling the latest docker images ...")
+	fmt.Fprintf(stdout, "Pulling the latest docker images ...\n")
 	imagesToPreinstall := []string{cfg.PythonImage}
 	brickImages, err := getAllSupportedBrickImages(brickindex, servicesindex)
 	if err != nil {

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -110,6 +110,10 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 		downloadDockerImages = true
 	}
 
+	if err := installPlatformPackage(ctx, plat); err != nil {
+		slog.Error("failed to install platform package", "error", err)
+	}
+
 	if downloadPlatformAndLibs {
 		if err := downloadLibsAndPlatformsUsedInExamples(ctx, cfg, platform, progressCB); err != nil {
 			return fmt.Errorf("failed to download libs and platforms used in examples: %w", err)
@@ -473,6 +477,40 @@ func removeDanglingNetworks(ctx context.Context, docker dockerClient.APIClient) 
 	}
 
 	return counter, nil
+}
+
+func installPlatformPackage(ctx context.Context, plat platform.Platform) error {
+	var packageName string
+
+	switch plat.BoardName {
+	case "unoq":
+		packageName = "arduino-unoq"
+	case "ventunoq":
+		packageName = "arduino-ventunoq"
+	default:
+		slog.Debug("no platform-specific package to install", "board_name", plat.BoardName)
+		return nil
+	}
+
+	slog.Info("Installing package", "package_name", packageName)
+	cmd, err := paths.NewProcess(nil, "sudo", "apt-get", "install", "-y", packageName)
+	if err != nil {
+		return err
+	}
+	// stdout := orchestrator.NewCallbackWriter(func(line string) {
+	// 	if !yield(line, nil) {
+	// 		if err := cmd.Kill(); err != nil {
+	// 			slog.Error("Failed to kill apt clean command", slog.String("error", err.Error()))
+	// 		}
+	// 	}
+	// })
+	// cmd.RedirectStderrTo(stdout)
+	// cmd.RedirectStdoutTo(stdout)
+
+	if err := cmd.RunWithinContext(ctx); err != nil {
+		return err
+	}
+	return nil
 }
 
 func downloadLibsAndPlatformsUsedInExamples(ctx context.Context, cfg config.Configuration, platform platform.Platform, progressCB initProgressCallback) error {

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -110,7 +110,7 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 		downloadDockerImages = true
 	}
 
-	if err := installPlatformPackage(ctx, platform); err != nil {
+	if err := installPlatformPackage(ctx, platform, stdout); err != nil {
 		slog.Error("failed to install platform package", "error", err)
 	}
 
@@ -418,7 +418,7 @@ func removeImage(ctx context.Context, docker dockerClient.APIClient, imageName s
 	return size, nil
 }
 
-// imgages required by the system
+// images required by the system
 func getRequiredImages(cfg config.Configuration, bricksindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex) ([]string, error) {
 	bricksContainers, err := getAllSupportedBrickImages(bricksindex, servicesindex)
 	if err != nil {
@@ -479,7 +479,7 @@ func removeDanglingNetworks(ctx context.Context, docker dockerClient.APIClient) 
 	return counter, nil
 }
 
-func installPlatformPackage(ctx context.Context, plat platform.Platform) error {
+func installPlatformPackage(ctx context.Context, plat platform.Platform, stdout io.Writer) error {
 	var packageName string
 
 	switch plat.BoardName {
@@ -488,24 +488,18 @@ func installPlatformPackage(ctx context.Context, plat platform.Platform) error {
 	case "ventunoq":
 		packageName = "arduino-ventunoq"
 	default:
-		slog.Debug("no platform-specific package to install", "board_name", plat.BoardName)
+		fmt.Fprintf(stdout, "no platform-specific debian package to install for board '%s'\n", plat.BoardName)
 		return nil
 	}
 
-	slog.Info("Installing package", "package_name", packageName)
+	fmt.Fprintf(stdout, "Installing package '%s'\n", packageName)
+
 	cmd, err := paths.NewProcess(nil, "sudo", "apt-get", "install", "-y", packageName)
 	if err != nil {
 		return err
 	}
-	// stdout := orchestrator.NewCallbackWriter(func(line string) {
-	// 	if !yield(line, nil) {
-	// 		if err := cmd.Kill(); err != nil {
-	// 			slog.Error("Failed to kill apt clean command", slog.String("error", err.Error()))
-	// 		}
-	// 	}
-	// })
-	// cmd.RedirectStderrTo(stdout)
-	// cmd.RedirectStdoutTo(stdout)
+	cmd.RedirectStderrTo(stdout)
+	cmd.RedirectStdoutTo(stdout)
 
 	if err := cmd.RunWithinContext(ctx); err != nil {
 		return err

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -110,7 +110,7 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 		downloadDockerImages = true
 	}
 
-	if err := installPlatformPackage(ctx, plat); err != nil {
+	if err := installPlatformPackage(ctx, platform); err != nil {
 		slog.Error("failed to install platform package", "error", err)
 	}
 

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -115,6 +115,7 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 	}
 
 	if downloadPlatformAndLibs {
+		fmt.Fprintf(stdout, "Downloading libs and platforms used in examples ...")
 		if err := downloadLibsAndPlatformsUsedInExamples(ctx, cfg, platform, progressCB); err != nil {
 			return fmt.Errorf("failed to download libs and platforms used in examples: %w", err)
 		}
@@ -131,6 +132,7 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 }
 
 func downloadSupportedImages(ctx context.Context, cfg config.Configuration, brickindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, docker *command.DockerCli, stdout io.Writer) error {
+	fmt.Fprintf(stdout, "Pulling the latest docker images ...") //
 	imagesToPreinstall := []string{cfg.PythonImage}
 	brickImages, err := getAllSupportedBrickImages(brickindex, servicesindex)
 	if err != nil {

--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -240,7 +240,7 @@ func runAptCleanCommand(ctx context.Context) iter.Seq2[string, error] {
 
 func pullDockerImages(ctx context.Context) iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {
-		cmd, err := paths.NewProcess(nil, "arduino-app-cli", "version")
+		cmd, err := paths.NewProcess(nil, "arduino-app-cli", "system", "init")
 		if err != nil {
 			_ = yield("", err)
 			return

--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -109,7 +109,6 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 		eventCB(update.NewDataEvent(update.UpgradeLineEvent, line))
 	}
 
-	eventCB(update.NewDataEvent(update.UpgradeLineEvent, "Pulling the latest docker images ..."))
 	for line, err := range pullDockerImages(ctx) {
 		if err != nil {
 			// In case of errors, including "out of disk space" erros, do a cleanup and then retry once.

--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -240,7 +240,7 @@ func runAptCleanCommand(ctx context.Context) iter.Seq2[string, error] {
 
 func pullDockerImages(ctx context.Context) iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {
-		cmd, err := paths.NewProcess(nil, "arduino-app-cli", "system", "init")
+		cmd, err := paths.NewProcess(nil, "arduino-app-cli", "version")
 		if err != nil {
 			_ = yield("", err)
 			return

--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -109,7 +109,7 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 		eventCB(update.NewDataEvent(update.UpgradeLineEvent, line))
 	}
 
-	for line, err := range pullDockerImages(ctx) {
+	for line, err := range runSystemInit(ctx) {
 		if err != nil {
 			// In case of errors, including "out of disk space" erros, do a cleanup and then retry once.
 
@@ -125,7 +125,7 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 
 			// Try again to pull the docker containers.
 			eventCB(update.NewDataEvent(update.UpgradeLineEvent, "Pulling the latest docker images (again) ..."))
-			for line, err := range pullDockerImages(ctx) {
+			for line, err := range runSystemInit(ctx) {
 				if err != nil {
 					return fmt.Errorf("error pulling docker images: %w", err)
 				}
@@ -237,7 +237,7 @@ func runAptCleanCommand(ctx context.Context) iter.Seq2[string, error] {
 	}
 }
 
-func pullDockerImages(ctx context.Context) iter.Seq2[string, error] {
+func runSystemInit(ctx context.Context) iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {
 		cmd, err := paths.NewProcess(nil, "arduino-app-cli", "system", "init")
 		if err != nil {


### PR DESCRIPTION
### Motivation
The unoq and ventunoQ require different Debian packages to be installed. 
For example, the `arduino-linux-config` is now only needed in the unoq board.
We want to install the Debian meta-package `arduino-unoq` or `arduino-ventunoq` based on the board.

### Change description
Based on the board, the `system init` command will install the correct Debian packages

### Additional Notes
How to test:
1. check the `arduino-unoq` pcakage is not installed
```
arduino@dido4g:~$ apt list --installed | grep arduino-
arduino-app-cli/unstable,now 0.10.0-rc.3 arm64 [installed]
arduino-app-lab/unstable,now 0.7.0 arm64 [installed,auto-removable]
arduino-cli/unstable,now 1.5.0-rc.1 arm64 [installed]
arduino-router/unstable,now 0.8.1 arm64 [installed]
arduino-unoq-radio-firmware/unstable,now 0.6.1 arm64 [installed,automatic]
```
2. start the update 
```
arduino-app-cli system update --only-arduino
```
3. Check the logs containiing this info
```
[log] Installing package 'arduino-unoq'
[log] Reading package lists...
[log] Building dependency tree...
[log] Reading state information...
[log] The following additional packages will be installed:
[log]   arduino-linux-config
[log] The following NEW packages will be installed:
[log]   arduino-linux-config arduino-unoq
[log] 0 upgraded, 2 newly installed, 0 to remove and 31 not upgraded.
[log] Need to get 952 kB of archives.
[log] After this operation, 0 B of additional disk space will be used.
[log] Get:1 https://apt-repo.arduino.cc unstable/main arm64 arduino-linux-config arm64 0.1.0-rc.3 [951 kB]
[log] Get:2 https://apt-repo.arduino.cc unstable/main arm64 arduino-unoq arm64 0.0.1-rc.3 [824 B]
[log] Fetched 952 kB in 2s (593 kB/s)
[log] Selecting previously unselected package arduino-linux-config.
(Reading database ... 65979 files and directories currently installed.)
[log] Preparing to unpack .../arduino-linux-config_0.1.0-rc.3_arm64.deb ...
[log] Unpacking arduino-linux-config (0.1.0-rc.3) ...
[log] Selecting previously unselected package arduino-unoq.
[log] Preparing to unpack .../arduino-unoq_0.0.1-rc.3_arm64.deb ...
[log] Unpacking arduino-unoq (0.0.1-rc.3) ...
[log] Setting up arduino-linux-config (0.1.0-rc.3) ...
[log] Setting up arduino-unoq (0.0.1-rc.3) ...
[log]
[log] Running kernel seems to be up-to-date.
[log]
````
4. 

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
