### PR TITLE
feat: parametric EI device type based on board platform

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -64,7 +64,7 @@ func NewHTTPRouter(
 
 	mux.Handle("GET /v1/models", handlers.HandleModelsList(dockerClient, modelsIndex, cfg, platform))
 	mux.Handle("GET /v1/models/{modelID}", handlers.HandlerModelByID(dockerClient, modelsIndex, cfg, platform))
-	mux.Handle("PUT /v1/models/ei/projects/{projectID}", handlers.HandleInstallEIModel(cfg, bricksIndex, modelsIndex, dockerClient))
+	mux.Handle("PUT /v1/models/ei/projects/{projectID}", handlers.HandleInstallEIModel(cfg, bricksIndex, modelsIndex, dockerClient, platform))
 	mux.Handle("PUT /v1/models/{modelID}", handlers.HandleInstallModel(dockerClient, modelsIndex, cfg, platform))
 	mux.Handle("DELETE /v1/models/{modelID}", handlers.HandlerDeleteModelByID(dockerClient, cfg, modelsIndex, bricksIndex, idProvider, platform))
 

--- a/internal/api/handlers/ai_models.go
+++ b/internal/api/handlers/ai_models.go
@@ -99,7 +99,7 @@ func HandlerDeleteModelByID(dockerClient command.Cli, cfg config.Configuration, 
 	}
 }
 
-func HandleInstallEIModel(cfg config.Configuration, bricksIndex *bricksindex.BricksIndex, modelsIndex *modelsindex.ModelsIndex, dockerClient command.Cli, p platform.Platform) http.HandlerFunc {
+func HandleInstallEIModel(cfg config.Configuration, bricksIndex *bricksindex.BricksIndex, modelsIndex *modelsindex.ModelsIndex, dockerClient command.Cli, platform platform.Platform) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		projectID, err := strconv.Atoi(r.PathValue("projectID"))
 		if err != nil {
@@ -131,7 +131,7 @@ func HandleInstallEIModel(cfg config.Configuration, bricksIndex *bricksindex.Bri
 			return
 		}
 
-		eiModel, err := orchestrator.InstallEIModel(r.Context(), bricksIndex, modelsIndex, dockerClient, eiClient, cfg.CustomModelsDir(), p, projectID, *req.ImpulseID)
+		eiModel, err := orchestrator.InstallEIModel(r.Context(), bricksIndex, modelsIndex, dockerClient, eiClient, cfg.CustomModelsDir(), platform, projectID, *req.ImpulseID)
 		if err != nil {
 			switch {
 			case errors.Is(err, edgeimpulse.ErrUnauthorized):

--- a/internal/api/handlers/ai_models.go
+++ b/internal/api/handlers/ai_models.go
@@ -99,7 +99,7 @@ func HandlerDeleteModelByID(dockerClient command.Cli, cfg config.Configuration, 
 	}
 }
 
-func HandleInstallEIModel(cfg config.Configuration, bricksIndex *bricksindex.BricksIndex, modelsIndex *modelsindex.ModelsIndex, dockerClient command.Cli) http.HandlerFunc {
+func HandleInstallEIModel(cfg config.Configuration, bricksIndex *bricksindex.BricksIndex, modelsIndex *modelsindex.ModelsIndex, dockerClient command.Cli, p platform.Platform) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		projectID, err := strconv.Atoi(r.PathValue("projectID"))
 		if err != nil {
@@ -131,7 +131,7 @@ func HandleInstallEIModel(cfg config.Configuration, bricksIndex *bricksindex.Bri
 			return
 		}
 
-		eiModel, err := orchestrator.InstallEIModel(r.Context(), bricksIndex, modelsIndex, dockerClient, eiClient, cfg.CustomModelsDir(), projectID, *req.ImpulseID)
+		eiModel, err := orchestrator.InstallEIModel(r.Context(), bricksIndex, modelsIndex, dockerClient, eiClient, cfg.CustomModelsDir(), p, projectID, *req.ImpulseID)
 		if err != nil {
 			switch {
 			case errors.Is(err, edgeimpulse.ErrUnauthorized):

--- a/internal/orchestrator/models.go
+++ b/internal/orchestrator/models.go
@@ -231,18 +231,13 @@ func isModelInUse(ctx context.Context, modelsIndex *modelsindex.ModelsIndex, doc
 
 func InstallEIModel(ctx context.Context, bricksIndex *bricksindex.BricksIndex, modelsIndex *modelsindex.ModelsIndex, dockerClient command.Cli, eiClient *edgeimpulse.EIClient, modelsDir *paths.Path, platform platform.Platform, projectID int, impulseID int) (AIModelItem, error) {
 
-	mType := "float32"
-	mEngine := "tflite"
-	var deviceType string
-	switch platform.BoardName {
-	case "unoq":
-		deviceType = "runner-linux-aarch64"
-	case "ventunoq":
-		deviceType = "runner-linux-aarch64-qnn"
+	eiParams, err := platform.EIDeploymentParams()
+	if err != nil {
+		return AIModelItem{}, err
 	}
 
 	id := fmt.Sprintf("ei-model-%d-%d", projectID, impulseID)
-	err := isModelInUse(ctx, modelsIndex, dockerClient, id)
+	err = isModelInUse(ctx, modelsIndex, dockerClient, id)
 	if err != nil {
 		return AIModelItem{}, fmt.Errorf("cannot install EI model: %w", err)
 	}
@@ -263,9 +258,9 @@ func InstallEIModel(ctx context.Context, bricksIndex *bricksindex.BricksIndex, m
 	// check if there is a deployment and is valid for arduino uno Q or ventuno target, otherwise build it.
 	var mversion int
 	if len(dpList) == 0 || dpList[0].ImpulseHasChangedSinceDeployment ||
-		dpList[0].DeploymentFormat != deviceType || string(dpList[0].Engine) != mEngine || string(*dpList[0].ModelType) != mType {
+		dpList[0].DeploymentFormat != eiParams.DeviceType || string(dpList[0].Engine) != eiParams.Engine || string(*dpList[0].ModelType) != eiParams.ModelType {
 
-		job, err := eiClient.Build(ctx, projectID, impulseID, mType, mEngine, deviceType)
+		job, err := eiClient.Build(ctx, projectID, impulseID, eiParams.ModelType, eiParams.Engine, eiParams.DeviceType)
 		if err != nil {
 			return AIModelItem{}, err
 		}
@@ -304,8 +299,8 @@ func InstallEIModel(ctx context.Context, bricksIndex *bricksindex.BricksIndex, m
 			"ei-project-id":         strconv.Itoa(projectID),
 			"ei-impulse-id":         strconv.Itoa(impulseID),
 			"ei-impulse-name":       impulse.Name,
-			"ei-model-type":         mType,
-			"ei-engine":             mEngine,
+			"ei-model-type":         eiParams.ModelType,
+			"ei-engine":             eiParams.Engine,
 			"ei-last-modified":      project.Details.LastModified.Local().Format(time.RFC3339Nano),
 			"ei-deployment-version": strconv.Itoa(mversion),
 		},

--- a/internal/orchestrator/models.go
+++ b/internal/orchestrator/models.go
@@ -229,12 +229,11 @@ func isModelInUse(ctx context.Context, modelsIndex *modelsindex.ModelsIndex, doc
 	return nil
 }
 
-func InstallEIModel(ctx context.Context, bricksIndex *bricksindex.BricksIndex, modelsIndex *modelsindex.ModelsIndex, dockerClient command.Cli, eiClient *edgeimpulse.EIClient, modelsDir *paths.Path, projectID int, impulseID int) (AIModelItem, error) {
+func InstallEIModel(ctx context.Context, bricksIndex *bricksindex.BricksIndex, modelsIndex *modelsindex.ModelsIndex, dockerClient command.Cli, eiClient *edgeimpulse.EIClient, modelsDir *paths.Path, p platform.Platform, projectID int, impulseID int) (AIModelItem, error) {
 
-	// TODO these parameters aim to build a model optimized for the Imola hardware, they should change based on the target device
 	mType := "float32"
 	mEngine := "tflite"
-	deviceType := "runner-linux-aarch64"
+	deviceType := p.EIDeviceType()
 	var mversion int
 
 	id := fmt.Sprintf("ei-model-%d-%d", projectID, impulseID)

--- a/internal/orchestrator/models.go
+++ b/internal/orchestrator/models.go
@@ -229,12 +229,17 @@ func isModelInUse(ctx context.Context, modelsIndex *modelsindex.ModelsIndex, doc
 	return nil
 }
 
-func InstallEIModel(ctx context.Context, bricksIndex *bricksindex.BricksIndex, modelsIndex *modelsindex.ModelsIndex, dockerClient command.Cli, eiClient *edgeimpulse.EIClient, modelsDir *paths.Path, p platform.Platform, projectID int, impulseID int) (AIModelItem, error) {
+func InstallEIModel(ctx context.Context, bricksIndex *bricksindex.BricksIndex, modelsIndex *modelsindex.ModelsIndex, dockerClient command.Cli, eiClient *edgeimpulse.EIClient, modelsDir *paths.Path, platform platform.Platform, projectID int, impulseID int) (AIModelItem, error) {
 
 	mType := "float32"
 	mEngine := "tflite"
-	deviceType := p.EIDeviceType()
-	var mversion int
+	var deviceType string
+	switch platform.BoardName {
+	case "unoq":
+		deviceType = "runner-linux-aarch64"
+	case "ventunoq":
+		deviceType = "runner-linux-aarch64-qnn"
+	}
 
 	id := fmt.Sprintf("ei-model-%d-%d", projectID, impulseID)
 	err := isModelInUse(ctx, modelsIndex, dockerClient, id)
@@ -255,7 +260,8 @@ func InstallEIModel(ctx context.Context, bricksIndex *bricksindex.BricksIndex, m
 	if err != nil {
 		return AIModelItem{}, err
 	}
-	// check if there is a deployment and si valid for arduino uno Q, otherwise build it.
+	// check if there is a deployment and is valid for arduino uno Q or ventuno target, otherwise build it.
+	var mversion int
 	if len(dpList) == 0 || dpList[0].ImpulseHasChangedSinceDeployment ||
 		dpList[0].DeploymentFormat != deviceType || string(dpList[0].Engine) != mEngine || string(*dpList[0].ModelType) != mType {
 

--- a/internal/orchestrator/models_test.go
+++ b/internal/orchestrator/models_test.go
@@ -332,7 +332,7 @@ func TestInstallEIModel_WhenModelIsNotBuilt_ThanTriggerTheBuild(t *testing.T) {
 	projectId := 100
 	impulseId := 1
 	tempDir := t.TempDir()
-	result, err := InstallEIModel(context.Background(), nil, &modelsindex.ModelsIndex{}, nil, client, paths.New(tempDir), projectId, impulseId)
+	result, err := InstallEIModel(context.Background(), nil, &modelsindex.ModelsIndex{}, nil, client, paths.New(tempDir), platform.Platform{BoardName: "unoq"}, projectId, impulseId)
 
 	// assert
 	require.NoError(t, err)
@@ -381,7 +381,7 @@ func TestInstallEIModel_WhenModelIsNotFullyTrained_ThanRaiseError(t *testing.T) 
 	projectId := 100
 	impulseId := 1
 	tempDir := t.TempDir()
-	_, err = InstallEIModel(context.Background(), nil, &modelsindex.ModelsIndex{}, nil, client, paths.New(tempDir), projectId, impulseId)
+	_, err = InstallEIModel(context.Background(), nil, &modelsindex.ModelsIndex{}, nil, client, paths.New(tempDir), platform.Platform{BoardName: "unoq"}, projectId, impulseId)
 
 	// assert
 	require.Equal(t, "impulse not ready for deployment for project 100 impulse 1", err.Error())
@@ -463,7 +463,7 @@ func TestInstallEIModel_WhenModelIsBuilt_DoNotTriggerTheBuild_and_StoreSucceeded
 	projectId := 100
 	impulseId := 1
 	tempDir := t.TempDir()
-	result, err := InstallEIModel(context.Background(), nil, &modelsindex.ModelsIndex{}, nil, client, paths.New(tempDir), projectId, impulseId)
+	result, err := InstallEIModel(context.Background(), nil, &modelsindex.ModelsIndex{}, nil, client, paths.New(tempDir), platform.Platform{BoardName: "unoq"}, projectId, impulseId)
 
 	// assert
 	require.NoError(t, err)
@@ -481,6 +481,87 @@ func TestInstallEIModel_WhenModelIsBuilt_DoNotTriggerTheBuild_and_StoreSucceeded
 		"/api/100/deployment/history",
 		"/api/100/deployment/history/5/download",
 		"/api/100/impulse",
+	}
+	assertServerCalls(trackActualServercalls, expectedCalls, t)
+}
+
+func TestInstallEIModel_VentunoQ_UsesQNNDeviceType(t *testing.T) {
+	trackActualServercalls := []string{}
+
+	projectInfoJSON := `{
+		"success": true,
+		"project": {
+			"id": 200,
+			"name": "VentunoQ-Model",
+			"description": "QNN model for ventunoq",
+			"category": "missing-category",
+			"lastModified": "2026-02-05T12:00:00Z"
+		},
+		"impulse": {
+			"created": true,
+			"configured": true,
+			"complete": true
+		}
+	}`
+
+	buildOnDeviceJSON := `{
+		"success": true,
+		"id": 77701,
+		"deploymentVersion": 1,
+		"error": null
+	}`
+
+	waitForbuildCompletionJSON := `{
+		"success": true,
+		"job": {
+			"id": 77701,
+			"finished": "2026-02-05T18:00:00Z",
+			"finishedSuccessful": true,
+			"jobType": "build-on-device"
+		}
+	}`
+
+	impulseInfoJSON := `{
+		"success": true,
+		"impulse": {
+			"id": 1,
+			"name": "My Impulse",
+			"created": true,
+			"configured": true,
+			"complete": true
+		}
+	}`
+
+	responses := map[string]mockResponse{
+		"/api/200":                               {status: http.StatusOK, body: projectInfoJSON},
+		"/api/200/deployment/history":            {status: http.StatusOK, body: `{"success": true, "deployments": []}`},
+		"/api/200/jobs/build-ondevice-model":     {status: http.StatusOK, body: buildOnDeviceJSON},
+		"/api/200/jobs/77701/status":             {status: http.StatusOK, body: waitForbuildCompletionJSON},
+		"/api/200/deployment/history/1/download": {status: http.StatusOK, body: `fake-binary-data`},
+		"/api/200/impulse":                       {status: http.StatusOK, body: impulseInfoJSON},
+	}
+	server := setupMockEIServer(t, responses, &trackActualServercalls)
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	client, _ := edgeimpulse.NewEIClient("fake-key", *serverURL)
+
+	projectId := 200
+	impulseId := 1
+	tempDir := t.TempDir()
+	result, err := InstallEIModel(context.Background(), nil, &modelsindex.ModelsIndex{}, nil, client, paths.New(tempDir), platform.Platform{BoardName: "ventunoq"}, projectId, impulseId)
+
+	require.NoError(t, err)
+	require.Equal(t, "VentunoQ-Model", result.Name)
+
+	expectedCalls := []string{
+		"/api/200",
+		"/api/200/deployment/history",
+		"/api/200/jobs/build-ondevice-model",
+		"/api/200/jobs/77701/status",
+		"/api/200/deployment/history/1/download",
+		"/api/200/impulse",
 	}
 	assertServerCalls(trackActualServercalls, expectedCalls, t)
 }

--- a/internal/orchestrator/models_test.go
+++ b/internal/orchestrator/models_test.go
@@ -239,6 +239,19 @@ bricks:
 	}
 }
 
+
+const impulseInfoJSON = `{
+	"success": true,
+	"impulse": {
+		"id": 1,
+		"name": "My Impulse",
+		"created": true,
+		"configured": true,
+		"complete": true
+	}
+}`
+
+
 type mockResponse struct {
 	status int
 	body   string
@@ -297,18 +310,6 @@ func TestInstallEIModel_WhenModelIsNotBuilt_ThanTriggerTheBuild(t *testing.T) {
 			"finished": "2026-02-05T18:00:00Z",
 			"finishedSuccessful": true,
 			"jobType": "build-on-device"
-		}
-	}`
-
-	// GetImpulseInfo
-	impulseInfoJSON := `{
-		"success": true,
-		"impulse": {
-			"id": 1,
-			"name": "My Impulse",
-			"created": true,
-			"configured": true,
-			"complete": true
 		}
 	}`
 
@@ -433,18 +434,6 @@ func TestInstallEIModel_WhenModelIsBuilt_DoNotTriggerTheBuild_and_StoreSucceeded
     ]
 	}`
 
-	// GetImpulseInfo
-	impulseInfoJSON := `{
-		"success": true,
-		"impulse": {
-			"id": 1,
-			"name": "My Impulse",
-			"created": true,
-			"configured": true,
-			"complete": true
-		}
-	}`
-
 	responses := map[string]mockResponse{
 		"/api/100":                               {status: http.StatusOK, body: projectInfoJSON},
 		"/api/100/deployment/history":            {status: http.StatusOK, body: deploymentHistoryJson},
@@ -518,17 +507,6 @@ func TestInstallEIModel_VentunoQ_UsesQNNDeviceType(t *testing.T) {
 			"finished": "2026-02-05T18:00:00Z",
 			"finishedSuccessful": true,
 			"jobType": "build-on-device"
-		}
-	}`
-
-	impulseInfoJSON := `{
-		"success": true,
-		"impulse": {
-			"id": 1,
-			"name": "My Impulse",
-			"created": true,
-			"configured": true,
-			"complete": true
 		}
 	}`
 

--- a/internal/orchestrator/models_test.go
+++ b/internal/orchestrator/models_test.go
@@ -239,7 +239,6 @@ bricks:
 	}
 }
 
-
 const impulseInfoJSON = `{
 	"success": true,
 	"impulse": {
@@ -250,7 +249,6 @@ const impulseInfoJSON = `{
 		"complete": true
 	}
 }`
-
 
 type mockResponse struct {
 	status int

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -7,6 +7,7 @@ package platform
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 
 	"github.com/arduino/go-paths-helper"
@@ -93,6 +94,23 @@ func (p Platform) GetMicro() micro.Micro {
 
 func (p Platform) SupportFlashToRam() bool {
 	return p.FQBN == "arduino:zephyr:unoq"
+}
+
+type EIDeploymentParams struct {
+	ModelType  string
+	Engine     string
+	DeviceType string
+}
+
+func (p Platform) EIDeploymentParams() (EIDeploymentParams, error) {
+	switch p.BoardName {
+	case "unoq":
+		return EIDeploymentParams{ModelType: "float32", Engine: "tflite", DeviceType: "runner-linux-aarch64"}, nil
+	case "ventunoq":
+		return EIDeploymentParams{ModelType: "float32", Engine: "tflite", DeviceType: "runner-linux-aarch64-qnn"}, nil
+	default:
+		return EIDeploymentParams{}, fmt.Errorf("unsupported platform %q for Edge Impulse deployment", p.BoardName)
+	}
 }
 
 func GetUnoQBoardLeds() paths.PathList {

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -91,16 +91,6 @@ func (p Platform) GetMicro() micro.Micro {
 	return micro.New(micro.GpioPin(p.Micro.ResetPin))
 }
 
-// EIDeviceType returns the Edge Impulse runner device type for this platform.
-// VentunoQ uses Qualcomm Neural Network acceleration; all others default to the
-// standard aarch64 runner.
-func (p Platform) EIDeviceType() string {
-	if p.BoardName == "ventunoq" {
-		return "runner-linux-aarch64-qnn"
-	}
-	return "runner-linux-aarch64"
-}
-
 func (p Platform) SupportFlashToRam() bool {
 	return p.FQBN == "arduino:zephyr:unoq"
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -91,6 +91,16 @@ func (p Platform) GetMicro() micro.Micro {
 	return micro.New(micro.GpioPin(p.Micro.ResetPin))
 }
 
+// EIDeviceType returns the Edge Impulse runner device type for this platform.
+// VentunoQ uses Qualcomm Neural Network acceleration; all others default to the
+// standard aarch64 runner.
+func (p Platform) EIDeviceType() string {
+	if p.BoardName == "ventunoq" {
+		return "runner-linux-aarch64-qnn"
+	}
+	return "runner-linux-aarch64"
+}
+
 func (p Platform) SupportFlashToRam() bool {
 	return p.FQBN == "arduino:zephyr:unoq"
 }

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -14,23 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEIDeviceType(t *testing.T) {
-	tests := []struct {
-		boardName string
-		want      string
-	}{
-		{"unoq", "runner-linux-aarch64"},
-		{"ventunoq", "runner-linux-aarch64-qnn"},
-		{"", "runner-linux-aarch64"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.boardName, func(t *testing.T) {
-			p := Platform{BoardName: tt.boardName}
-			assert.Equal(t, tt.want, p.EIDeviceType())
-		})
-	}
-}
-
 func TestGetPlatformWithOverride(t *testing.T) {
 	tmpDir := paths.New(t.TempDir())
 	override := Platform{

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -14,6 +14,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestEIDeviceType(t *testing.T) {
+	tests := []struct {
+		boardName string
+		want      string
+	}{
+		{"unoq", "runner-linux-aarch64"},
+		{"ventunoq", "runner-linux-aarch64-qnn"},
+		{"", "runner-linux-aarch64"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.boardName, func(t *testing.T) {
+			p := Platform{BoardName: tt.boardName}
+			assert.Equal(t, tt.want, p.EIDeviceType())
+		})
+	}
+}
+
 func TestGetPlatformWithOverride(t *testing.T) {
 	tmpDir := paths.New(t.TempDir())
 	override := Platform{


### PR DESCRIPTION
## Summary

- `InstallEIModel` now accepts a `platform.Platform` parameter and selects `deviceType` via a switch on `platform.BoardName` instead of a hardcoded value
- UNO Q → `runner-linux-aarch64`; VentunoQ → `runner-linux-aarch64-qnn` (Qualcomm Neural Network acceleration)
- Threads the platform through `HandleInstallEIModel` handler and the API router

Closes #326