### PR TITLE
fix: e2e test timeout

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -61,7 +61,7 @@ tasks:
 
   test:update:
     cmds:
-      - go tool gotest.tools/gotestsum -- -v -timeout=30m ./internal/e2e/updatetest
+      - go tool gotest.tools/gotestsum -- -v -timeout=60m ./internal/e2e/updatetest
 
   test:pkg:
     desc: Run only tests in the pkg directory

--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -7,7 +7,6 @@ package updatetest
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -47,7 +46,7 @@ func fetchDebPackageLatest(t *testing.T, path, repo string) string {
 	}
 	tag := fields[0]
 
-	fmt.Println("Repo:", repo, "Detected tag:", tag)
+	t.Logf("Repo: %s Detected tag: %s", repo, tag)
 	cmd2 := exec.Command(
 		"gh", "release", "download",
 		tag,
@@ -144,21 +143,13 @@ func buildDockerImage(t *testing.T, dockerfile, name, arch string) {
 	arch = fmt.Sprintf("ARCH=%s", arch)
 
 	cmd := exec.Command("docker", "build", "--build-arg", arch, "-t", name, "-f", dockerfile, ".")
-	// Capture both stdout and stderr
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
 
-	err := cmd.Run()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		fmt.Printf("❌ Docker build failed: %v\n", err)
-		fmt.Printf("---- STDERR ----\n%s\n", stderr.String())
-		fmt.Printf("---- STDOUT ----\n%s\n", out.String())
-		return
+		t.Fatalf("Docker build failed: %v\n%s", err, out)
 	}
 
-	fmt.Println("✅ Docker build succeeded!")
+	t.Log("Docker build succeeded!")
 }
 
 func startDockerContainer(t *testing.T, containerName string, containerImageName string) {
@@ -230,9 +221,9 @@ func removeDockerImage(t *testing.T, imageName string) {
 	t.Helper()
 
 	cmd := exec.Command("docker", "rmi", "-f", imageName)
-	fmt.Println("🧹 Removing Docker image " + imageName)
+	t.Log("Removing Docker image " + imageName)
 	if err := cmd.Run(); err != nil {
-		fmt.Printf("⚠️  Warning: could not remove image (might not exist): %v\n", err)
+		t.Logf("Warning: could not remove image: %v\n", err)
 	}
 }
 
@@ -241,11 +232,10 @@ func stopDockerContainer(t *testing.T, containerName string) {
 
 	cleanupCmd := exec.Command("docker", "rm", "-f", containerName)
 
-	fmt.Println("🧹 Removing Docker container " + containerName)
+	t.Log("Removing Docker container " + containerName)
 	if err := cleanupCmd.Run(); err != nil {
-		fmt.Printf("⚠️  Warning: could not remove container (might not exist): %v\n", err)
+		t.Logf("Warning: could not remove container: %v\n", err)
 	}
-
 }
 
 func putUpdateRequest(t *testing.T, host string) {

--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -39,12 +38,12 @@ func fetchDebPackageLatest(t *testing.T, path, repo string) string {
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Fatalf("command failed: %v\nOutput: %s", err, output)
+		t.Fatalf("command failed: %v\nOutput: %s", err, output)
 	}
 
 	fields := strings.Fields(string(output))
 	if len(fields) == 0 {
-		log.Fatal("could not parse tag from gh release list output")
+		t.Fatal("could not parse tag from gh release list output")
 	}
 	tag := fields[0]
 
@@ -59,7 +58,7 @@ func fetchDebPackageLatest(t *testing.T, path, repo string) string {
 
 	out, err := cmd2.CombinedOutput()
 	if err != nil {
-		log.Fatalf("download failed: %v\nOutput: %s", err, out)
+		t.Fatalf("download failed: %v\nOutput: %s", err, out)
 	}
 
 	return tag
@@ -86,7 +85,7 @@ func buildDebVersion(t *testing.T, storePath, tagVersion, arch string) {
 	)
 
 	if err := cmd.Run(); err != nil {
-		log.Fatalf("failed to run build command: %v", err)
+		t.Fatalf("failed to run build command: %v", err)
 	}
 }
 
@@ -118,7 +117,7 @@ func genMinorTag(t *testing.T, tag string) string {
 
 	parts := strings.Split(tag, ".")
 	if len(parts) != 3 {
-		log.Fatalf("invalid tag format: %s", tag)
+		t.Fatalf("invalid tag format: %s", tag)
 	}
 	majorPart := parts[0]
 	minorPart := parts[1]
@@ -148,8 +147,8 @@ func buildDockerImage(t *testing.T, dockerfile, name, arch string) {
 	// Capture both stdout and stderr
 	var out bytes.Buffer
 	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
 
 	err := cmd.Run()
 	if err != nil {
@@ -178,6 +177,9 @@ func startDockerContainer(t *testing.T, containerName string, containerImageName
 		containerImageName,
 	)
 
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to run container: %v", err)
 	}
@@ -195,7 +197,7 @@ func getAppCliVersion(t *testing.T, containerName string) string {
 	)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Fatalf("command failed: %v\nOutput: %s", err, output)
+		t.Fatalf("command failed: %v\nOutput: %s", err, output)
 	}
 
 	var version struct {
@@ -227,6 +229,16 @@ func runSystemUpdate(t *testing.T, containerName string) {
 	require.NoError(t, err, "system update failed")
 }
 
+func removeDockerImage(t *testing.T, imageName string) {
+	t.Helper()
+
+	cmd := exec.Command("docker", "rmi", "-f", imageName)
+	fmt.Println("🧹 Removing Docker image " + imageName)
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("⚠️  Warning: could not remove image (might not exist): %v\n", err)
+	}
+}
+
 func stopDockerContainer(t *testing.T, containerName string) {
 	t.Helper()
 
@@ -247,7 +259,7 @@ func putUpdateRequest(t *testing.T, host string) {
 
 	req, err := http.NewRequest(http.MethodPut, url, nil)
 	if err != nil {
-		log.Fatalf("Error creating request: %v", err)
+		t.Fatalf("Error creating request: %v", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -255,7 +267,7 @@ func putUpdateRequest(t *testing.T, host string) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Fatalf("Error sending request: %v", err)
+		t.Fatalf("Error sending request: %v", err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -147,8 +147,8 @@ func buildDockerImage(t *testing.T, dockerfile, name, arch string) {
 	// Capture both stdout and stderr
 	var out bytes.Buffer
 	var stderr bytes.Buffer
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
 
 	err := cmd.Run()
 	if err != nil {
@@ -176,9 +176,6 @@ func startDockerContainer(t *testing.T, containerName string, containerImageName
 		"--name", containerName,
 		containerImageName,
 	)
-
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
 
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to run container: %v", err)

--- a/internal/e2e/updatetest/test.Dockerfile
+++ b/internal/e2e/updatetest/test.Dockerfile
@@ -29,6 +29,9 @@ RUN usermod -aG docker arduino
 RUN echo "deb [trusted=yes arch=${ARCH}] file:/var/www/html/myrepo trixie main" \
     > /etc/apt/sources.list.d/my-mock-repo.list
 
+# Limit the tests to UNO Q (this reduces the number of pulled containers).
+RUN echo '{"board_name": "unoq"}' > /var/lib/arduino-app-cli/platform.json
+
 EXPOSE 8800
 # CMD: systemd must be PID 1
 CMD ["/sbin/init"]

--- a/internal/e2e/updatetest/update_test.go
+++ b/internal/e2e/updatetest/update_test.go
@@ -20,38 +20,57 @@ var arch = runtime.GOARCH
 const dockerFile = "test.Dockerfile"
 const daemonHost = "127.0.0.1:8800"
 
+// logStep logs the step name with a timestamp, runs fn, then logs how long it took.
+func logStep(t *testing.T, name string, fn func()) {
+	t.Helper()
+	fmt.Printf("➡️ [%s] %s starting...\n", time.Now().Format("15:04:05"), name)
+	start := time.Now()
+	fn()
+	fmt.Printf("⬅️ [%s] %s done in %s\n", time.Now().Format("15:04:05"), name, time.Since(start).Round(time.Millisecond))
+}
+
 func TestUpdatePackage(t *testing.T) {
 	fmt.Printf("***** ARCH %s ***** \n", arch)
 
-	t.Run("Stable To Current", func(t *testing.T) {
+	t.Run("StableToCurrent", func(t *testing.T) {
 		t.Cleanup(func() { os.RemoveAll("build") })
 
-		tagAppCli := fetchDebPackageLatest(t, "build/stable", "arduino/arduino-app-cli")
-		fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
-		fetchDebPackageLatest(t, "build/stable", "bcmi-labs/arduino-deb-packages")
+		var tagAppCli string
+		logStep(t, "fetch latest stable packages (StableToCurrent)", func() {
+			tagAppCli = fetchDebPackageLatest(t, "build/stable", "arduino/arduino-app-cli")
+			fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
+			fetchDebPackageLatest(t, "build/stable", "bcmi-labs/arduino-deb-packages")
+		})
 
 		majorTag := genMajorTag(t, tagAppCli)
+		t.Logf("Updating from stable version %s to unstable version %s", tagAppCli, majorTag)
 
-		fmt.Printf("Updating from stable version %s to unstable version %s \n", tagAppCli, majorTag)
-		fmt.Printf("Building local deb version %s \n", majorTag)
-		buildDebVersion(t, "build", majorTag, arch)
+		logStep(t, fmt.Sprintf("build deb version %s", majorTag), func() {
+			buildDebVersion(t, "build", majorTag, arch)
+		})
 
 		const dockerImageName = "apt-test-update-image"
-		fmt.Println("**** BUILD docker image *****")
-		buildDockerImage(t, dockerFile, dockerImageName, arch)
+		logStep(t, fmt.Sprintf("build docker image %s", dockerImageName), func() {
+			buildDockerImage(t, dockerFile, dockerImageName, arch)
+		})
 		t.Cleanup(func() { removeDockerImage(t, dockerImageName) })
 
 		t.Run("CLI Command", func(t *testing.T) {
 			const containerName = "apt-test-update"
 			t.Cleanup(func() { stopDockerContainer(t, containerName) })
 
-			fmt.Println("**** RUN docker image *****")
-			startDockerContainer(t, containerName, dockerImageName)
-			waitForPort(t, daemonHost, 5*time.Second)
+			logStep(t, fmt.Sprintf("start container %s and wait for daemon", containerName), func() {
+				startDockerContainer(t, containerName, dockerImageName)
+				waitForPort(t, daemonHost, 5*time.Second)
+			})
 
 			preUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+preUpdateVersion, tagAppCli)
-			runSystemUpdate(t, containerName)
+
+			logStep(t, "system update (CLI command)", func() {
+				runSystemUpdate(t, containerName)
+			})
+
 			postUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+postUpdateVersion, majorTag)
 		})
@@ -60,14 +79,18 @@ func TestUpdatePackage(t *testing.T) {
 			const containerName = "apt-test-update-http"
 			t.Cleanup(func() { stopDockerContainer(t, containerName) })
 
-			startDockerContainer(t, containerName, dockerImageName)
-			waitForPort(t, daemonHost, 5*time.Second)
+			logStep(t, fmt.Sprintf("start container %s and wait for daemon", containerName), func() {
+				startDockerContainer(t, containerName, dockerImageName)
+				waitForPort(t, daemonHost, 5*time.Second)
+			})
 
 			preUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+preUpdateVersion, tagAppCli)
 
-			putUpdateRequest(t, daemonHost)
-			waitForUpgrade(t, daemonHost)
+			logStep(t, "system update (HTTP request)", func() {
+				putUpdateRequest(t, daemonHost)
+				waitForUpgrade(t, daemonHost)
+			})
 
 			postUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+postUpdateVersion, majorTag)
@@ -78,33 +101,42 @@ func TestUpdatePackage(t *testing.T) {
 	t.Run("CurrentToStable", func(t *testing.T) {
 		t.Cleanup(func() { os.RemoveAll("build") })
 
-		tagAppCli := fetchDebPackageLatest(t, "build", "arduino/arduino-app-cli")
-		fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
-		fetchDebPackageLatest(t, "build/stable", "bcmi-labs/arduino-deb-packages")
+		var tagAppCli string
+		logStep(t, "fetch latest stable packages (CurrentToStable)", func() {
+			tagAppCli = fetchDebPackageLatest(t, "build", "arduino/arduino-app-cli")
+			fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
+			fetchDebPackageLatest(t, "build/stable", "bcmi-labs/arduino-deb-packages")
+		})
 
 		minorTag := genMinorTag(t, tagAppCli)
+		t.Logf("Updating from unstable version %s to stable version %s", minorTag, tagAppCli)
 
-		fmt.Printf("Updating from unstable version %s to stable version %s \n", minorTag, tagAppCli)
-		fmt.Printf("Building local deb version %s \n", minorTag)
-		buildDebVersion(t, "build/stable", minorTag, arch)
+		logStep(t, fmt.Sprintf("build deb version %s", minorTag), func() {
+			buildDebVersion(t, "build/stable", minorTag, arch)
+		})
 
-		fmt.Println("**** BUILD docker image *****")
 		const dockerImageName = "test-apt-update-unstable-image"
-
-		buildDockerImage(t, dockerFile, dockerImageName, arch)
+		logStep(t, fmt.Sprintf("build docker image %s", dockerImageName), func() {
+			buildDockerImage(t, dockerFile, dockerImageName, arch)
+		})
 		t.Cleanup(func() { removeDockerImage(t, dockerImageName) })
 
 		t.Run("CLI Command", func(t *testing.T) {
 			const containerName = "apt-test-update-unstable"
 			t.Cleanup(func() { stopDockerContainer(t, containerName) })
 
-			fmt.Println("**** RUN docker image *****")
-			startDockerContainer(t, containerName, dockerImageName)
-			waitForPort(t, daemonHost, 5*time.Second)
+			logStep(t, fmt.Sprintf("start container %s and wait for daemon", containerName), func() {
+				startDockerContainer(t, containerName, dockerImageName)
+				waitForPort(t, daemonHost, 5*time.Second)
+			})
 
 			preUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+preUpdateVersion, minorTag)
-			runSystemUpdate(t, containerName)
+
+			logStep(t, "system update (CLI command)", func() {
+				runSystemUpdate(t, containerName)
+			})
+
 			postUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+postUpdateVersion, tagAppCli)
 		})
@@ -113,14 +145,18 @@ func TestUpdatePackage(t *testing.T) {
 			const containerName = "apt-test-update--unstable-http"
 			t.Cleanup(func() { stopDockerContainer(t, containerName) })
 
-			startDockerContainer(t, containerName, dockerImageName)
-			waitForPort(t, daemonHost, 5*time.Second)
+			logStep(t, fmt.Sprintf("start container %s and wait for daemon", containerName), func() {
+				startDockerContainer(t, containerName, dockerImageName)
+				waitForPort(t, daemonHost, 5*time.Second)
+			})
 
 			preUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+preUpdateVersion, minorTag)
 
-			putUpdateRequest(t, daemonHost)
-			waitForUpgrade(t, daemonHost)
+			logStep(t, "system update (HTTP request)", func() {
+				putUpdateRequest(t, daemonHost)
+				waitForUpgrade(t, daemonHost)
+			})
 
 			postUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+postUpdateVersion, tagAppCli)

--- a/internal/e2e/updatetest/update_test.go
+++ b/internal/e2e/updatetest/update_test.go
@@ -20,56 +20,40 @@ var arch = runtime.GOARCH
 const dockerFile = "test.Dockerfile"
 const daemonHost = "127.0.0.1:8800"
 
-// logStep logs the step name with a timestamp, runs fn, then logs how long it took.
-func logStep(t *testing.T, name string, fn func()) {
-	t.Helper()
-	fmt.Printf("➡️ [%s] %s starting...\n", time.Now().Format("15:04:05"), name)
-	start := time.Now()
-	fn()
-	fmt.Printf("⬅️ [%s] %s done in %s\n", time.Now().Format("15:04:05"), name, time.Since(start).Round(time.Millisecond))
-}
-
 func TestUpdatePackage(t *testing.T) {
 	fmt.Printf("***** ARCH %s ***** \n", arch)
 
+	// Test that the upgrade works from the current version to a newer one (created on the fly).
 	t.Run("StableToCurrent", func(t *testing.T) {
 		t.Cleanup(func() { os.RemoveAll("build") })
 
-		var tagAppCli string
-		logStep(t, "fetch latest stable packages (StableToCurrent)", func() {
-			tagAppCli = fetchDebPackageLatest(t, "build/stable", "arduino/arduino-app-cli")
-			fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
-			fetchDebPackageLatest(t, "build/stable", "bcmi-labs/arduino-deb-packages")
-		})
+		tagAppCli := fetchDebPackageLatest(t, "build/stable", "arduino/arduino-app-cli")
+		fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
+		fetchDebPackageLatest(t, "build/stable", "bcmi-labs/arduino-deb-packages")
 
 		majorTag := genMajorTag(t, tagAppCli)
 		t.Logf("Updating from stable version %s to unstable version %s", tagAppCli, majorTag)
 
-		logStep(t, fmt.Sprintf("build deb version %s", majorTag), func() {
-			buildDebVersion(t, "build", majorTag, arch)
-		})
+		t.Logf("Building local deb version %s \n", majorTag)
+		buildDebVersion(t, "build", majorTag, arch)
 
 		const dockerImageName = "apt-test-update-image"
-		logStep(t, fmt.Sprintf("build docker image %s", dockerImageName), func() {
-			buildDockerImage(t, dockerFile, dockerImageName, arch)
-		})
+		t.Logf("Build docker image %s", dockerImageName)
+		buildDockerImage(t, dockerFile, dockerImageName, arch)
 		t.Cleanup(func() { removeDockerImage(t, dockerImageName) })
 
 		t.Run("CLI Command", func(t *testing.T) {
 			const containerName = "apt-test-update"
 			t.Cleanup(func() { stopDockerContainer(t, containerName) })
 
-			logStep(t, fmt.Sprintf("start container %s and wait for daemon", containerName), func() {
-				startDockerContainer(t, containerName, dockerImageName)
-				waitForPort(t, daemonHost, 5*time.Second)
-			})
+			t.Logf("start container %s and wait for daemon", containerName)
+			startDockerContainer(t, containerName, dockerImageName)
+			waitForPort(t, daemonHost, 5*time.Second)
 
 			preUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+preUpdateVersion, tagAppCli)
 
-			logStep(t, "system update (CLI command)", func() {
-				runSystemUpdate(t, containerName)
-			})
+			runSystemUpdate(t, containerName)
 
 			postUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+postUpdateVersion, majorTag)
@@ -79,63 +63,52 @@ func TestUpdatePackage(t *testing.T) {
 			const containerName = "apt-test-update-http"
 			t.Cleanup(func() { stopDockerContainer(t, containerName) })
 
-			logStep(t, fmt.Sprintf("start container %s and wait for daemon", containerName), func() {
-				startDockerContainer(t, containerName, dockerImageName)
-				waitForPort(t, daemonHost, 5*time.Second)
-			})
+			t.Logf("start container %s and wait for daemon", containerName)
+			startDockerContainer(t, containerName, dockerImageName)
+			waitForPort(t, daemonHost, 5*time.Second)
 
 			preUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+preUpdateVersion, tagAppCli)
 
-			logStep(t, "system update (HTTP request)", func() {
-				putUpdateRequest(t, daemonHost)
-				waitForUpgrade(t, daemonHost)
-			})
+			putUpdateRequest(t, daemonHost)
+			waitForUpgrade(t, daemonHost)
 
 			postUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+postUpdateVersion, majorTag)
 		})
-
 	})
 
+	// Test that the upgrade works from a newer version to the current one.
 	t.Run("CurrentToStable", func(t *testing.T) {
 		t.Cleanup(func() { os.RemoveAll("build") })
 
-		var tagAppCli string
-		logStep(t, "fetch latest stable packages (CurrentToStable)", func() {
-			tagAppCli = fetchDebPackageLatest(t, "build", "arduino/arduino-app-cli")
-			fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
-			fetchDebPackageLatest(t, "build/stable", "bcmi-labs/arduino-deb-packages")
-		})
+		tagAppCli := fetchDebPackageLatest(t, "build", "arduino/arduino-app-cli")
+		fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
+		fetchDebPackageLatest(t, "build/stable", "bcmi-labs/arduino-deb-packages")
 
 		minorTag := genMinorTag(t, tagAppCli)
 		t.Logf("Updating from unstable version %s to stable version %s", minorTag, tagAppCli)
 
-		logStep(t, fmt.Sprintf("build deb version %s", minorTag), func() {
-			buildDebVersion(t, "build/stable", minorTag, arch)
-		})
+		t.Logf("build deb version %s", minorTag)
+		buildDebVersion(t, "build/stable", minorTag, arch)
 
 		const dockerImageName = "test-apt-update-unstable-image"
-		logStep(t, fmt.Sprintf("build docker image %s", dockerImageName), func() {
-			buildDockerImage(t, dockerFile, dockerImageName, arch)
-		})
+		t.Logf("build docker image %s", dockerImageName)
+		buildDockerImage(t, dockerFile, dockerImageName, arch)
 		t.Cleanup(func() { removeDockerImage(t, dockerImageName) })
 
 		t.Run("CLI Command", func(t *testing.T) {
 			const containerName = "apt-test-update-unstable"
 			t.Cleanup(func() { stopDockerContainer(t, containerName) })
 
-			logStep(t, fmt.Sprintf("start container %s and wait for daemon", containerName), func() {
-				startDockerContainer(t, containerName, dockerImageName)
-				waitForPort(t, daemonHost, 5*time.Second)
-			})
+			t.Logf("start container %s and wait for daemon", containerName)
+			startDockerContainer(t, containerName, dockerImageName)
+			waitForPort(t, daemonHost, 5*time.Second)
 
 			preUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+preUpdateVersion, minorTag)
 
-			logStep(t, "system update (CLI command)", func() {
-				runSystemUpdate(t, containerName)
-			})
+			runSystemUpdate(t, containerName)
 
 			postUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+postUpdateVersion, tagAppCli)
@@ -145,23 +118,18 @@ func TestUpdatePackage(t *testing.T) {
 			const containerName = "apt-test-update--unstable-http"
 			t.Cleanup(func() { stopDockerContainer(t, containerName) })
 
-			logStep(t, fmt.Sprintf("start container %s and wait for daemon", containerName), func() {
-				startDockerContainer(t, containerName, dockerImageName)
-				waitForPort(t, daemonHost, 5*time.Second)
-			})
+			t.Logf("start container %s and wait for daemon", containerName)
+			startDockerContainer(t, containerName, dockerImageName)
+			waitForPort(t, daemonHost, 5*time.Second)
 
 			preUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+preUpdateVersion, minorTag)
 
-			logStep(t, "system update (HTTP request)", func() {
-				putUpdateRequest(t, daemonHost)
-				waitForUpgrade(t, daemonHost)
-			})
+			putUpdateRequest(t, daemonHost)
+			waitForUpgrade(t, daemonHost)
 
 			postUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+postUpdateVersion, tagAppCli)
 		})
-
 	})
-
 }

--- a/internal/e2e/updatetest/update_test.go
+++ b/internal/e2e/updatetest/update_test.go
@@ -39,7 +39,7 @@ func TestUpdatePackage(t *testing.T) {
 		const dockerImageName = "apt-test-update-image"
 		fmt.Println("**** BUILD docker image *****")
 		buildDockerImage(t, dockerFile, dockerImageName, arch)
-		//TODO: t cleanup remove docker image
+		t.Cleanup(func() { removeDockerImage(t, dockerImageName) })
 
 		t.Run("CLI Command", func(t *testing.T) {
 			const containerName = "apt-test-update"
@@ -92,7 +92,7 @@ func TestUpdatePackage(t *testing.T) {
 		const dockerImageName = "test-apt-update-unstable-image"
 
 		buildDockerImage(t, dockerFile, dockerImageName, arch)
-		// TODO: t cleanup remove docker image
+		t.Cleanup(func() { removeDockerImage(t, dockerImageName) })
 
 		t.Run("CLI Command", func(t *testing.T) {
 			const containerName = "apt-test-update-unstable"


### PR DESCRIPTION
Reduce the number of container images downloaded, by limiting the test to a "unoq" board.
This should reduce the timeout errors in the e2e tests.

Test run here: https://github.com/arduino/arduino-app-cli/actions/runs/26164192467
