### PR TITLE
fix(pkg/board): support file and dir with spaces

### DIFF
--- a/pkg/board/remote/adb/adb.go
+++ b/pkg/board/remote/adb/adb.go
@@ -18,6 +18,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/arduino/go-paths-helper"
@@ -148,7 +149,7 @@ func (a *ADBConnection) ForwardKillAll(ctx context.Context) error {
 }
 
 func (a *ADBConnection) List(path string) ([]remote.FileInfo, error) {
-	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "ls", "-la", path)
+	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "ls", "-laQ", strconv.Quote(path))
 	if err != nil {
 		return nil, err
 	}
@@ -163,41 +164,11 @@ func (a *ADBConnection) List(path string) ([]remote.FileInfo, error) {
 	}
 	defer func() { _ = cmd.Wait() }()
 
-	r := bufio.NewReader(output)
-	_, err = r.ReadBytes('\n') // Skip the first line
-	if err != nil {
-		return nil, err
-	}
-
-	var files []remote.FileInfo
-	for {
-		line, err := r.ReadBytes('\n')
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, err
-		}
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 {
-			continue
-		}
-		parts := bytes.Split(line, []byte(" "))
-		name := string(parts[len(parts)-1])
-		if name == "." || name == ".." {
-			continue
-		}
-		files = append(files, remote.FileInfo{
-			Name:  name,
-			IsDir: line[0] == 'd',
-		})
-	}
-
-	return files, nil
+	return remote.ParseLsOutput(output)
 }
 
 func (a *ADBConnection) Stats(p string) (remote.FileInfo, error) {
-	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "file", p)
+	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "file", strconv.Quote(p))
 	if err != nil {
 		return remote.FileInfo{}, err
 	}
@@ -237,15 +208,15 @@ func (a *ADBConnection) Stats(p string) (remote.FileInfo, error) {
 }
 
 func (a *ADBConnection) ReadFile(path string) (io.ReadCloser, error) {
-	return adbReadFile(a, path)
+	return adbReadFile(a, strconv.Quote(path))
 }
 
 func (a *ADBConnection) WriteFile(r io.Reader, path string) error {
-	return adbWriteFile(a, r, path)
+	return adbWriteFile(a, r, strconv.Quote(path))
 }
 
 func (a *ADBConnection) MkDirAll(path string) error {
-	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "install", "-o", username, "-g", username, "-m", "755", "-d", path)
+	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "install", "-o", username, "-g", username, "-m", "755", "-d", strconv.Quote(path))
 	if err != nil {
 		return err
 	}
@@ -257,7 +228,7 @@ func (a *ADBConnection) MkDirAll(path string) error {
 }
 
 func (a *ADBConnection) Remove(path string) error {
-	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "rm", "-r", path) // nolint:gosec
+	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "rm", "-r", strconv.Quote(path))
 	if err != nil {
 		return err
 	}

--- a/pkg/board/remote/parser.go
+++ b/pkg/board/remote/parser.go
@@ -7,6 +7,7 @@ package remote
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -29,4 +30,40 @@ func ParseChage(r io.Reader) (bool, error) {
 		return false, err
 	}
 	return false, fmt.Errorf("unexpected output from chage command")
+}
+
+// ParseLsOutput parses the output of the `ls -laQ` command and returns a slice of FileInfo.
+func ParseLsOutput(out io.Reader) ([]FileInfo, error) {
+	// skip the first line which contains the total size
+	r := bufio.NewReader(out)
+	if _, err := r.ReadBytes('\n'); err != nil {
+		return nil, err
+	}
+
+	var files []FileInfo
+	for {
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		first := strings.IndexByte(string(line), '"')
+		last := strings.LastIndexByte(string(line), '"')
+		name := string(line[first+1 : last])
+		if name == "." || name == ".." {
+			continue
+		}
+		files = append(files, FileInfo{
+			Name:  name,
+			IsDir: line[0] == 'd',
+		})
+	}
+
+	return files, nil
 }

--- a/pkg/board/remote/remote_test.go
+++ b/pkg/board/remote/remote_test.go
@@ -8,6 +8,8 @@ package remote_test
 import (
 	"fmt"
 	"net"
+	"path"
+	"slices"
 
 	"io"
 	"strings"
@@ -53,58 +55,89 @@ func TestRemoteFS(t *testing.T) {
 	},
 	}
 
+	files := []string{
+		"testdir/testfile.txt",
+		"testdir/testfile with spaces.txt",
+		"testdir with space/testfile.txt",
+		"testdir with space/testfile with spaces.txt",
+	}
+
+	dirs := func() []string {
+		dirs := make([]string, 0, len(files))
+		for _, file := range files {
+			dirs = append(dirs, path.Dir(file))
+		}
+		slices.Sort(dirs)
+		return slices.Compact(dirs)
+	}()
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("Mkdir", func(t *testing.T) {
-				err := tc.conn.MkDirAll("./testdir")
-				require.NoError(t, err)
-				info, err := tc.conn.Stats("./testdir")
-				require.NoError(t, err)
-				assert.Equal(t, remote.FileInfo{
-					Name:  "testdir",
-					IsDir: true,
-				}, info)
+				for _, dir := range dirs {
+					err := tc.conn.MkDirAll("./" + dir)
+					require.NoError(t, err)
+					info, err := tc.conn.Stats("./" + dir)
+					require.NoError(t, err)
+					assert.Equal(t, remote.FileInfo{
+						Name:  dir,
+						IsDir: true,
+					}, info)
+				}
 			})
 
 			t.Run("WriteFile/ReadFile", func(t *testing.T) {
-				err := tc.conn.WriteFile(strings.NewReader("Hello, World!"), "./testdir/testfile.txt")
-				require.NoError(t, err)
-				info, err := tc.conn.Stats("./testdir/testfile.txt")
-				require.NoError(t, err)
-				assert.Equal(t, remote.FileInfo{
-					Name:  "testfile.txt",
-					IsDir: false,
-				}, info)
+				for _, file := range files {
+					t.Run(file, func(t *testing.T) {
+						err := tc.conn.WriteFile(strings.NewReader("Hello, World!"), "./"+file)
+						require.NoError(t, err)
+						info, err := tc.conn.Stats("./" + file)
+						require.NoError(t, err)
+						assert.Equal(t, remote.FileInfo{
+							Name:  path.Base(file),
+							IsDir: false,
+						}, info)
 
-				r, err := tc.conn.ReadFile("./testdir/testfile.txt")
-				require.NoError(t, err)
-				data, err := io.ReadAll(r)
-				require.NoError(t, err)
-				require.Equal(t, "Hello, World!", string(data))
+						r, err := tc.conn.ReadFile("./" + file)
+						require.NoError(t, err)
+						data, err := io.ReadAll(r)
+						require.NoError(t, err)
+						require.Equal(t, "Hello, World!", string(data))
+					})
+				}
 			})
 
 			t.Run("List", func(t *testing.T) {
-				files, err := tc.conn.List("./")
+				gotFiles, err := tc.conn.List("./")
 				require.NoError(t, err)
-				assert.NotEmpty(t, files)
-				assert.Contains(t, files, remote.FileInfo{Name: "testdir", IsDir: true})
+				for _, dir := range dirs {
+					assert.Contains(t, gotFiles, remote.FileInfo{Name: dir, IsDir: true})
+				}
 
-				files, err = tc.conn.List("./testdir")
-				require.NoError(t, err)
-				assert.Len(t, files, 1)
-				assert.Equal(t, remote.FileInfo{Name: "testfile.txt", IsDir: false}, files[0])
+				for _, dir := range dirs {
+					gotFiles, err = tc.conn.List("./" + dir)
+					require.NoError(t, err)
+					assert.Len(t, gotFiles, 2)
+					for _, gotFile := range gotFiles {
+						assert.Contains(t, files, path.Join(dir, gotFile.Name))
+					}
+				}
 			})
 
 			t.Run("Remove", func(t *testing.T) {
-				err := tc.conn.Remove("./testdir/testfile.txt")
-				require.NoError(t, err)
-				_, err = tc.conn.Stats("./testdir/testfile.txt")
-				assert.Error(t, err)
+				for _, file := range files {
+					err := tc.conn.Remove("./" + file)
+					require.NoError(t, err)
+					_, err = tc.conn.Stats("./" + file)
+					assert.Error(t, err)
+				}
 
-				err = tc.conn.Remove("./testdir")
-				require.NoError(t, err)
-				_, err = tc.conn.Stats("./testdir")
-				assert.Error(t, err)
+				for _, dir := range dirs {
+					err := tc.conn.Remove("./" + dir)
+					require.NoError(t, err)
+					_, err = tc.conn.Stats("./" + dir)
+					assert.Error(t, err)
+				}
 			})
 		})
 	}

--- a/pkg/board/remote/ssh/ssh.go
+++ b/pkg/board/remote/ssh/ssh.go
@@ -159,39 +159,13 @@ func (a *SSHConnection) List(path string) ([]remote.FileInfo, error) {
 	}
 	defer session.Close()
 
-	// Run the `ls -la` command on the remote host
-	cmd := fmt.Sprintf("ls -la %s", path)
+	cmd := fmt.Sprintf("ls -laQ %q", path)
 	output, err := session.Output(cmd)
 	if err != nil {
 		return nil, err
 	}
 
-	lines := bytes.Split(output, []byte("\n"))
-	if len(lines) > 0 {
-		lines = lines[1:] // Skip the first line (header)
-	}
-
-	files := make([]remote.FileInfo, 0, len(lines))
-	for _, line := range lines {
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 {
-			continue
-		}
-		parts := bytes.Fields(line)
-		if len(parts) < 9 {
-			continue
-		}
-		name := string(parts[len(parts)-1])
-		if name == "." || name == ".." {
-			continue
-		}
-		files = append(files, remote.FileInfo{
-			Name:  name,
-			IsDir: line[0] == 'd',
-		})
-	}
-
-	return files, nil
+	return remote.ParseLsOutput(bytes.NewReader(output))
 }
 
 func (a *SSHConnection) MkDirAll(path string) error {
@@ -201,7 +175,7 @@ func (a *SSHConnection) MkDirAll(path string) error {
 	}
 	defer session.Close()
 
-	cmd := fmt.Sprintf("mkdir -p %s", path)
+	cmd := fmt.Sprintf("mkdir -p %q", path)
 	if err := session.Run(cmd); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
@@ -216,7 +190,7 @@ func (a *SSHConnection) WriteFile(r io.Reader, path string) error {
 	}
 	defer session.Close()
 
-	cmd := fmt.Sprintf("cat > %s", path)
+	cmd := fmt.Sprintf("cat > %q", path)
 	session.Stdin = r
 
 	if err := session.Run(cmd); err != nil {
@@ -232,7 +206,7 @@ func (a *SSHConnection) ReadFile(path string) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	cmd := fmt.Sprintf("cat %s", path)
+	cmd := fmt.Sprintf("cat %q", path)
 	output, err := session.StdoutPipe()
 	if err != nil {
 		return nil, err
@@ -255,7 +229,7 @@ func (a *SSHConnection) Remove(path string) error {
 	}
 	defer session.Close()
 
-	cmd := fmt.Sprintf("rm -rf %s", path)
+	cmd := fmt.Sprintf("rm -rf %q", path)
 	if err := session.Run(cmd); err != nil {
 		return fmt.Errorf("failed to remove file: %w", err)
 	}
@@ -270,7 +244,7 @@ func (a *SSHConnection) Stats(p string) (remote.FileInfo, error) {
 	}
 	defer session.Close()
 
-	cmd := fmt.Sprintf("file %s", p)
+	cmd := fmt.Sprintf("file %q", p)
 	output, err := session.Output(cmd)
 	if err != nil {
 		return remote.FileInfo{}, err


### PR DESCRIPTION
### Motivation

The fs api of the board wasn't correctly handling file paths with spaces.

### Change description

1. quote every path
2. improve the list api with -Q parameter
3. add test for file and folder with space

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
