### PR TITLE
[API] Add stop upgrade endpoint

### DIFF
--- a/cmd/gendoc/docs.go
+++ b/cmd/gendoc/docs.go
@@ -964,6 +964,22 @@ Contains a JSON object with the details of an error.
 			},
 		},
 		{
+			OperationId: "stopUpdate",
+			Method:      http.MethodPut,
+			Path:        "/v1/system/update/stop",
+			CustomSuccessResponse: &CustomResponseDef{
+				Description: "Successful response",
+				StatusCode:  http.StatusOK,
+			},
+			Description: "Stop the upgrade process.",
+			Summary:     "Stop the upgrade process in background",
+			Tags:        []Tag{SystemTag},
+			PossibleErrors: []ErrorResponse{
+				{StatusCode: http.StatusConflict, Reference: "#/components/responses/Conflict"},
+				{StatusCode: http.StatusInternalServerError, Reference: "#/components/responses/InternalServerError"},
+			},
+		},
+		{
 			OperationId: "applyUpdate",
 			Method:      http.MethodPut,
 			Path:        "/v1/system/update/apply",

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -59,7 +59,8 @@ func NewHTTPRouter(
 
 	mux.Handle("GET /v1/system/update/check", handlers.HandleCheckUpgradable(updater))
 	mux.Handle("GET /v1/system/update/events", handlers.HandleUpdateEvents(updater))
-	mux.Handle("PUT /v1/system/update/apply", handlers.HandleUpdateApply(updater))
+
+	mux.Handle("PUT /v1/system/update/stop", handlers.HandlerUpdateStop(updater))
 	mux.Handle("GET /v1/system/resources", handlers.HandleSystemResources(cfg))
 
 	mux.Handle("GET /v1/models", handlers.HandleModelsList(modelsIndex))

--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -1340,6 +1340,20 @@ paths:
       summary: SSE stream of the update process
       tags:
       - System
+  /v1/system/update/stop:
+    put:
+      description: Stop the upgrade process.
+      operationId: stopUpdate
+      responses:
+        "200":
+          description: Successful response
+        "409":
+          $ref: '#/components/responses/Conflict'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: Stop the upgrade process in background
+      tags:
+      - System
   /v1/version:
     get:
       description: returns the application current version

--- a/internal/api/handlers/update.go
+++ b/internal/api/handlers/update.go
@@ -115,6 +115,16 @@ func HandleUpdateApply(updater *update.Manager) http.HandlerFunc {
 	}
 }
 
+func HandlerUpdateStop(updater *update.Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if updater.StopUpgrade() {
+			render.EncodeResponse(w, http.StatusOK, "Upgrade operation cancellation requested")
+		} else {
+			render.EncodeResponse(w, http.StatusConflict, models.ErrorResponse{Details: "No upgrade operation in progress"})
+		}
+	}
+}
+
 func HandleUpdateEvents(updater *update.Manager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// HOTFIX: app-lab use HEAD requests to check endpoint availability

--- a/internal/e2e/client/client.gen.go
+++ b/internal/e2e/client/client.gen.go
@@ -846,6 +846,9 @@ type ClientInterface interface {
 	// EventsUpdate request
 	EventsUpdate(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// StopUpdate request
+	StopUpdate(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetVersions request
 	GetVersions(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
@@ -1440,6 +1443,18 @@ func (c *Client) CheckUpdate(ctx context.Context, params *CheckUpdateParams, req
 
 func (c *Client) EventsUpdate(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewEventsUpdateRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StopUpdate(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStopUpdateRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -3337,6 +3352,33 @@ func NewEventsUpdateRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewStopUpdateRequest generates requests for StopUpdate
+func NewStopUpdateRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/system/update/stop")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetVersionsRequest generates requests for GetVersions
 func NewGetVersionsRequest(server string) (*http.Request, error) {
 	var err error
@@ -3546,6 +3588,9 @@ type ClientWithResponsesInterface interface {
 
 	// EventsUpdateWithResponse request
 	EventsUpdateWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*EventsUpdateResp, error)
+
+	// StopUpdateWithResponse request
+	StopUpdateWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*StopUpdateResp, error)
 
 	// GetVersionsWithResponse request
 	GetVersionsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetVersionsResp, error)
@@ -4520,6 +4565,29 @@ func (r EventsUpdateResp) StatusCode() int {
 	return 0
 }
 
+type StopUpdateResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON409      *Conflict
+	JSON500      *InternalServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r StopUpdateResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StopUpdateResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetVersionsResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -4981,6 +5049,15 @@ func (c *ClientWithResponses) EventsUpdateWithResponse(ctx context.Context, reqE
 		return nil, err
 	}
 	return ParseEventsUpdateResp(rsp)
+}
+
+// StopUpdateWithResponse request returning *StopUpdateResp
+func (c *ClientWithResponses) StopUpdateWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*StopUpdateResp, error) {
+	rsp, err := c.StopUpdate(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStopUpdateResp(rsp)
 }
 
 // GetVersionsWithResponse request returning *GetVersionsResp
@@ -6625,6 +6702,39 @@ func ParseEventsUpdateResp(rsp *http.Response) (*EventsUpdateResp, error) {
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStopUpdateResp parses an HTTP response from a StopUpdateWithResponse call
+func ParseStopUpdateResp(rsp *http.Response) (*StopUpdateResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StopUpdateResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -8,6 +8,7 @@ package apt
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"iter"
@@ -15,6 +16,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/arduino/go-paths-helper"
 	"go.bug.st/f"
@@ -58,6 +60,8 @@ func (s *Service) ListUpgradablePackages(ctx context.Context, matcher func(updat
 	return pkgs, nil
 }
 
+const restartServicesTimeout = 5 * time.Minute
+
 // UpgradePackages upgrades the specified packages using the `apt-get upgrade` command.
 // It publishes events to subscribers during the upgrade process.
 // It returns an error if the upgrade is already in progress or if the upgrade command fails.
@@ -65,12 +69,20 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
 	// At the end of the upgrade, always try to restart the services (that need it).
 	// This makes sure key services are restarted even if an error happens in the upgrade steps (for examples container images download).
 	defer func() {
 		eventCB(update.NewDataEvent(update.RestartEvent, "Upgrade completed. Restarting ..."))
 
-		err := restartServices(ctx)
+		// Use a fresh context for restarting services, independent from the upgrade context,
+		// to ensure the restart always happens even if the upgrade was canceled or timed out.
+		restartCtx, restartCancel := context.WithTimeout(context.Background(), restartServicesTimeout)
+		defer restartCancel()
+
+		err := restartServices(restartCtx)
 		if err != nil {
 			eventCB(update.NewErrorEvent(fmt.Errorf("error restarting services after upgrade: %w", err)))
 			return
@@ -84,7 +96,12 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 	stream := runUpgradeCommand(ctx, names)
 	for line, err := range stream {
 		if err != nil {
-			return fmt.Errorf("error running upgrade command: %w", err)
+			if errors.Is(err, context.Canceled) {
+				eventCB(update.NewCancelEvent("Run upgrade operation canceled"))
+				return nil
+			} else {
+				return fmt.Errorf("error running upgrade command: %w", err)
+			}
 		}
 		eventCB(update.NewDataEvent(update.UpgradeLineEvent, line))
 	}
@@ -92,7 +109,12 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 	eventCB(update.NewDataEvent(update.StartEvent, "apt cleaning cache is starting"))
 	for line, err := range runAptCleanCommand(ctx) {
 		if err != nil {
-			return fmt.Errorf("error running apt clean command: %w", err)
+			if errors.Is(err, context.Canceled) {
+				eventCB(update.NewCancelEvent("Run apt clean operation canceled"))
+				return nil
+			} else {
+				return fmt.Errorf("error running apt clean command: %w", err)
+			}
 		}
 		eventCB(update.NewDataEvent(update.UpgradeLineEvent, line))
 	}
@@ -100,12 +122,21 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 	for line, err := range runSystemInit(ctx) {
 		if err != nil {
 			// In case of errors, including "out of disk space" erros, do a cleanup and then retry once.
+			if errors.Is(err, context.Canceled) {
+				eventCB(update.NewCancelEvent("Run system init operation canceled"))
+				return nil
+			}
 
 			eventCB(update.NewDataEvent(update.UpgradeLineEvent, "Stop and destroy docker containers and images, to free up space ..."))
 			streamCleanup := cleanupDockerContainers(ctx)
 			for line, err := range streamCleanup {
 				if err != nil {
-					slog.Warn("Error during cleanup of container and images", "error", err)
+					if errors.Is(err, context.Canceled) {
+						eventCB(update.NewCancelEvent("run docker cleanup operation canceled"))
+						return nil
+					} else {
+						slog.Warn("Error during cleanup of container and images", "error", err)
+					}
 				} else {
 					eventCB(update.NewDataEvent(update.UpgradeLineEvent, line))
 				}
@@ -115,7 +146,12 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 			eventCB(update.NewDataEvent(update.UpgradeLineEvent, "Pulling the latest docker images (again) ..."))
 			for line, err := range runSystemInit(ctx) {
 				if err != nil {
-					return fmt.Errorf("error pulling docker images: %w", err)
+					if errors.Is(err, context.Canceled) {
+						eventCB(update.NewCancelEvent("Run system init operation canceled"))
+						return nil
+					} else {
+						return fmt.Errorf("error pulling docker images: %w", err)
+					}
 				}
 				eventCB(update.NewDataEvent(update.UpgradeLineEvent, line))
 			}
@@ -129,7 +165,12 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 	streamCleanup := cleanupDockerContainers(ctx)
 	for line, err := range streamCleanup {
 		if err != nil {
-			slog.Warn("Error during cleanup of container and images", "error", err)
+			if errors.Is(err, context.Canceled) {
+				eventCB(update.NewCancelEvent("run docker cleanup operation canceled"))
+				return nil
+			} else {
+				slog.Warn("Error during cleanup of container and images", "error", err)
+			}
 		} else {
 			eventCB(update.NewDataEvent(update.UpgradeLineEvent, line))
 		}

--- a/internal/update/arduino/arduino.go
+++ b/internal/update/arduino/arduino.go
@@ -7,10 +7,12 @@ package arduino
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/arduino/arduino-cli/commands"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
@@ -192,6 +194,9 @@ func (a *ArduinoPlatformUpdater) UpgradePackages(ctx context.Context, packages [
 		eventCB(update.NewDataEvent(update.UpgradeLineEvent, data))
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
 	eventCB(update.NewDataEvent(update.StartEvent, "Upgrade is starting"))
 
 	logrus.SetLevel(logrus.ErrorLevel) // Reduce the log level of arduino-cli
@@ -202,7 +207,13 @@ func (a *ArduinoPlatformUpdater) UpgradePackages(ctx context.Context, packages [
 
 	var inst *rpc.Instance
 	if resp, err := srv.Create(ctx, &rpc.CreateRequest{}); err != nil {
-		return fmt.Errorf("error creating arduino-cli instance: %w", err)
+		if errors.Is(err, context.Canceled) {
+			slog.Info("Arduino instance creation canceled by user.")
+			eventCB(update.NewCancelEvent("Arduino instance creation canceled by user."))
+			return nil
+		} else {
+			return fmt.Errorf("error creating Arduino instance: %w", err)
+		}
 	} else {
 		inst = resp.GetInstance()
 	}
@@ -217,10 +228,22 @@ func (a *ArduinoPlatformUpdater) UpgradePackages(ctx context.Context, packages [
 	{
 		stream, _ := commands.UpdateIndexStreamResponseToCallbackFunction(ctx, downloadProgressCB)
 		if err := srv.UpdateIndex(&rpc.UpdateIndexRequest{Instance: inst}, stream); err != nil {
-			return fmt.Errorf("error updating index: %w", err)
+			if errors.Is(err, context.Canceled) {
+				slog.Info("Arduino index update canceled by user.")
+				eventCB(update.NewCancelEvent("Arduino index update canceled by user."))
+				return nil
+			} else {
+				return fmt.Errorf("error updating index: %w", err)
+			}
 		}
 		if err := srv.Init(&rpc.InitRequest{Instance: inst}, commands.InitStreamResponseToCallbackFunction(ctx, nil)); err != nil {
-			return fmt.Errorf("error initializing instance: %w", err)
+			if errors.Is(err, context.Canceled) {
+				slog.Info("Arduino instance initialization canceled by user.")
+				eventCB(update.NewCancelEvent("Arduino instance initialization canceled by user."))
+				return nil
+			} else {
+				return fmt.Errorf("error initializing instance: %w", err)
+			}
 		}
 	}
 
@@ -239,7 +262,13 @@ func (a *ArduinoPlatformUpdater) UpgradePackages(ctx context.Context, packages [
 		},
 		stream,
 	); err != nil {
-		return fmt.Errorf("error installing platform version %s: %w", targetVersion, err)
+		if errors.Is(err, context.Canceled) {
+			slog.Info("Arduino platform installation canceled by user.")
+			eventCB(update.NewCancelEvent("Arduino platform installation canceled by user."))
+			return nil
+		} else {
+			return fmt.Errorf("error installing platform version %s: %w", targetVersion, err)
+		}
 	}
 
 	cbw := orchestrator.NewCallbackWriter(func(line string) {
@@ -255,7 +284,13 @@ func (a *ArduinoPlatformUpdater) UpgradePackages(ctx context.Context, packages [
 		commands.BurnBootloaderToServerStreams(ctx, cbw, cbw),
 	)
 	if err != nil {
-		return fmt.Errorf("error burning bootloader: %w", err)
+		if errors.Is(err, context.Canceled) {
+			slog.Info("Arduino bootloader burning canceled by user.")
+			eventCB(update.NewCancelEvent("Arduino bootloader burning canceled by user."))
+			return nil
+		} else {
+			return fmt.Errorf("error burning bootloader: %w", err)
+		}
 	}
 
 	return nil

--- a/internal/update/event.go
+++ b/internal/update/event.go
@@ -16,6 +16,7 @@ const (
 	RestartEvent
 	DoneEvent
 	ErrorEvent
+	CancelEvent
 )
 
 // Event represents a single event in the upgrade process.
@@ -38,6 +39,8 @@ func (t EventType) String() string {
 		return "done"
 	case ErrorEvent:
 		return "error"
+	case CancelEvent:
+		return "cancel"
 	default:
 		panic("unreachable")
 	}
@@ -54,6 +57,13 @@ func NewErrorEvent(err error) Event {
 	return Event{
 		Type: ErrorEvent,
 		err:  err,
+	}
+}
+
+func NewCancelEvent(str string) Event {
+	return Event{
+		Type: CancelEvent,
+		data: str,
 	}
 }
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -51,8 +51,10 @@ type Manager struct {
 	debUpdateService             ServiceUpdater
 	arduinoPlatformUpdateService ServiceUpdater
 
-	mu   sync.RWMutex
-	subs map[chan Event]struct{}
+	mu                   sync.RWMutex
+	subs                 map[chan Event]struct{}
+	currentUpgradeCancel atomic.Pointer[context.CancelFunc]
+	currentCheckCancel   atomic.Pointer[context.CancelFunc]
 }
 
 func NewManager(debUpdateService ServiceUpdater, arduinoPlatformUpdateService ServiceUpdater) *Manager {
@@ -74,6 +76,10 @@ func (m *Manager) ListUpgradablePackages(ctx context.Context, matcher func(Upgra
 	if !isConnected() {
 		return nil, ErrNoInternetConnection
 	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	m.currentCheckCancel.Store(&cancel)
+	defer m.currentCheckCancel.Store(nil)
 
 	// Get the list of upgradable packages from two sources (deb and platform) in parallel.
 	g, ctx := errgroup.WithContext(ctx)
@@ -112,6 +118,7 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 	ctx = context.WithoutCancel(ctx)
 	var debPkgs []PackageInfo
 	var arduinoPlatform []PackageInfo
+
 	for _, v := range pkgs {
 		switch v.Type {
 		case Arduino:
@@ -130,6 +137,12 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 	go func() {
 		defer m.lock.Unlock()
 		defer m.isUpgrading.Store(false)
+
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		m.currentUpgradeCancel.Store(&cancel)
+		defer m.currentUpgradeCancel.Store(nil)
 
 		// We are launching on purpose the update sequentially. The reason is that
 		// the deb pkgs restart the orchestrator, and if we run in parallel the
@@ -150,6 +163,28 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 		m.broadcast(NewDataEvent(DoneEvent, "Update completed"))
 	}()
 	return nil
+}
+
+func (m *Manager) StopUpgrade() bool {
+	stoppedUpgrade := m.stopUpgrade()
+	stoppedCheck := m.stopCheck()
+	return stoppedUpgrade || stoppedCheck
+}
+
+func (m *Manager) stopUpgrade() bool {
+	if cancelFuncPtr := m.currentUpgradeCancel.Swap(nil); cancelFuncPtr != nil {
+		(*cancelFuncPtr)()
+		return true
+	}
+	return false
+
+}
+func (m *Manager) stopCheck() bool {
+	if cancelFuncPtr := m.currentCheckCancel.Swap(nil); cancelFuncPtr != nil {
+		(*cancelFuncPtr)()
+		return true
+	}
+	return false
 }
 
 // Subscribe creates a new channel for receiving APT events.


### PR DESCRIPTION
### Motivation
closes https://github.com/bcmi-labs/orchestrator/issues/382
### Change description
Adding API endpoint `PUT /v1/system/update/stop`.
It stops service and platform updates. 

The update cancellation is implemented via a SIGTERM signal (context cancellation) to allow for a graceful shutdown. 

`apt-get`, In some phases, traps this signal to complete its current critical operation before exiting, delaying the interruption. 


<!-- What does your code do? -->


### Additional Notes

### Test

- [ ]  Installing orchestrator with new features
- [ ] Start listening to events
  `curl -X GET localhost:8800/v1/system/update/events`
- [ ] Start updates
 `curl -X PUT localhost:8800/v1/system/update/apply`
- [ ] After 0,5 -1-3 seconds, stop updates
 `curl -X PUT localhost:8800/v1/system/update/stop`


### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
