### PR TITLE
fix(pkg/board): add permission handling in fs

### DIFF
--- a/pkg/board/remote/adb/adb.go
+++ b/pkg/board/remote/adb/adb.go
@@ -8,6 +8,7 @@ package adb
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"io"
@@ -170,12 +171,9 @@ func (a *ADBConnection) Stats(p string) (remote.FileInfo, error) {
 	if err != nil {
 		return remote.FileInfo{}, err
 	}
-	output, err := runCmd.RunAndCaptureCombinedOutput(context.TODO())
-	if err != nil {
-		return remote.FileInfo{}, fmt.Errorf("failed to stat path %q: %w: %s", p, err, output)
-	}
-
-	return remote.ParseStatOutput(output)
+	output, err1 := runCmd.RunAndCaptureCombinedOutput(context.TODO())
+	info, err2 := remote.ParseStatOutput(output)
+	return info, cmp.Or(err2, err1)
 }
 
 func (a *ADBConnection) ReadFile(path string) (io.ReadCloser, error) {

--- a/pkg/board/remote/adb/adb.go
+++ b/pkg/board/remote/adb/adb.go
@@ -11,11 +11,9 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/fs"
 	"log/slog"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -168,43 +166,16 @@ func (a *ADBConnection) List(path string) ([]remote.FileInfo, error) {
 }
 
 func (a *ADBConnection) Stats(p string) (remote.FileInfo, error) {
-	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "file", strconv.Quote(p))
+	runCmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "stat", "-c", "'%A %n'", strconv.Quote(p))
 	if err != nil {
 		return remote.FileInfo{}, err
 	}
-	output, err := cmd.StdoutPipe()
+	output, err := runCmd.RunAndCaptureCombinedOutput(context.TODO())
 	if err != nil {
-		return remote.FileInfo{}, err
-	}
-	defer output.Close()
-	if err := cmd.Start(); err != nil {
-		return remote.FileInfo{}, err
-	}
-	defer func() { _ = cmd.Wait() }()
-
-	r := bufio.NewReader(output)
-	line, err := r.ReadBytes('\n')
-	if err != nil {
-		return remote.FileInfo{}, err
+		return remote.FileInfo{}, fmt.Errorf("failed to stat path %q: %w: %s", p, err, output)
 	}
 
-	line = bytes.TrimSpace(line)
-	parts := bytes.Split(line, []byte(":"))
-	if len(parts) < 2 {
-		return remote.FileInfo{}, fmt.Errorf("unexpected file command output: %s", line)
-	}
-
-	name := string(bytes.TrimSpace(parts[0]))
-	other := string(bytes.TrimSpace(parts[1]))
-
-	if strings.Contains(other, "cannot open") {
-		return remote.FileInfo{}, fs.ErrNotExist
-	}
-
-	return remote.FileInfo{
-		Name:  path.Base(name),
-		IsDir: other == "directory",
-	}, nil
+	return remote.ParseStatOutput(output)
 }
 
 func (a *ADBConnection) ReadFile(path string) (io.ReadCloser, error) {
@@ -216,7 +187,7 @@ func (a *ADBConnection) WriteFile(r io.Reader, path string) error {
 }
 
 func (a *ADBConnection) MkDirAll(path string) error {
-	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "install", "-o", username, "-g", username, "-m", "755", "-d", strconv.Quote(path))
+	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "install", "-o", username, "-g", username, "-m", "775", "-d", strconv.Quote(path))
 	if err != nil {
 		return err
 	}

--- a/pkg/board/remote/adb/adb_nowindows.go
+++ b/pkg/board/remote/adb/adb_nowindows.go
@@ -42,7 +42,7 @@ func adbReadFile(a *ADBConnection, path string) (io.ReadCloser, error) {
 
 func adbWriteFile(a *ADBConnection, r io.Reader, pathStr string) error {
 	// Create the file with the correct permissions and ownership
-	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "install", "-o", username, "-g", username, "-m", "0644", "/dev/null", pathStr) // nolint:gosec
+	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "install", "-o", username, "-g", username, "-m", "0664", "/dev/null", pathStr) // nolint:gosec
 	if err != nil {
 		return fmt.Errorf("failed to create command for creating file %q: %w", pathStr, err)
 	}

--- a/pkg/board/remote/adb/adb_windows.go
+++ b/pkg/board/remote/adb/adb_windows.go
@@ -46,7 +46,7 @@ func adbReadFile(a *ADBConnection, path string) (io.ReadCloser, error) {
 
 func adbWriteFile(a *ADBConnection, r io.Reader, pathStr string) error {
 	// Create the file with the correct permissions and ownership
-	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "install", "-o", username, "-g", username, "-m", "0644", "/dev/null", pathStr) // nolint:gosec
+	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "install", "-o", username, "-g", username, "-m", "0664", "/dev/null", pathStr) // nolint:gosec
 	if err != nil {
 		return fmt.Errorf("cannot create process: %w", err)
 	}

--- a/pkg/board/remote/local/local.go
+++ b/pkg/board/remote/local/local.go
@@ -40,9 +40,14 @@ func (a *LocalConnection) List(path string) ([]remote.FileInfo, error) {
 	}
 
 	return f.Map(dirs, func(d fs.DirEntry) remote.FileInfo {
+		var mode fs.FileMode
+		if info, err := d.Info(); err == nil {
+			mode = info.Mode().Perm()
+		}
 		return remote.FileInfo{
 			Name:  d.Name(),
 			IsDir: d.IsDir(),
+			Mode:  uint32(mode),
 		}
 	}), nil
 }
@@ -56,6 +61,7 @@ func (a *LocalConnection) Stats(path string) (remote.FileInfo, error) {
 	return remote.FileInfo{
 		Name:  info.Name(),
 		IsDir: info.IsDir(),
+		Mode:  uint32(info.Mode().Perm()),
 	}, nil
 }
 
@@ -78,7 +84,7 @@ func (a *LocalConnection) WriteFile(r io.Reader, path string) error {
 }
 
 func (a *LocalConnection) MkDirAll(path string) error {
-	return os.MkdirAll(path, 0700)
+	return os.MkdirAll(path, 0775)
 }
 
 func (a *LocalConnection) Remove(path string) error {

--- a/pkg/board/remote/parser.go
+++ b/pkg/board/remote/parser.go
@@ -10,7 +10,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
+	"path"
 	"strings"
+
+	"go.bug.st/f"
 )
 
 func ParseChage(r io.Reader) (bool, error) {
@@ -32,38 +36,83 @@ func ParseChage(r io.Reader) (bool, error) {
 	return false, fmt.Errorf("unexpected output from chage command")
 }
 
-// ParseLsOutput parses the output of the `ls -laQ` command and returns a slice of FileInfo.
-func ParseLsOutput(out io.Reader) ([]FileInfo, error) {
-	// skip the first line which contains the total size
-	r := bufio.NewReader(out)
-	if _, err := r.ReadBytes('\n'); err != nil {
-		return nil, err
+// ParseStatOutput parses the output of the `stat -c "%A %n"`
+func ParseStatOutput(out []byte) (FileInfo, error) {
+	out = bytes.TrimSpace(out)
+	if bytes.HasPrefix(out, []byte("stat: ")) {
+		if bytes.Contains(out, []byte("No such file or directory")) {
+			return FileInfo{}, os.ErrNotExist
+		}
+		return FileInfo{}, fmt.Errorf("unexpected stat output: %q", string(out))
 	}
 
-	var files []FileInfo
-	for {
-		line, err := r.ReadBytes('\n')
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, err
+	if len(out) < 12 {
+		return FileInfo{}, fmt.Errorf("unexpected stat output: %q", string(out))
+	}
+	perm := out[:10]
+	name := out[11:] // skip the space after perm
+	return FileInfo{
+		Name:  path.Base(string(name)),
+		IsDir: perm[0] == 'd',
+		Mode:  parsePermissions(perm),
+	}, nil
+}
+
+// parsePermissions parses a Unix permission string like "-rwxr-xr-x" into an os.FileMode.
+func parsePermissions(s []byte) uint32 {
+	f.Assert(len(s) == 10, "permission string must be 10 characters long")
+
+	var mode uint32
+	bits := []struct {
+		char byte
+		bit  uint32
+	}{
+		{s[1], 0400}, {s[2], 0200}, {s[3], 0100},
+		{s[4], 0040}, {s[5], 0020}, {s[6], 0010},
+		{s[7], 0004}, {s[8], 0002}, {s[9], 0001},
+	}
+	for _, b := range bits {
+		if b.char != '-' {
+			mode |= b.bit
 		}
-		line = bytes.TrimSpace(line)
+	}
+	return mode
+}
+
+// ParseLsOutput parses the output of the `ls -laQ` command and returns a slice of FileInfo.
+func ParseLsOutput(out io.Reader) ([]FileInfo, error) {
+	var files []FileInfo
+	scanner := bufio.NewScanner(out)
+	first := true
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if first {
+			first = false
+			if strings.HasPrefix(line, "total") {
+				continue
+			}
+		}
 		if len(line) == 0 {
 			continue
 		}
-		first := strings.IndexByte(string(line), '"')
-		last := strings.LastIndexByte(string(line), '"')
-		name := string(line[first+1 : last])
+		first_quote := strings.IndexByte(line, '"')
+		last_quote := strings.LastIndexByte(line, '"')
+		if first_quote < 0 || last_quote <= first_quote {
+			continue
+		}
+		name := line[first_quote+1 : last_quote]
 		if name == "." || name == ".." {
 			continue
 		}
+		mode := parsePermissions([]byte(line[:10]))
 		files = append(files, FileInfo{
 			Name:  name,
 			IsDir: line[0] == 'd',
+			Mode:  mode,
 		})
 	}
-
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
 	return files, nil
 }

--- a/pkg/board/remote/parser.go
+++ b/pkg/board/remote/parser.go
@@ -103,6 +103,9 @@ func ParseLsOutput(out io.Reader) ([]FileInfo, error) {
 		if name == "." || name == ".." {
 			continue
 		}
+		if len(line) < 10 {
+			return nil, fmt.Errorf("unexpected ls output line: %q", line)
+		}
 		mode := parsePermissions([]byte(line[:10]))
 		files = append(files, FileInfo{
 			Name:  name,

--- a/pkg/board/remote/parser.go
+++ b/pkg/board/remote/parser.go
@@ -57,7 +57,7 @@ func ParseStatOutput(out []byte) (FileInfo, error) {
 	}, nil
 }
 
-// parsePermissions parses a Unix permission string like "-rwxr-xr-x" into an os.FileMode.
+// parsePermissions parses a Unix permission string like "-rwxr-xr-x" into a uint32 Unix permission bitmask.
 func parsePermissions(s []byte) uint32 {
 	f.Assert(len(s) == 10, "permission string must be 10 characters long")
 

--- a/pkg/board/remote/parser.go
+++ b/pkg/board/remote/parser.go
@@ -94,12 +94,12 @@ func ParseLsOutput(out io.Reader) ([]FileInfo, error) {
 		if len(line) == 0 {
 			continue
 		}
-		first_quote := strings.IndexByte(line, '"')
-		last_quote := strings.LastIndexByte(line, '"')
-		if first_quote < 0 || last_quote <= first_quote {
+		firstQuote := strings.IndexByte(line, '"')
+		lastQuote := strings.LastIndexByte(line, '"')
+		if firstQuote < 0 || lastQuote <= firstQuote {
 			continue
 		}
-		name := line[first_quote+1 : last_quote]
+		name := line[firstQuote+1 : lastQuote]
 		if name == "." || name == ".." {
 			continue
 		}

--- a/pkg/board/remote/parser.go
+++ b/pkg/board/remote/parser.go
@@ -46,15 +46,14 @@ func ParseStatOutput(out []byte) (FileInfo, error) {
 		return FileInfo{}, fmt.Errorf("unexpected stat output: %q", string(out))
 	}
 
-	if len(out) < 12 {
+	perm, name, ok := strings.Cut(string(out), " ")
+	if !ok || len(perm) < 10 {
 		return FileInfo{}, fmt.Errorf("unexpected stat output: %q", string(out))
 	}
-	perm := out[:10]
-	name := out[11:] // skip the space after perm
 	return FileInfo{
 		Name:  path.Base(string(name)),
 		IsDir: perm[0] == 'd',
-		Mode:  parsePermissions(perm),
+		Mode:  parsePermissions([]byte(perm[:10])), // make sure to pass only permissions bit.
 	}, nil
 }
 

--- a/pkg/board/remote/remote.go
+++ b/pkg/board/remote/remote.go
@@ -16,6 +16,7 @@ var ErrPortAvailable = fmt.Errorf("port is not available")
 type FileInfo struct {
 	Name  string
 	IsDir bool
+	Mode  uint32
 }
 
 type RemoteConn interface {

--- a/pkg/board/remote/remote_test.go
+++ b/pkg/board/remote/remote_test.go
@@ -77,7 +77,9 @@ func TestRemoteFS(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("Mkdir", func(t *testing.T) {
 				for _, dir := range dirs {
-					err := tc.conn.MkDirAll("./" + dir)
+					_, err := tc.conn.Stats("./" + dir)
+					require.ErrorIs(t, err, os.ErrNotExist)
+					err = tc.conn.MkDirAll("./" + dir)
 					require.NoError(t, err)
 					info, err := tc.conn.Stats("./" + dir)
 					require.NoError(t, err)
@@ -90,7 +92,9 @@ func TestRemoteFS(t *testing.T) {
 			t.Run("WriteFile/ReadFile", func(t *testing.T) {
 				for _, file := range files {
 					t.Run(file, func(t *testing.T) {
-						err := tc.conn.WriteFile(strings.NewReader("Hello, World!"), "./"+file)
+						_, err := tc.conn.Stats("./" + file)
+						require.ErrorIs(t, err, os.ErrNotExist)
+						err = tc.conn.WriteFile(strings.NewReader("Hello, World!"), "./"+file)
 						require.NoError(t, err)
 						info, err := tc.conn.Stats("./" + file)
 						require.NoError(t, err)
@@ -134,17 +138,21 @@ func TestRemoteFS(t *testing.T) {
 
 			t.Run("Remove", func(t *testing.T) {
 				for _, file := range files {
-					err := tc.conn.Remove("./" + file)
+					_, err := tc.conn.Stats("./" + file)
+					assert.NoError(t, err)
+					err = tc.conn.Remove("./" + file)
 					require.NoError(t, err)
 					_, err = tc.conn.Stats("./" + file)
-					assert.Error(t, err)
+					assert.ErrorIs(t, err, os.ErrNotExist)
 				}
 
 				for _, dir := range dirs {
-					err := tc.conn.Remove("./" + dir)
+					_, err := tc.conn.Stats("./" + dir)
+					assert.NoError(t, err)
+					err = tc.conn.Remove("./" + dir)
 					require.NoError(t, err)
 					_, err = tc.conn.Stats("./" + dir)
-					assert.Error(t, err)
+					assert.ErrorIs(t, err, os.ErrNotExist)
 				}
 			})
 		})

--- a/pkg/board/remote/remote_test.go
+++ b/pkg/board/remote/remote_test.go
@@ -87,9 +87,9 @@ func TestRemoteFS(t *testing.T) {
 					require.NoError(t, err)
 					info, err := tc.conn.Stats(prefix + dir)
 					require.NoError(t, err)
-					assert.Equal(t, info.Name, dir)
+					assert.Equal(t, dir, info.Name)
 					assert.True(t, info.IsDir)
-					assert.Equal(t, info.Mode&0700, uint32(0700), "directory should be accessible by owner")
+					assert.Equal(t, uint32(0700), info.Mode&0700, "directory should be accessible by owner")
 				}
 			})
 

--- a/pkg/board/remote/remote_test.go
+++ b/pkg/board/remote/remote_test.go
@@ -81,10 +81,9 @@ func TestRemoteFS(t *testing.T) {
 					require.NoError(t, err)
 					info, err := tc.conn.Stats("./" + dir)
 					require.NoError(t, err)
-					assert.Equal(t, remote.FileInfo{
-						Name:  dir,
-						IsDir: true,
-					}, info)
+					assert.Equal(t, info.Name, dir)
+					assert.True(t, info.IsDir)
+					assert.Equal(t, info.Mode&0700, uint32(0700), "directory should be accessible by owner")
 				}
 			})
 
@@ -95,11 +94,9 @@ func TestRemoteFS(t *testing.T) {
 						require.NoError(t, err)
 						info, err := tc.conn.Stats("./" + file)
 						require.NoError(t, err)
-						assert.Equal(t, remote.FileInfo{
-							Name:  path.Base(file),
-							IsDir: false,
-						}, info)
-
+						assert.Equal(t, path.Base(file), info.Name)
+						assert.False(t, info.IsDir)
+						assert.Equal(t, uint32(0600), info.Mode&0700, "file should be readable and writable by owner")
 						r, err := tc.conn.ReadFile("./" + file)
 						require.NoError(t, err)
 						data, err := io.ReadAll(r)
@@ -113,7 +110,11 @@ func TestRemoteFS(t *testing.T) {
 				gotFiles, err := tc.conn.List("./")
 				require.NoError(t, err)
 				for _, dir := range dirs {
-					assert.Contains(t, gotFiles, remote.FileInfo{Name: dir, IsDir: true})
+					for _, gotFile := range gotFiles {
+						if gotFile.Name == dir && gotFile.IsDir {
+							assert.Equal(t, uint32(0700), gotFile.Mode&0700, "directory should be accessible by owner")
+						}
+					}
 				}
 
 				for _, dir := range dirs {
@@ -121,7 +122,12 @@ func TestRemoteFS(t *testing.T) {
 					require.NoError(t, err)
 					assert.Len(t, gotFiles, 2)
 					for _, gotFile := range gotFiles {
-						assert.Contains(t, files, path.Join(dir, gotFile.Name))
+						for _, file := range files {
+							if path.Join(dir, gotFile.Name) == file {
+								assert.False(t, gotFile.IsDir)
+								assert.Equal(t, gotFile.Mode&0700, uint32(0600), "file should be readable and writable by owner")
+							}
+						}
 					}
 				}
 			})
@@ -334,10 +340,8 @@ func TestRemoteTransfer(t *testing.T) {
 
 				info, err := tc.conn.Stats("./testdir/pushfile.txt")
 				require.NoError(t, err)
-				assert.Equal(t, remote.FileInfo{
-					Name:  "pushfile.txt",
-					IsDir: false,
-				}, info)
+				assert.Equal(t, "pushfile.txt", info.Name)
+				assert.False(t, info.IsDir)
 
 				r, err := tc.conn.ReadFile("./testdir/pushfile.txt")
 				require.NoError(t, err)
@@ -352,18 +356,18 @@ func TestRemoteTransfer(t *testing.T) {
 
 				info, err := tc.conn.Stats("./testdir/pushdir")
 				require.NoError(t, err)
-				assert.Equal(t, remote.FileInfo{
-					Name:  "pushdir",
-					IsDir: true,
-				}, info)
+				assert.Equal(t, "pushdir", info.Name)
+				assert.True(t, info.IsDir)
 
 				info, err = tc.conn.Stats("./testdir/pushdir/a.txt")
 				require.NoError(t, err)
-				assert.Equal(t, remote.FileInfo{Name: "a.txt", IsDir: false}, info)
+				assert.Equal(t, "a.txt", info.Name)
+				assert.False(t, info.IsDir)
 
 				info, err = tc.conn.Stats("./testdir/pushdir/nested")
 				require.NoError(t, err)
-				assert.Equal(t, remote.FileInfo{Name: "nested", IsDir: true}, info)
+				assert.Equal(t, "nested", info.Name)
+				assert.True(t, info.IsDir)
 
 				r, err := tc.conn.ReadFile("./testdir/pushdir/a.txt")
 				require.NoError(t, err)
@@ -388,10 +392,8 @@ func TestRemoteTransfer(t *testing.T) {
 
 				info, err := tc.conn.Stats("./testdir/pushfile.txt")
 				require.NoError(t, err)
-				assert.Equal(t, remote.FileInfo{
-					Name:  "pushfile.txt",
-					IsDir: false,
-				}, info)
+				assert.Equal(t, "pushfile.txt", info.Name)
+				assert.False(t, info.IsDir)
 
 				r, err := tc.conn.ReadFile("./testdir/pushfile.txt")
 				require.NoError(t, err)

--- a/pkg/board/remote/remote_test.go
+++ b/pkg/board/remote/remote_test.go
@@ -629,15 +629,17 @@ func TestRemoteTransferBehavioralCheck(t *testing.T) {
 					t.Cleanup(func() { _ = impl.conn.Remove(remoteDir) })
 
 					// Build local source.
-					src := filepath.Join(t.TempDir(), name)
+					tmp := t.TempDir()
+					src := filepath.Join(tmp, name)
 					switch tc.srcKind {
 					case file:
-						require.NoError(t, os.WriteFile(src, []byte("hello"), 0600))
+						require.NoError(t, os.WriteFile(src, []byte("hello"), 0440)) //nolint:gosec
 					case dir:
-						require.NoError(t, os.MkdirAll(src, 0755))
-						require.NoError(t, os.WriteFile(filepath.Join(src, "a.txt"), []byte("hello"), 0600))
+						require.NoError(t, os.MkdirAll(src, 0730))                                           //nolint:gosec
+						require.NoError(t, os.WriteFile(filepath.Join(src, "a.txt"), []byte("hello"), 0440)) //nolint:gosec
+						require.NoError(t, os.Chmod(src, 0530))
 					case emptyDir:
-						require.NoError(t, os.MkdirAll(src, 0755))
+						require.NoError(t, os.MkdirAll(src, 0530)) //nolint:gosec
 					}
 
 					// Pre-create destination if required.
@@ -652,6 +654,15 @@ func TestRemoteTransferBehavioralCheck(t *testing.T) {
 					case emptyDir:
 						require.NoError(t, impl.conn.MkDirAll(dst))
 					}
+					defer func() {
+						_ = os.Chmod(tmp, 0777) //nolint:gosec
+						_ = filepath.WalkDir(tmp, func(path string, d os.DirEntry, err error) error {
+							if err != nil {
+								return nil
+							}
+							return os.Chmod(path, 0777) //nolint:gosec
+						})
+					}()
 
 					// Perform the push operation.
 					err := impl.conn.Push(t.Context(), src, dst)
@@ -677,8 +688,10 @@ func TestRemoteTransferBehavioralCheck(t *testing.T) {
 					switch tc.wantKind {
 					case file:
 						assert.Equal(t, "hello", readRemoteFile(t, impl.conn, dst))
+						assert.Equal(t, uint32(0600), info.Mode&0700, "files should be accessible by owner")
 					case dir:
 						assert.True(t, info.IsDir)
+						assert.Equal(t, uint32(0700), info.Mode&0700, "files should be accessible by owner")
 						assert.Equal(t,
 							"hello",
 							readRemoteFile(t, impl.conn, path.Join(dst, "/a.txt")),
@@ -692,7 +705,9 @@ func TestRemoteTransferBehavioralCheck(t *testing.T) {
 						}
 					case emptyDir:
 						assert.True(t, info.IsDir)
+						assert.Equal(t, uint32(0700), info.Mode&0700, "files should be accessible by owner")
 					}
+
 				})
 			}
 		})

--- a/pkg/board/remote/remote_test.go
+++ b/pkg/board/remote/remote_test.go
@@ -649,7 +649,7 @@ func TestRemoteTransferBehavioralCheck(t *testing.T) {
 
 					// Build local source.
 					tmp := t.TempDir()
-					src := filepath.Join(tmp, name)
+					src := filepath.Join(tmp, tc.srcName)
 					switch tc.srcKind {
 					case file:
 						require.NoError(t, os.WriteFile(src, []byte("hello"), 0440)) //nolint:gosec

--- a/pkg/board/remote/remote_test.go
+++ b/pkg/board/remote/remote_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.bug.st/f"
 
 	"github.com/arduino/arduino-app-cli/internal/testtools"
 	"github.com/arduino/arduino-app-cli/pkg/board/remote"
@@ -75,13 +76,16 @@ func TestRemoteFS(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			prefix := fmt.Sprintf("./testdir_%s/", tc.name)
+			tc.conn.MkDirAll(prefix)
+
 			t.Run("Mkdir", func(t *testing.T) {
 				for _, dir := range dirs {
-					_, err := tc.conn.Stats("./" + dir)
+					_, err := tc.conn.Stats(prefix + dir)
 					require.ErrorIs(t, err, os.ErrNotExist)
-					err = tc.conn.MkDirAll("./" + dir)
+					err = tc.conn.MkDirAll(prefix + dir)
 					require.NoError(t, err)
-					info, err := tc.conn.Stats("./" + dir)
+					info, err := tc.conn.Stats(prefix + dir)
 					require.NoError(t, err)
 					assert.Equal(t, info.Name, dir)
 					assert.True(t, info.IsDir)
@@ -92,16 +96,16 @@ func TestRemoteFS(t *testing.T) {
 			t.Run("WriteFile/ReadFile", func(t *testing.T) {
 				for _, file := range files {
 					t.Run(file, func(t *testing.T) {
-						_, err := tc.conn.Stats("./" + file)
+						_, err := tc.conn.Stats(prefix + file)
 						require.ErrorIs(t, err, os.ErrNotExist)
-						err = tc.conn.WriteFile(strings.NewReader("Hello, World!"), "./"+file)
+						err = tc.conn.WriteFile(strings.NewReader("Hello, World!"), prefix+file)
 						require.NoError(t, err)
-						info, err := tc.conn.Stats("./" + file)
+						info, err := tc.conn.Stats(prefix + file)
 						require.NoError(t, err)
 						assert.Equal(t, path.Base(file), info.Name)
 						assert.False(t, info.IsDir)
 						assert.Equal(t, uint32(0600), info.Mode&0700, "file should be readable and writable by owner")
-						r, err := tc.conn.ReadFile("./" + file)
+						r, err := tc.conn.ReadFile(prefix + file)
 						require.NoError(t, err)
 						data, err := io.ReadAll(r)
 						require.NoError(t, err)
@@ -111,47 +115,54 @@ func TestRemoteFS(t *testing.T) {
 			})
 
 			t.Run("List", func(t *testing.T) {
-				gotFiles, err := tc.conn.List("./")
+				gotFiles, err := tc.conn.List(prefix)
 				require.NoError(t, err)
-				for _, dir := range dirs {
-					for _, gotFile := range gotFiles {
-						if gotFile.Name == dir && gotFile.IsDir {
-							assert.Equal(t, uint32(0700), gotFile.Mode&0700, "directory should be accessible by owner")
-						}
-					}
+
+				gotDirs := f.Filter(gotFiles, func(f remote.FileInfo) bool {
+					return f.IsDir
+				})
+
+				assert.ElementsMatch(t, dirs, f.Map(gotDirs, func(f remote.FileInfo) string {
+					return f.Name
+				}), "should contain the expected directories")
+
+				for _, dir := range gotDirs {
+					assert.Equal(t, dir.Mode&0700, uint32(0700), "file should be readable and writable by owner")
 				}
 
 				for _, dir := range dirs {
-					gotFiles, err = tc.conn.List("./" + dir)
+					gotFiles, err = tc.conn.List(prefix + dir)
 					require.NoError(t, err)
-					assert.Len(t, gotFiles, 2)
+					gotFileNames := make([]string, 0, len(gotFiles))
 					for _, gotFile := range gotFiles {
-						for _, file := range files {
-							if path.Join(dir, gotFile.Name) == file {
-								assert.False(t, gotFile.IsDir)
-								assert.Equal(t, gotFile.Mode&0700, uint32(0600), "file should be readable and writable by owner")
-							}
-						}
+						assert.False(t, gotFile.IsDir)
+						assert.Equal(t, uint32(0600), gotFile.Mode&0700, "file should be readable and writable by owner")
+						gotFileNames = append(gotFileNames, path.Join(dir, gotFile.Name))
 					}
+
+					expectedFiles := f.Filter(files, func(file string) bool {
+						return path.Dir(file) == dir
+					})
+					assert.ElementsMatch(t, expectedFiles, gotFileNames, "should contain the expected files in %q", dir)
 				}
 			})
 
 			t.Run("Remove", func(t *testing.T) {
 				for _, file := range files {
-					_, err := tc.conn.Stats("./" + file)
+					_, err := tc.conn.Stats(prefix + file)
 					assert.NoError(t, err)
-					err = tc.conn.Remove("./" + file)
+					err = tc.conn.Remove(prefix + file)
 					require.NoError(t, err)
-					_, err = tc.conn.Stats("./" + file)
+					_, err = tc.conn.Stats(prefix + file)
 					assert.ErrorIs(t, err, os.ErrNotExist)
 				}
 
 				for _, dir := range dirs {
-					_, err := tc.conn.Stats("./" + dir)
+					_, err := tc.conn.Stats(prefix + dir)
 					assert.NoError(t, err)
-					err = tc.conn.Remove("./" + dir)
+					err = tc.conn.Remove(prefix + dir)
 					require.NoError(t, err)
-					_, err = tc.conn.Stats("./" + dir)
+					_, err = tc.conn.Stats(prefix + dir)
 					assert.ErrorIs(t, err, os.ErrNotExist)
 				}
 			})

--- a/pkg/board/remote/ssh/ssh.go
+++ b/pkg/board/remote/ssh/ssh.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"log/slog"
 	"net"
 	"os"
@@ -245,29 +244,13 @@ func (a *SSHConnection) Stats(p string) (remote.FileInfo, error) {
 	}
 	defer session.Close()
 
-	cmd := fmt.Sprintf("file %q", p)
+	cmd := fmt.Sprintf("stat -c '%%A %%n' %q", p)
 	output, err := session.Output(cmd)
 	if err != nil {
-		return remote.FileInfo{}, err
+		return remote.FileInfo{}, fmt.Errorf("failed to stat file: %w", err)
 	}
 
-	line := bytes.TrimSpace(output)
-	parts := bytes.Split(line, []byte(":"))
-	if len(parts) < 2 {
-		return remote.FileInfo{}, fmt.Errorf("unexpected file command output: %s", line)
-	}
-
-	name := string(bytes.TrimSpace(parts[0]))
-	other := string(bytes.TrimSpace(parts[1]))
-
-	if strings.Contains(other, "cannot open") {
-		return remote.FileInfo{}, fs.ErrNotExist
-	}
-
-	return remote.FileInfo{
-		Name:  path.Base(name),
-		IsDir: other == "directory",
-	}, nil
+	return remote.ParseStatOutput(output)
 }
 
 type SSHCommand struct {

--- a/pkg/board/remote/ssh/ssh.go
+++ b/pkg/board/remote/ssh/ssh.go
@@ -7,6 +7,7 @@ package ssh
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -245,12 +246,9 @@ func (a *SSHConnection) Stats(p string) (remote.FileInfo, error) {
 	defer session.Close()
 
 	cmd := fmt.Sprintf("stat -c '%%A %%n' %q", p)
-	output, err := session.Output(cmd)
-	if err != nil {
-		return remote.FileInfo{}, fmt.Errorf("failed to stat file: %w", err)
-	}
-
-	return remote.ParseStatOutput(output)
+	output, err1 := session.CombinedOutput(cmd)
+	info, err2 := remote.ParseStatOutput(output)
+	return info, cmp.Or(err2, err1)
 }
 
 type SSHCommand struct {

--- a/pkg/board/remotefs/remotefs.go
+++ b/pkg/board/remotefs/remotefs.go
@@ -171,6 +171,7 @@ func (a *RemoteDir) ReadDir(n int) ([]fs.DirEntry, error) {
 		return RemoteDirEntry{
 			name:  file.Name,
 			isDir: file.IsDir,
+			mode:  file.Mode,
 		}
 	}), nil
 }
@@ -193,6 +194,7 @@ type RemoteDirEntry struct {
 	name string
 
 	isDir bool
+	mode  uint32
 }
 
 func (a RemoteDirEntry) Name() string {
@@ -203,9 +205,9 @@ func (a RemoteDirEntry) IsDir() bool {
 }
 func (a RemoteDirEntry) Type() fs.FileMode {
 	if a.isDir {
-		return fs.ModeDir
+		return fs.ModeDir | fs.FileMode(a.mode)
 	}
-	return 0
+	return fs.FileMode(a.mode)
 }
 
 func (a RemoteDirEntry) Info() (fs.FileInfo, error) {

--- a/pkg/board/remotefs/remotefs.go
+++ b/pkg/board/remotefs/remotefs.go
@@ -39,11 +39,13 @@ func (a RemoteFS) Open(name string) (fs.File, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if stats.IsDir {
-		return &RemoteDir{name: name, base: a.base, conn: a.conn}, nil
+		mode := fs.FileMode(stats.Mode) | fs.ModeDir
+		return &RemoteDir{name: name, base: a.base, conn: a.conn, mode: mode}, nil
 	}
 
-	return &RemoteFile{name: name, base: a.base, conn: a.conn}, nil
+	return &RemoteFile{name: name, base: a.base, conn: a.conn, mode: fs.FileMode(stats.Mode)}, nil
 }
 
 type RemoteFSWriter struct {
@@ -71,6 +73,7 @@ func (a RemoteFSWriter) RmFile(p string) error {
 type RemoteFile struct {
 	name string
 	base string
+	mode fs.FileMode
 
 	read io.ReadCloser
 
@@ -100,13 +103,15 @@ func (a RemoteFile) Close() error {
 }
 
 func (a RemoteFile) Stat() (fs.FileInfo, error) {
-	return &RemoteFileInfo{name: path.Base(a.name)}, nil
+	return &RemoteFileInfo{
+		name: path.Base(a.name),
+		mode: a.mode,
+	}, nil
 }
 
 type RemoteFileInfo struct {
 	name string
-
-	isDir bool
+	mode fs.FileMode
 }
 
 func (a RemoteFileInfo) Name() string {
@@ -119,10 +124,7 @@ func (a RemoteFileInfo) Size() int64 {
 }
 
 func (a RemoteFileInfo) Mode() fs.FileMode {
-	if a.isDir {
-		return fs.ModeDir
-	}
-	return 0
+	return a.mode
 }
 
 func (a RemoteFileInfo) ModTime() time.Time {
@@ -131,7 +133,7 @@ func (a RemoteFileInfo) ModTime() time.Time {
 }
 
 func (a RemoteFileInfo) IsDir() bool {
-	return a.isDir
+	return a.Mode().IsDir()
 }
 
 func (a RemoteFileInfo) Sys() any {
@@ -141,6 +143,7 @@ func (a RemoteFileInfo) Sys() any {
 type RemoteDir struct {
 	name string
 	base string
+	mode fs.FileMode
 
 	files []remote.FileInfo
 	valid bool
@@ -168,16 +171,22 @@ func (a *RemoteDir) ReadDir(n int) ([]fs.DirEntry, error) {
 	a.files = rest
 
 	return f.Map(files, func(file remote.FileInfo) fs.DirEntry {
+		mode := fs.FileMode(file.Mode)
+		if file.IsDir {
+			mode |= fs.ModeDir
+		}
 		return RemoteDirEntry{
-			name:  file.Name,
-			isDir: file.IsDir,
-			mode:  file.Mode,
+			name: file.Name,
+			mode: mode,
 		}
 	}), nil
 }
 
 func (a RemoteDir) Stat() (fs.FileInfo, error) {
-	return &RemoteFileInfo{name: path.Base(a.name), isDir: true}, nil
+	return &RemoteFileInfo{
+		name: path.Base(a.name),
+		mode: a.mode,
+	}, nil
 }
 
 func (a RemoteDir) Close() error {
@@ -192,24 +201,19 @@ func (a RemoteDir) Read(p []byte) (n int, err error) {
 
 type RemoteDirEntry struct {
 	name string
-
-	isDir bool
-	mode  uint32
+	mode fs.FileMode
 }
 
 func (a RemoteDirEntry) Name() string {
 	return a.name
 }
 func (a RemoteDirEntry) IsDir() bool {
-	return a.isDir
+	return a.mode.IsDir()
 }
 func (a RemoteDirEntry) Type() fs.FileMode {
-	if a.isDir {
-		return fs.ModeDir | fs.FileMode(a.mode)
-	}
-	return fs.FileMode(a.mode)
+	return a.mode.Type()
 }
 
 func (a RemoteDirEntry) Info() (fs.FileInfo, error) {
-	return &RemoteFileInfo{name: a.name, isDir: a.isDir}, nil
+	return &RemoteFileInfo{name: a.name, mode: a.mode}, nil
 }


### PR DESCRIPTION
### Motivation

fs operation should support file and folder permissions.

### Change description

1. Parse and return file permission (with stat and not file)
2. Make the permissions for file creation over different connections more coherent

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
