### PR TITLE
feat: fqbn override for compilation

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1052,16 +1052,16 @@ func compileUploadSketch(
 		return err
 	}
 
-	menuOptions, err := GetPlatformMenuOptions(ctx, platform)
-	if err != nil {
-		slog.Warn("failed to get platform menu options", slog.String("error", err.Error()))
-	}
-
 	compileFqbn := fqbn.MustParse(platform.FQBN)
 	if f, err := fqbn.Parse(sketch.GetDefaultProfile().GetFqbn()); err == nil {
 		compileFqbn = f
 	} else {
 		slog.Warn("failed to parse FQBN from sketch profile, using platform FQBN for compilation", slog.String("error", err.Error()))
+	}
+
+	menuOptions, err := GetPlatformMenuOptions(ctx, compileFqbn.String())
+	if err != nil {
+		slog.Warn("failed to get platform menu options", slog.String("error", err.Error()))
 	}
 	if menuOptions.Has(WaitForApp) {
 		compileFqbn.Configs.Set(WaitForApp.name, WaitForApp.value)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1058,7 +1058,7 @@ func compileUploadSketch(
 
 	fqbn := platform.FQBN
 	if menuOptions.Has(WaitForApp) {
-		fqbn += ":" + WaitForApp.String()
+		fqbn = addOptionToFqbn(fqbn, WaitForApp)
 	}
 
 	slog.Debug("compile and upload sketch", slog.String("fqbn", fqbn), slog.Any("menuOptions", menuOptions))

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/arduino/arduino-cli/commands"
+	"github.com/arduino/arduino-cli/pkg/fqbn"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
 	"github.com/arduino/go-paths-helper"
 	"github.com/docker/cli/cli/command"
@@ -1056,12 +1057,17 @@ func compileUploadSketch(
 		slog.Warn("failed to get platform menu options", slog.String("error", err.Error()))
 	}
 
-	fqbn := platform.FQBN
+	compileFqbn := fqbn.MustParse(platform.FQBN)
+	if f, err := fqbn.Parse(sketch.GetDefaultProfile().GetFqbn()); err == nil {
+		compileFqbn = f
+	} else {
+		slog.Warn("failed to parse FQBN from sketch profile, using platform FQBN for compilation", slog.String("error", err.Error()))
+	}
 	if menuOptions.Has(WaitForApp) {
-		fqbn = addOptionToFqbn(fqbn, WaitForApp)
+		compileFqbn.Configs.Set(WaitForApp.name, WaitForApp.value)
 	}
 
-	slog.Debug("compile and upload sketch", slog.String("fqbn", fqbn), slog.Any("menuOptions", menuOptions))
+	slog.Debug("compile and upload sketch", slog.String("fqbn", compileFqbn.String()), slog.Any("menuOptions", menuOptions))
 
 	// build the sketch
 	buildPath := arduinoApp.SketchBuildPath()
@@ -1074,7 +1080,7 @@ func compileUploadSketch(
 	server, getCompileResult := commands.CompilerServerToStreams(ctx, w, w, nil)
 	compileReq := rpc.CompileRequest{
 		Instance:   inst,
-		Fqbn:       fqbn,
+		Fqbn:       compileFqbn.String(),
 		SketchPath: sketchPath.String(),
 		BuildPath:  buildPath.String(),
 		Jobs:       platform.CompileJobs,

--- a/internal/orchestrator/sketch_flash.go
+++ b/internal/orchestrator/sketch_flash.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"slices"
+	"strings"
 
 	"github.com/arduino/arduino-cli/commands"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
@@ -156,4 +157,11 @@ func GetPlatformMenuOptions(ctx context.Context, platform platform.Platform) (Me
 		options = append(options, option)
 	}
 	return options, nil
+}
+
+func addOptionToFqbn(fqbn string, option MenuOptionValue) string {
+	if strings.Count(fqbn, ":") == 2 {
+		return fqbn + ":" + option.String()
+	}
+	return fqbn + "," + option.String()
 }

--- a/internal/orchestrator/sketch_flash.go
+++ b/internal/orchestrator/sketch_flash.go
@@ -11,7 +11,6 @@ import (
 	"log/slog"
 	"os"
 	"slices"
-	"strings"
 
 	"github.com/arduino/arduino-cli/commands"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
@@ -157,11 +156,4 @@ func GetPlatformMenuOptions(ctx context.Context, platform platform.Platform) (Me
 		options = append(options, option)
 	}
 	return options, nil
-}
-
-func addOptionToFqbn(fqbn string, option MenuOptionValue) string {
-	if strings.Count(fqbn, ":") == 2 {
-		return fqbn + ":" + option.String()
-	}
-	return fqbn + "," + option.String()
 }

--- a/internal/orchestrator/sketch_flash.go
+++ b/internal/orchestrator/sketch_flash.go
@@ -112,7 +112,7 @@ func (o MenuOptions) Has(optionValue MenuOptionValue) bool {
 	})
 }
 
-func GetPlatformMenuOptions(ctx context.Context, platform platform.Platform) (MenuOptions, error) {
+func GetPlatformMenuOptions(ctx context.Context, fqbn string) (MenuOptions, error) {
 	logrus.SetLevel(logrus.ErrorLevel) // Reduce the log level of arduino-cli
 	srv := commands.NewArduinoCoreServer()
 	if err := SetArduinoCliConfig(ctx, srv); err != nil {
@@ -141,7 +141,7 @@ func GetPlatformMenuOptions(ctx context.Context, platform platform.Platform) (Me
 
 	info, err := srv.BoardDetails(ctx, &rpc.BoardDetailsRequest{
 		Instance: inst,
-		Fqbn:     platform.FQBN,
+		Fqbn:     fqbn,
 	})
 	if err != nil {
 		return MenuOptions{}, err


### PR DESCRIPTION
### Motivation

Allow FQBN compilation target customization. There are some cases in which we would like to use a different FQBN as a compilation target, for instance, if we want to test a special platform or if we want to inject some compilation menu option.

### Change description

The FQBN will now be obtained from the following sources (the first one present wins):
- the one specified in the sketch.yaml
- then the one in the `platform.json` override file
- then the hardcoded one

In all of those cases, the fqbn will be enriched with the menu option `WaitForApp`.

### Additional Notes

- related to https://github.com/arduino/arduino-app-cli/issues/233

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
