### PR TITLE
feat(pkg/board): add CopyFS api

### DIFF
--- a/pkg/board/remote/fs.go
+++ b/pkg/board/remote/fs.go
@@ -1,0 +1,36 @@
+package remote
+
+import (
+	"fmt"
+	"io/fs"
+	"path"
+)
+
+// CopyFS copies the file system fsys into a remote directory dir using the provided RemoteConn.
+//
+// Copying stops at and returns the first error encountered.
+func CopyFS(conn RemoteConn, dir string, fsys fs.FS) error {
+	return fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		newPath := path.Join(dir, p)
+		switch d.Type() {
+		case fs.ModeDir:
+			return conn.MkDirAll(newPath)
+		case fs.ModeSymlink:
+			// FIXME: implement symbolic link support
+			return fmt.Errorf("CopyFS: symbolic links not supported")
+		case 0:
+			r, err := fsys.Open(p)
+			if err != nil {
+				return err
+			}
+			defer r.Close()
+			// FIXME: support permission fowarding
+			return conn.WriteFile(r, newPath)
+		default:
+			return &fs.PathError{Op: "CopyFS", Path: p, Err: fs.ErrInvalid}
+		}
+	})
+}

--- a/pkg/board/remote/fs.go
+++ b/pkg/board/remote/fs.go
@@ -1,3 +1,8 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package remote
 
 import (

--- a/pkg/board/remotefs/remotefs.go
+++ b/pkg/board/remotefs/remotefs.go
@@ -46,28 +46,6 @@ func (a RemoteFS) Open(name string) (fs.File, error) {
 	return &RemoteFile{name: name, base: a.base, conn: a.conn}, nil
 }
 
-type RemoteFSWriter struct {
-	RemoteFS
-}
-
-func (a RemoteFS) ToWriter() RemoteFSWriter {
-	return RemoteFSWriter{
-		RemoteFS: a,
-	}
-}
-
-func (a RemoteFSWriter) MkDirAll(p string) error {
-	return a.conn.MkDirAll(path.Join(a.base, p))
-}
-
-func (a RemoteFSWriter) WriteFile(p string, data io.ReadCloser) error {
-	return a.conn.WriteFile(data, path.Join(a.base, p))
-}
-
-func (a RemoteFSWriter) RmFile(p string) error {
-	return a.conn.Remove(path.Join(a.base, p))
-}
-
 type RemoteFile struct {
 	name string
 	base string


### PR DESCRIPTION
### Motivation

Add a simple api similar to https://pkg.go.dev/os#CopyFS for copying an FS into the board.

### Change description

This could be used both to copy files from the local filesystem to the board, and from the board itself.


```go
// from the local os to the board 
fs := os.DirFS("./a local path")
err := remote.CopyFS(conn, fs, "./a remote path")


// from the board to the board
fs := remotefs.New(conn, "./a path from the board")
err := remote.CopyFS(conn, fs, "./a remote path")
```



### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
