### PR TITLE
Update builting leds paths

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -58,13 +58,13 @@ func GetPlatform(dir *paths.Path) Platform {
 			Linux: struct{ BoardLeds paths.PathList }{
 				BoardLeds: paths.NewPathList(
 					// LED 1
-					"/sys/class/leds/blue:user",
-					"/sys/class/leds/green:user",
-					"/sys/class/leds/red:user",
+					"/dev/leds/builtin/led1_b",
+					"/dev/leds/builtin/led1_g",
+					"/dev/leds/builtin/led1_r",
 					// LED 2
-					"/sys/class/leds/blue:bt",
-					"/sys/class/leds/green:wlan",
-					"/sys/class/leds/red:panic",
+					"/dev/leds/builtin/led2_b",
+					"/dev/leds/builtin/led2_g",
+					"/dev/leds/builtin/led2_r",
 				),
 			},
 			CompileJobs: 2,

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -56,16 +56,7 @@ func GetPlatform(dir *paths.Path) Platform {
 			PlatformID: "arduino:zephyr",
 			BoardName:  "unoq",
 			Linux: struct{ BoardLeds paths.PathList }{
-				BoardLeds: paths.NewPathList(
-					// LED 1
-					"/dev/leds/builtin/led1_b",
-					"/dev/leds/builtin/led1_g",
-					"/dev/leds/builtin/led1_r",
-					// LED 2
-					"/dev/leds/builtin/led2_b",
-					"/dev/leds/builtin/led2_g",
-					"/dev/leds/builtin/led2_r",
-				),
+				BoardLeds: GetUnoQBoardLeds(),
 			},
 			CompileJobs: 2,
 			Micro: struct{ ResetPin GpioPin }{
@@ -115,4 +106,35 @@ func (p Platform) GetMicro() micro.Micro {
 
 func (p Platform) SupportFlashToRam() bool {
 	return p.FQBN == "arduino:zephyr:unoq"
+}
+
+func GetUnoQBoardLeds() paths.PathList {
+	// new leds paths
+	newPaths := []string{
+		// LED 1
+		"/dev/leds/builtin/led1_b",
+		"/dev/leds/builtin/led1_g",
+		"/dev/leds/builtin/led1_r",
+		// LED 2
+		"/dev/leds/builtin/led2_b",
+		"/dev/leds/builtin/led2_g",
+		"/dev/leds/builtin/led2_r",
+	}
+
+	// legacy paths, old code expects this ones
+	legacyPaths := []string{
+		// LED 1
+		"/sys/class/leds/blue:user",
+		"/sys/class/leds/green:user",
+		"/sys/class/leds/red:user",
+		// LED 2
+		"/sys/class/leds/blue:bt",
+		"/sys/class/leds/green:wlan",
+		"/sys/class/leds/red:panic",
+	}
+
+	if paths.New(newPaths[0]).Exist() {
+		return paths.NewPathList(newPaths...)
+	}
+	return paths.NewPathList(legacyPaths...)
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -110,7 +110,7 @@ func (p Platform) SupportFlashToRam() bool {
 
 func GetUnoQBoardLeds() paths.PathList {
 	// new leds paths
-	newPaths := []string{
+	newPaths := paths.NewPathList(
 		// LED 1
 		"/dev/leds/builtin/led1_b",
 		"/dev/leds/builtin/led1_g",
@@ -119,10 +119,10 @@ func GetUnoQBoardLeds() paths.PathList {
 		"/dev/leds/builtin/led2_b",
 		"/dev/leds/builtin/led2_g",
 		"/dev/leds/builtin/led2_r",
-	}
+	)
 
 	// legacy paths, old code expects this ones
-	legacyPaths := []string{
+	legacyPaths := paths.NewPathList(
 		// LED 1
 		"/sys/class/leds/blue:user",
 		"/sys/class/leds/green:user",
@@ -131,10 +131,10 @@ func GetUnoQBoardLeds() paths.PathList {
 		"/sys/class/leds/blue:bt",
 		"/sys/class/leds/green:wlan",
 		"/sys/class/leds/red:panic",
-	}
+	)
 
-	if paths.New(newPaths[0]).Exist() {
-		return paths.NewPathList(newPaths...)
+	if newPaths[0].Exist() {
+		return newPaths
 	}
-	return paths.NewPathList(legacyPaths...)
+	return legacyPaths
 }


### PR DESCRIPTION
### Motivation

The latest kernel version introduces an updated DTB with a revised LED path structure to accommodate new board developments. A new set of udev rules will be distributed alongside the kernel to provide an abstraction layer for the /sys paths.
This PR updates the LED paths to the new /dev abstraction while maintaining the legacy paths as a fallback.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
