### PR TITLE
feat: reuse port forwards

### DIFF
--- a/pkg/board/remote/adb/adb.go
+++ b/pkg/board/remote/adb/adb.go
@@ -110,21 +110,37 @@ func FromHost(host string, adbPath string) (*ADBConnection, error) {
 }
 
 func (a *ADBConnection) Forward(ctx context.Context, localPort int, remotePort int) error {
+	localString := fmt.Sprintf("tcp:%d", localPort)
+	remoteString := fmt.Sprintf("tcp:%d", remotePort)
+
 	if !ports.IsAvailable(localPort) {
+		// Check if the port is already forwarded by adb to the expected remote port
+		checkCmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "forward", "--list")
+		if err == nil {
+			if out, err := checkCmd.RunAndCaptureCombinedOutput(ctx); err == nil {
+				scanner := bufio.NewScanner(bytes.NewReader(out))
+				for scanner.Scan() {
+					// Output format is typically: <serial> <local> <remote>
+					fields := strings.Fields(scanner.Text())
+					if len(fields) >= 3 && fields[0] == a.host && fields[1] == localString && fields[2] == remoteString {
+						return nil // Port is already forwarded exactly as requested
+					}
+				}
+			}
+		}
+
 		return remote.ErrPortAvailable
 	}
 
-	local := fmt.Sprintf("tcp:%d", localPort)
-	remote := fmt.Sprintf("tcp:%d", remotePort)
-	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "forward", local, remote)
+	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "forward", localString, remoteString)
 	if err != nil {
 		return err
 	}
 	if out, err := cmd.RunAndCaptureCombinedOutput(ctx); err != nil {
 		return fmt.Errorf(
 			"failed to forward ADB port %s to %s: %w: %s",
-			local,
-			remote,
+			localString,
+			remoteString,
 			err,
 			out,
 		)

--- a/pkg/board/remote/adb/adb.go
+++ b/pkg/board/remote/adb/adb.go
@@ -115,8 +115,7 @@ func (a *ADBConnection) Forward(ctx context.Context, localPort int, remotePort i
 
 	if !ports.IsAvailable(localPort) {
 		// Check if the port is already forwarded by adb to the expected remote port
-		checkCmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "forward", "--list")
-		if err == nil {
+		if checkCmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "forward", "--list"); err == nil {
 			if out, err := checkCmd.RunAndCaptureCombinedOutput(ctx); err == nil {
 				scanner := bufio.NewScanner(bytes.NewReader(out))
 				for scanner.Scan() {

--- a/pkg/board/remote/ssh/ssh.go
+++ b/pkg/board/remote/ssh/ssh.go
@@ -38,12 +38,18 @@ import (
 
 var ErrAuthFailed = errors.New("ssh authentication failed")
 
+type ForwardedPort struct {
+	Listener   net.Listener
+	LocalPort  int
+	RemotePort int
+}
+
 type SSHConnection struct {
 	client *ssh.Client
 	wg     sync.WaitGroup
 
-	mu        sync.Mutex
-	Listeners []net.Listener
+	mu             sync.Mutex
+	ForwardedPorts []ForwardedPort
 }
 
 // Ensures SSHConnection implements the RemoteConn interface at compile time.
@@ -74,6 +80,18 @@ func FromHost(user, password, address string) (*SSHConnection, error) {
 }
 
 func (a *SSHConnection) Forward(ctx context.Context, localPort int, remotePort int) error {
+	a.mu.Lock()
+	for _, fp := range a.ForwardedPorts {
+		if fp.LocalPort == localPort {
+			a.mu.Unlock()
+			if fp.RemotePort == remotePort {
+				return nil // Port already forwarded as requested
+			}
+			return remote.ErrPortAvailable // Already mapped but to a different remote port
+		}
+	}
+	a.mu.Unlock()
+
 	if !ports.IsAvailable(localPort) {
 		return remote.ErrPortAvailable
 	}
@@ -84,7 +102,11 @@ func (a *SSHConnection) Forward(ctx context.Context, localPort int, remotePort i
 	}
 
 	a.mu.Lock()
-	a.Listeners = append(a.Listeners, listener)
+	a.ForwardedPorts = append(a.ForwardedPorts, ForwardedPort{
+		Listener:   listener,
+		LocalPort:  localPort,
+		RemotePort: remotePort,
+	})
 	a.mu.Unlock()
 
 	a.wg.Add(1)
@@ -111,7 +133,6 @@ func (a *SSHConnection) Forward(ctx context.Context, localPort int, remotePort i
 				if err != nil {
 					slog.Warn("failed to dial remote host:", slog.Any("error", err))
 					return
-
 				}
 				defer remoteConn.Close()
 
@@ -137,13 +158,13 @@ func copyAndLog(dst io.Writer, src io.Reader) {
 func (a *SSHConnection) ForwardKillAll(ctx context.Context) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	for _, listener := range a.Listeners {
-		if err := listener.Close(); err != nil {
+	for _, fp := range a.ForwardedPorts {
+		if err := fp.Listener.Close(); err != nil {
 			return err
 		}
 	}
 	a.wg.Wait()
-	a.Listeners = make([]net.Listener, 0)
+	a.ForwardedPorts = make([]ForwardedPort, 0)
 	return nil
 }
 

--- a/pkg/board/remote/ssh/ssh.go
+++ b/pkg/board/remote/ssh/ssh.go
@@ -27,6 +27,7 @@ import (
 	"log/slog"
 	"net"
 	"path"
+	"slices"
 	"strings"
 	"sync"
 
@@ -38,18 +39,18 @@ import (
 
 var ErrAuthFailed = errors.New("ssh authentication failed")
 
-type ForwardedPort struct {
-	Listener   net.Listener
-	LocalPort  int
-	RemotePort int
-}
-
 type SSHConnection struct {
 	client *ssh.Client
 	wg     sync.WaitGroup
 
 	mu             sync.Mutex
 	ForwardedPorts []ForwardedPort
+}
+
+type ForwardedPort struct {
+	Listener   net.Listener
+	LocalPort  int
+	RemotePort int
 }
 
 // Ensures SSHConnection implements the RemoteConn interface at compile time.
@@ -81,16 +82,13 @@ func FromHost(user, password, address string) (*SSHConnection, error) {
 
 func (a *SSHConnection) Forward(ctx context.Context, localPort int, remotePort int) error {
 	a.mu.Lock()
-	for _, fp := range a.ForwardedPorts {
-		if fp.LocalPort == localPort {
-			a.mu.Unlock()
-			if fp.RemotePort == remotePort {
-				return nil // Port already forwarded as requested
-			}
-			return remote.ErrPortAvailable // Already mapped but to a different remote port
-		}
+	defer a.mu.Unlock()
+
+	if slices.ContainsFunc(a.ForwardedPorts, func(fp ForwardedPort) bool {
+		return fp.LocalPort == localPort && fp.RemotePort == remotePort
+	}) {
+		return nil // Port already forwarded as requested
 	}
-	a.mu.Unlock()
 
 	if !ports.IsAvailable(localPort) {
 		return remote.ErrPortAvailable
@@ -101,13 +99,11 @@ func (a *SSHConnection) Forward(ctx context.Context, localPort int, remotePort i
 		return err
 	}
 
-	a.mu.Lock()
 	a.ForwardedPorts = append(a.ForwardedPorts, ForwardedPort{
 		Listener:   listener,
 		LocalPort:  localPort,
 		RemotePort: remotePort,
 	})
-	a.mu.Unlock()
 
 	a.wg.Add(1)
 	go func() {


### PR DESCRIPTION
### Motivation
Check if a port forward request is already available. In that case the Forward function should reuse it, instead of opening a new one.

### Change description
- adb: we use adb forward --list to check if the requested port forward is already existing
- ssh: we track the currently opened port forwards, and check that list

### Additional Notes
The Forward function is used [here](https://github.com/bcmi-labs/cloud-editor-mono/blob/main/standalone-apps/app-lab-desktop/internal/tunnel/tunnel.go#L35) by the App Lab.
