### PR TITLE
fix: some boards require an always running micro

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -292,10 +292,9 @@ func stopAppWithCmd(ctx context.Context, docker command.Cli, platform platform.P
 		}
 		if running != nil && running.FullPath.String() == app.FullPath.String() {
 			cb(StreamMessage{data: "Stopping microcontroller..."})
-			if err := platform.GetMicro().Disable(); err != nil {
-				return err
-				// XXX: if we fail to stop the sketch, do we want to continue to stop the app anyway?
-				//      maybe we can just log the error and continue
+			// Reset the microcontroller stops the sketch because the micro will wait for the wait-for-app signal.
+			if err := platform.GetMicro().Reset(); err != nil {
+				slog.Warn("failed to reset microcontroller", slog.String("error", err.Error()))
 			}
 		}
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -292,7 +292,12 @@ func stopAppWithCmd(ctx context.Context, docker command.Cli, platform platform.P
 		}
 		if running != nil && running.FullPath.String() == app.FullPath.String() {
 			cb(StreamMessage{data: "Stopping microcontroller..."})
-			// Reset the microcontroller stops the sketch because the micro will wait for the wait-for-app signal.
+// Reset() triggers a reset of the microcontroller.
+// Note: If the sketch was compiled with 'Wait for App', the microcontroller 
+// will stop and wait for the wait-for-app signal before restarting the sketch. 
+// In all other boot modes (e.g., 'Wait for Linux' or 'Immediate'), the 
+// sketch will simply restart.
+
 			if err := platform.GetMicro().Reset(); err != nil {
 				slog.Warn("failed to reset microcontroller", slog.String("error", err.Error()))
 			}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -292,16 +292,11 @@ func stopAppWithCmd(ctx context.Context, docker command.Cli, platform platform.P
 		}
 		if running != nil && running.FullPath.String() == app.FullPath.String() {
 			cb(StreamMessage{data: "Stopping microcontroller..."})
-// Reset() triggers a reset of the microcontroller.
-// Note: If the sketch was compiled with 'Wait for App', the microcontroller 
-// will stop and wait for the wait-for-app signal before restarting the sketch. 
-// In all other boot modes (e.g., 'Wait for Linux' or 'Immediate'), the 
- 				// Reset() triggers a reset of the microcontroller.
-				// Note: If the sketch was compiled with 'Wait for App', the microcontroller 
-				// will stop and wait for the wait-for-app signal before restarting the sketch. 
-				// In all other boot modes (e.g., 'Wait for Linux' or 'Immediate'), the 
-				// sketch will simply restart.
-
+			// Reset() triggers a reset of the microcontroller.
+			// Note: If the sketch was compiled with 'Wait for App', the microcontroller
+			// will stop and wait for the wait-for-app signal before restarting the sketch.
+			// In all other boot modes (e.g., 'Wait for Linux' or 'Immediate'), the
+			// sketch will simply restart.
 			if err := platform.GetMicro().Reset(); err != nil {
 				slog.Warn("failed to reset microcontroller", slog.String("error", err.Error()))
 			}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -296,7 +296,11 @@ func stopAppWithCmd(ctx context.Context, docker command.Cli, platform platform.P
 // Note: If the sketch was compiled with 'Wait for App', the microcontroller 
 // will stop and wait for the wait-for-app signal before restarting the sketch. 
 // In all other boot modes (e.g., 'Wait for Linux' or 'Immediate'), the 
-// sketch will simply restart.
+ 				// Reset() triggers a reset of the microcontroller.
+				// Note: If the sketch was compiled with 'Wait for App', the microcontroller 
+				// will stop and wait for the wait-for-app signal before restarting the sketch. 
+				// In all other boot modes (e.g., 'Wait for Linux' or 'Immediate'), the 
+				// sketch will simply restart.
 
 			if err := platform.GetMicro().Reset(); err != nil {
 				slog.Warn("failed to reset microcontroller", slog.String("error", err.Error()))


### PR DESCRIPTION
### Motivation

On Monza, the microcontroller runs some other task other than the sketch that we cannot stop. So we need to stop only the user sketch and not the other services.

### Change description

Instead of keeping the reset pin down to stop the micro, we can do a reset and make the sketch wait for the wait-for-app signal.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
