### PR TITLE
fix(pkg/board): ensure pushed files and folder are read and writable

### DIFF
--- a/pkg/board/remote/adb/adb.go
+++ b/pkg/board/remote/adb/adb.go
@@ -353,6 +353,13 @@ func (a *ADBConnection) Push(ctx context.Context, local, remote string) error {
 	if err != nil {
 		return fmt.Errorf("failed to push file from %q to %q: %w: %s", local, remote, err, string(stdout))
 	}
+
+	if cmd, err = paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "chmod", "-R", "u+wr", strconv.Quote(remote)); err == nil {
+		if stdout, err = cmd.RunAndCaptureCombinedOutput(ctx); err != nil {
+			slog.Warn("failed to set permissions for remote path", "path", remote, "error", err, "output", string(stdout))
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/board/remote/local/local.go
+++ b/pkg/board/remote/local/local.go
@@ -156,7 +156,8 @@ func (a *LocalConnection) Push(ctx context.Context, src string, dst string) erro
 	}
 
 	if !info.IsDir() {
-		return copyFile(ctx, src, dst, info.Mode().Perm())
+		perm := info.Mode().Perm() | 0600 // Ensure files are readable and writable.
+		return copyFile(ctx, src, dst, perm)
 	}
 
 	return fs.WalkDir(os.DirFS(src), ".", func(path string, d fs.DirEntry, err error) error {
@@ -176,7 +177,8 @@ func (a *LocalConnection) Push(ctx context.Context, src string, dst string) erro
 		}
 
 		if d.IsDir() {
-			if err := os.MkdirAll(target, info.Mode().Perm()); err != nil {
+			perm := info.Mode().Perm() | 0700 // Ensure directories are executable.
+			if err := os.MkdirAll(target, perm); err != nil {
 				return fmt.Errorf("failed to create directory %q: %w", target, err)
 			}
 			return nil

--- a/pkg/board/remote/ssh/scp.go
+++ b/pkg/board/remote/ssh/scp.go
@@ -128,7 +128,8 @@ func pushFile(ctx context.Context, rw io.ReadWriteCloser, f fs.File) error {
 		return err
 	}
 
-	fmt.Fprintf(rw, "C%04o %d %s\n", info.Mode().Perm(), info.Size(), info.Name())
+	perm := info.Mode().Perm() | 0600 // ensure files are readable and writable by the owner.
+	fmt.Fprintf(rw, "C%04o %d %s\n", perm, info.Size(), info.Name())
 
 	if err := checkErr(rw); err != nil {
 		return err
@@ -158,7 +159,8 @@ func pushDir(ctx context.Context, rw io.ReadWriteCloser, fsys fs.FS, remoteBase 
 func pushDirRec(ctx context.Context, rw io.ReadWriteCloser, fsys fs.FS, name, remote string, info os.FileInfo) error {
 	switch info.Mode().Type() {
 	case fs.ModeDir:
-		fmt.Fprintf(rw, "D%04o 0 %s\n", info.Mode().Perm(), remote)
+		perm := info.Mode().Perm() | 0700 // ensure directories are readable, writable and executable by the owner.
+		fmt.Fprintf(rw, "D%04o 0 %s\n", perm, remote)
 		if err := checkErr(rw); err != nil {
 			return err
 		}


### PR DESCRIPTION
### Motivation

Pushing read-only folders and files should make them readable and writable.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
