### PR TITLE
chore(tests):  integration update tests are failing

### DIFF
--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -204,8 +204,7 @@ func getAppCliVersion(t *testing.T, containerName string) string {
 	}
 	err = json.Unmarshal(output, &version)
 	require.NoError(t, err)
-	// TODO to enable after 0.6.7
-	// require.Equal(t, version.Version, version.DaemonVersion, "client and daemon versions should match")
+	require.Equal(t, version.Version, version.DaemonVersion, "client and daemon versions should match")
 	require.NotEmpty(t, version.Version)
 	return version.Version
 
@@ -218,7 +217,7 @@ func runSystemUpdate(t *testing.T, containerName string) {
 		"docker", "exec",
 		"--user", "arduino",
 		containerName,
-		"arduino-app-cli", "system", "update", "--yes",
+		"arduino-app-cli", "system", "update", "--only-arduino", "--yes",
 	)
 
 	cmd.Stderr = os.Stderr

--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -54,15 +54,13 @@ func fetchDebPackageLatest(t *testing.T, path, repo string) string {
 		log.Fatalf("command failed: %v\nOutput: %s", err, output)
 	}
 
-	fmt.Println(string(output))
-
 	fields := strings.Fields(string(output))
 	if len(fields) == 0 {
 		log.Fatal("could not parse tag from gh release list output")
 	}
 	tag := fields[0]
 
-	fmt.Println("Detected tag:", tag)
+	fmt.Println("Repo:", repo, "Detected tag:", tag)
 	cmd2 := exec.Command(
 		"gh", "release", "download",
 		tag,
@@ -128,9 +126,16 @@ func genMinorTag(t *testing.T, tag string) string {
 	lastNum, _ := strconv.Atoi(strings.TrimPrefix(last, "v"))
 	if lastNum > 0 {
 		lastNum--
+		parts[len(parts)-1] = strconv.Itoa(lastNum)
+	} else if len(parts) >= 2 {
+		minorStr := parts[len(parts)-2]
+		minorNum, _ := strconv.Atoi(minorStr)
+		if minorNum > 0 {
+			minorNum--
+		}
+		parts[len(parts)-2] = strconv.Itoa(minorNum)
 	}
 
-	parts[len(parts)-1] = strconv.Itoa(lastNum)
 	newTag := strings.Join(parts, ".")
 
 	if !strings.HasPrefix(newTag, "v") {

--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -120,28 +120,35 @@ func genMajorTag(t *testing.T, tag string) string {
 func genMinorTag(t *testing.T, tag string) string {
 	t.Helper()
 
-	parts := strings.Split(tag, ".")
-	last := parts[len(parts)-1]
-
-	lastNum, _ := strconv.Atoi(strings.TrimPrefix(last, "v"))
-	if lastNum > 0 {
-		lastNum--
-		parts[len(parts)-1] = strconv.Itoa(lastNum)
-	} else if len(parts) >= 2 {
-		minorStr := parts[len(parts)-2]
-		minorNum, _ := strconv.Atoi(minorStr)
-		if minorNum > 0 {
-			minorNum--
+	buildVersion := func(major, minor, patch string) string {
+		newTag := strings.Join([]string{major, minor, patch}, ".")
+		if !strings.HasPrefix(newTag, "v") {
+			newTag = "v" + newTag
 		}
-		parts[len(parts)-2] = strconv.Itoa(minorNum)
+		return newTag
 	}
 
-	newTag := strings.Join(parts, ".")
-
-	if !strings.HasPrefix(newTag, "v") {
-		newTag = "v" + newTag
+	parts := strings.Split(tag, ".")
+	if len(parts) != 3 {
+		log.Fatalf("invalid tag format: %s", tag)
 	}
-	return newTag
+	majorPart := parts[0]
+	minorPart := parts[1]
+	patchPart := parts[2]
+
+	if patchNum, _ := strconv.Atoi(patchPart); patchNum > 0 {
+		patchNum--
+		return buildVersion(majorPart, minorPart, strconv.Itoa(patchNum))
+	}
+	if minorNum, _ := strconv.Atoi(minorPart); minorNum > 0 {
+		minorNum--
+		return buildVersion(majorPart, strconv.Itoa(minorNum), "0")
+	}
+	if majorNum, _ := strconv.Atoi(strings.TrimPrefix(majorPart, "v")); majorNum > 0 {
+		majorNum--
+		return buildVersion(strconv.Itoa(majorNum), "9", "0")
+	}
+	return buildVersion(parts[0], parts[1], parts[2])
 }
 
 func buildDockerImage(t *testing.T, dockerfile, name, arch string) {

--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -209,7 +209,8 @@ func getAppCliVersion(t *testing.T, containerName string) string {
 	}
 	err = json.Unmarshal(output, &version)
 	require.NoError(t, err)
-	require.Equal(t, version.Version, version.DaemonVersion, "client and daemon versions should match")
+	// TODOD: enable
+	// require.Equal(t, version.Version, version.DaemonVersion, "client and daemon versions should match")
 	require.NotEmpty(t, version.Version)
 	return version.Version
 

--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -209,7 +209,7 @@ func getAppCliVersion(t *testing.T, containerName string) string {
 	}
 	err = json.Unmarshal(output, &version)
 	require.NoError(t, err)
-	// TODOD: enable
+	// TODO to enable after 0.6.7
 	// require.Equal(t, version.Version, version.DaemonVersion, "client and daemon versions should match")
 	require.NotEmpty(t, version.Version)
 	return version.Version

--- a/internal/e2e/updatetest/helpers_test.go
+++ b/internal/e2e/updatetest/helpers_test.go
@@ -1,3 +1,20 @@
+// This file is part of arduino-app-cli.
+//
+// Copyright (C) Arduino s.r.l. and/or its affiliated companies
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 package updatetest
 
 import (

--- a/internal/e2e/updatetest/helpers_test.go
+++ b/internal/e2e/updatetest/helpers_test.go
@@ -1,0 +1,48 @@
+package updatetest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenMinorTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "decrement patch version",
+			input:    "1.2.3",
+			expected: "v1.2.2",
+		},
+		{
+			name:     "patch is zero, decrement minor",
+			input:    "1.2.0",
+			expected: "v1.1.0",
+		},
+		{
+			name:     "minor and patch are zero, decrement major",
+			input:    "1.0.0",
+			expected: "v0.9.0",
+		},
+		{
+			name:     "with v prefix",
+			input:    "v1.2.3",
+			expected: "v1.2.2",
+		},
+		{
+			name:     "major version 0, no decrement",
+			input:    "0.0.0",
+			expected: "v0.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := genMinorTag(t, tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/e2e/updatetest/update_test.go
+++ b/internal/e2e/updatetest/update_test.go
@@ -33,59 +33,59 @@ const dockerFile = "test.Dockerfile"
 const daemonHost = "127.0.0.1:8800"
 
 func TestUpdatePackage(t *testing.T) {
-	fmt.Printf("***** ARCH %s ***** \n", arch)
+	// fmt.Printf("***** ARCH %s ***** \n", arch)
 
-	t.Run("Stable To Current", func(t *testing.T) {
-		t.Cleanup(func() { os.RemoveAll("build") })
+	// t.Run("Stable To Current", func(t *testing.T) {
+	// 	t.Cleanup(func() { os.RemoveAll("build") })
 
-		tagAppCli := fetchDebPackageLatest(t, "build/stable", "arduino/arduino-app-cli")
-		fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
-		fetchDebPackageLatest(t, "build/stable", "bcmi-labs/arduino-deb-packages")
+	// 	tagAppCli := fetchDebPackageLatest(t, "build/stable", "arduino/arduino-app-cli")
+	// 	fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
+	// 	fetchDebPackageLatest(t, "build/stable", "bcmi-labs/arduino-deb-packages")
 
-		majorTag := genMajorTag(t, tagAppCli)
+	// 	majorTag := genMajorTag(t, tagAppCli)
 
-		fmt.Printf("Updating from stable version %s to unstable version %s \n", tagAppCli, majorTag)
-		fmt.Printf("Building local deb version %s \n", majorTag)
-		buildDebVersion(t, "build", majorTag, arch)
+	// 	fmt.Printf("Updating from stable version %s to unstable version %s \n", tagAppCli, majorTag)
+	// 	fmt.Printf("Building local deb version %s \n", majorTag)
+	// 	buildDebVersion(t, "build", majorTag, arch)
 
-		const dockerImageName = "apt-test-update-image"
-		fmt.Println("**** BUILD docker image *****")
-		buildDockerImage(t, dockerFile, dockerImageName, arch)
-		//TODO: t cleanup remove docker image
+	// 	const dockerImageName = "apt-test-update-image"
+	// 	fmt.Println("**** BUILD docker image *****")
+	// 	buildDockerImage(t, dockerFile, dockerImageName, arch)
+	// 	//TODO: t cleanup remove docker image
 
-		t.Run("CLI Command", func(t *testing.T) {
-			const containerName = "apt-test-update"
-			t.Cleanup(func() { stopDockerContainer(t, containerName) })
+	// 	t.Run("CLI Command", func(t *testing.T) {
+	// 		const containerName = "apt-test-update"
+	// 		t.Cleanup(func() { stopDockerContainer(t, containerName) })
 
-			fmt.Println("**** RUN docker image *****")
-			startDockerContainer(t, containerName, dockerImageName)
-			waitForPort(t, daemonHost, 5*time.Second)
+	// 		fmt.Println("**** RUN docker image *****")
+	// 		startDockerContainer(t, containerName, dockerImageName)
+	// 		waitForPort(t, daemonHost, 5*time.Second)
 
-			preUpdateVersion := getAppCliVersion(t, containerName)
-			require.Equal(t, "v"+preUpdateVersion, tagAppCli)
-			runSystemUpdate(t, containerName)
-			postUpdateVersion := getAppCliVersion(t, containerName)
-			require.Equal(t, "v"+postUpdateVersion, majorTag)
-		})
+	// 		preUpdateVersion := getAppCliVersion(t, containerName)
+	// 		require.Equal(t, "v"+preUpdateVersion, tagAppCli)
+	// 		runSystemUpdate(t, containerName)
+	// 		postUpdateVersion := getAppCliVersion(t, containerName)
+	// 		require.Equal(t, "v"+postUpdateVersion, majorTag)
+	// 	})
 
-		t.Run("HTTP Request", func(t *testing.T) {
-			const containerName = "apt-test-update-http"
-			t.Cleanup(func() { stopDockerContainer(t, containerName) })
+	// 	t.Run("HTTP Request", func(t *testing.T) {
+	// 		const containerName = "apt-test-update-http"
+	// 		t.Cleanup(func() { stopDockerContainer(t, containerName) })
 
-			startDockerContainer(t, containerName, dockerImageName)
-			waitForPort(t, daemonHost, 5*time.Second)
+	// 		startDockerContainer(t, containerName, dockerImageName)
+	// 		waitForPort(t, daemonHost, 5*time.Second)
 
-			preUpdateVersion := getAppCliVersion(t, containerName)
-			require.Equal(t, "v"+preUpdateVersion, tagAppCli)
+	// 		preUpdateVersion := getAppCliVersion(t, containerName)
+	// 		require.Equal(t, "v"+preUpdateVersion, tagAppCli)
 
-			putUpdateRequest(t, daemonHost)
-			waitForUpgrade(t, daemonHost)
+	// 		putUpdateRequest(t, daemonHost)
+	// 		waitForUpgrade(t, daemonHost)
 
-			postUpdateVersion := getAppCliVersion(t, containerName)
-			require.Equal(t, "v"+postUpdateVersion, majorTag)
-		})
+	// 		postUpdateVersion := getAppCliVersion(t, containerName)
+	// 		require.Equal(t, "v"+postUpdateVersion, majorTag)
+	// 	})
 
-	})
+	// })
 
 	t.Run("CurrentToStable", func(t *testing.T) {
 		t.Cleanup(func() { os.RemoveAll("build") })
@@ -106,20 +106,20 @@ func TestUpdatePackage(t *testing.T) {
 		buildDockerImage(t, dockerFile, dockerImageName, arch)
 		// TODO: t cleanup remove docker image
 
-		t.Run("CLI Command", func(t *testing.T) {
-			const containerName = "apt-test-update-unstable"
-			t.Cleanup(func() { stopDockerContainer(t, containerName) })
+		// t.Run("CLI Command", func(t *testing.T) {
+		// 	const containerName = "apt-test-update-unstable"
+		// 	t.Cleanup(func() { stopDockerContainer(t, containerName) })
 
-			fmt.Println("**** RUN docker image *****")
-			startDockerContainer(t, containerName, dockerImageName)
-			waitForPort(t, daemonHost, 5*time.Second)
+		// 	fmt.Println("**** RUN docker image *****")
+		// 	startDockerContainer(t, containerName, dockerImageName)
+		// 	waitForPort(t, daemonHost, 5*time.Second)
 
-			preUpdateVersion := getAppCliVersion(t, containerName)
-			require.Equal(t, "v"+preUpdateVersion, minorTag)
-			runSystemUpdate(t, containerName)
-			postUpdateVersion := getAppCliVersion(t, containerName)
-			require.Equal(t, "v"+postUpdateVersion, tagAppCli)
-		})
+		// 	preUpdateVersion := getAppCliVersion(t, containerName)
+		// 	require.Equal(t, "v"+preUpdateVersion, minorTag)
+		// 	runSystemUpdate(t, containerName)
+		// 	postUpdateVersion := getAppCliVersion(t, containerName)
+		// 	require.Equal(t, "v"+postUpdateVersion, tagAppCli)
+		// })
 
 		t.Run("HTTP Request", func(t *testing.T) {
 			const containerName = "apt-test-update--unstable-http"

--- a/internal/e2e/updatetest/update_test.go
+++ b/internal/e2e/updatetest/update_test.go
@@ -33,59 +33,59 @@ const dockerFile = "test.Dockerfile"
 const daemonHost = "127.0.0.1:8800"
 
 func TestUpdatePackage(t *testing.T) {
-	// fmt.Printf("***** ARCH %s ***** \n", arch)
+	fmt.Printf("***** ARCH %s ***** \n", arch)
 
-	// t.Run("Stable To Current", func(t *testing.T) {
-	// 	t.Cleanup(func() { os.RemoveAll("build") })
+	t.Run("Stable To Current", func(t *testing.T) {
+		t.Cleanup(func() { os.RemoveAll("build") })
 
-	// 	tagAppCli := fetchDebPackageLatest(t, "build/stable", "arduino/arduino-app-cli")
-	// 	fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
-	// 	fetchDebPackageLatest(t, "build/stable", "bcmi-labs/arduino-deb-packages")
+		tagAppCli := fetchDebPackageLatest(t, "build/stable", "arduino/arduino-app-cli")
+		fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
+		fetchDebPackageLatest(t, "build/stable", "bcmi-labs/arduino-deb-packages")
 
-	// 	majorTag := genMajorTag(t, tagAppCli)
+		majorTag := genMajorTag(t, tagAppCli)
 
-	// 	fmt.Printf("Updating from stable version %s to unstable version %s \n", tagAppCli, majorTag)
-	// 	fmt.Printf("Building local deb version %s \n", majorTag)
-	// 	buildDebVersion(t, "build", majorTag, arch)
+		fmt.Printf("Updating from stable version %s to unstable version %s \n", tagAppCli, majorTag)
+		fmt.Printf("Building local deb version %s \n", majorTag)
+		buildDebVersion(t, "build", majorTag, arch)
 
-	// 	const dockerImageName = "apt-test-update-image"
-	// 	fmt.Println("**** BUILD docker image *****")
-	// 	buildDockerImage(t, dockerFile, dockerImageName, arch)
-	// 	//TODO: t cleanup remove docker image
+		const dockerImageName = "apt-test-update-image"
+		fmt.Println("**** BUILD docker image *****")
+		buildDockerImage(t, dockerFile, dockerImageName, arch)
+		//TODO: t cleanup remove docker image
 
-	// 	t.Run("CLI Command", func(t *testing.T) {
-	// 		const containerName = "apt-test-update"
-	// 		t.Cleanup(func() { stopDockerContainer(t, containerName) })
+		t.Run("CLI Command", func(t *testing.T) {
+			const containerName = "apt-test-update"
+			t.Cleanup(func() { stopDockerContainer(t, containerName) })
 
-	// 		fmt.Println("**** RUN docker image *****")
-	// 		startDockerContainer(t, containerName, dockerImageName)
-	// 		waitForPort(t, daemonHost, 5*time.Second)
+			fmt.Println("**** RUN docker image *****")
+			startDockerContainer(t, containerName, dockerImageName)
+			waitForPort(t, daemonHost, 5*time.Second)
 
-	// 		preUpdateVersion := getAppCliVersion(t, containerName)
-	// 		require.Equal(t, "v"+preUpdateVersion, tagAppCli)
-	// 		runSystemUpdate(t, containerName)
-	// 		postUpdateVersion := getAppCliVersion(t, containerName)
-	// 		require.Equal(t, "v"+postUpdateVersion, majorTag)
-	// 	})
+			preUpdateVersion := getAppCliVersion(t, containerName)
+			require.Equal(t, "v"+preUpdateVersion, tagAppCli)
+			runSystemUpdate(t, containerName)
+			postUpdateVersion := getAppCliVersion(t, containerName)
+			require.Equal(t, "v"+postUpdateVersion, majorTag)
+		})
 
-	// 	t.Run("HTTP Request", func(t *testing.T) {
-	// 		const containerName = "apt-test-update-http"
-	// 		t.Cleanup(func() { stopDockerContainer(t, containerName) })
+		t.Run("HTTP Request", func(t *testing.T) {
+			const containerName = "apt-test-update-http"
+			t.Cleanup(func() { stopDockerContainer(t, containerName) })
 
-	// 		startDockerContainer(t, containerName, dockerImageName)
-	// 		waitForPort(t, daemonHost, 5*time.Second)
+			startDockerContainer(t, containerName, dockerImageName)
+			waitForPort(t, daemonHost, 5*time.Second)
 
-	// 		preUpdateVersion := getAppCliVersion(t, containerName)
-	// 		require.Equal(t, "v"+preUpdateVersion, tagAppCli)
+			preUpdateVersion := getAppCliVersion(t, containerName)
+			require.Equal(t, "v"+preUpdateVersion, tagAppCli)
 
-	// 		putUpdateRequest(t, daemonHost)
-	// 		waitForUpgrade(t, daemonHost)
+			putUpdateRequest(t, daemonHost)
+			waitForUpgrade(t, daemonHost)
 
-	// 		postUpdateVersion := getAppCliVersion(t, containerName)
-	// 		require.Equal(t, "v"+postUpdateVersion, majorTag)
-	// 	})
+			postUpdateVersion := getAppCliVersion(t, containerName)
+			require.Equal(t, "v"+postUpdateVersion, majorTag)
+		})
 
-	// })
+	})
 
 	t.Run("CurrentToStable", func(t *testing.T) {
 		t.Cleanup(func() { os.RemoveAll("build") })
@@ -106,20 +106,20 @@ func TestUpdatePackage(t *testing.T) {
 		buildDockerImage(t, dockerFile, dockerImageName, arch)
 		// TODO: t cleanup remove docker image
 
-		// t.Run("CLI Command", func(t *testing.T) {
-		// 	const containerName = "apt-test-update-unstable"
-		// 	t.Cleanup(func() { stopDockerContainer(t, containerName) })
+		t.Run("CLI Command", func(t *testing.T) {
+			const containerName = "apt-test-update-unstable"
+			t.Cleanup(func() { stopDockerContainer(t, containerName) })
 
-		// 	fmt.Println("**** RUN docker image *****")
-		// 	startDockerContainer(t, containerName, dockerImageName)
-		// 	waitForPort(t, daemonHost, 5*time.Second)
+			fmt.Println("**** RUN docker image *****")
+			startDockerContainer(t, containerName, dockerImageName)
+			waitForPort(t, daemonHost, 5*time.Second)
 
-		// 	preUpdateVersion := getAppCliVersion(t, containerName)
-		// 	require.Equal(t, "v"+preUpdateVersion, minorTag)
-		// 	runSystemUpdate(t, containerName)
-		// 	postUpdateVersion := getAppCliVersion(t, containerName)
-		// 	require.Equal(t, "v"+postUpdateVersion, tagAppCli)
-		// })
+			preUpdateVersion := getAppCliVersion(t, containerName)
+			require.Equal(t, "v"+preUpdateVersion, minorTag)
+			runSystemUpdate(t, containerName)
+			postUpdateVersion := getAppCliVersion(t, containerName)
+			require.Equal(t, "v"+postUpdateVersion, tagAppCli)
+		})
 
 		t.Run("HTTP Request", func(t *testing.T) {
 			const containerName = "apt-test-update--unstable-http"


### PR DESCRIPTION
### Motivation

temptative: Decreasing the time to execute the upate test by installing `only-arduino` packages

Failign beacuse the minor from 0.9.0 is no correctly generated ?
### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
