### PR TITLE
fix(pkg/board): discovery user product property if available

### DIFF
--- a/pkg/board/board.go
+++ b/pkg/board/board.go
@@ -190,14 +190,21 @@ func FromFQBN(ctx context.Context, fqbns []string) ([]Board, error) {
 		switch port.GetPort().GetProtocol() {
 		case SerialProtocol:
 			serial := strings.ToLower(port.GetPort().GetHardwareId()) // in windows this is uppercase.
-			// TODO: we should store the board custom name in the product id so we can get it from the discovery service.
+
 			var customName string
-			if conn, err := adb.FromSerial(serial, ""); err == nil {
-				if name, err := GetCustomName(ctx, conn); err == nil {
-					customName = name
+			if sn, ok := port.GetPort().GetProperties()["product"]; ok {
+				if _, last, ok := strings.Cut(sn, "-"); ok {
+					customName = strings.TrimSpace(last)
 				}
 			} else {
-				slog.Warn("failed to get custom name", "serial", serial, "error", err)
+				// fallback to get custom name from the board if product property is not available.
+				if conn, err := adb.FromSerial(serial, ""); err == nil {
+					if name, err := GetCustomName(ctx, conn); err == nil {
+						customName = name
+					}
+				} else {
+					slog.Warn("failed to get custom name", "serial", serial, "error", err)
+				}
 			}
 
 			boards = append(boards, Board{


### PR DESCRIPTION
### Motivation

Try to get the board's custom name from the product if present.

### Change description

<!-- What does your code do? -->

### Additional Notes

- requires https://github.com/arduino/serial-discovery/pull/118

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
