### PR TITLE
Remove arduino-radio-firmware since it is not required by arduino-router

### DIFF
--- a/internal/e2e/updatetest/test.Dockerfile
+++ b/internal/e2e/updatetest/test.Dockerfile
@@ -11,10 +11,9 @@ ARG ARCH=amd64
 COPY build/stable/arduino-app-cli*_${ARCH}.deb /tmp/stable.deb
 COPY build/arduino-app-cli*_${ARCH}.deb /tmp/unstable.deb
 COPY build/stable/arduino-router*_${ARCH}.deb /tmp/router.deb
-COPY build/stable/arduino-unoq-radio-firmware*_${ARCH}.deb /tmp/radio-firmware.deb
 
-RUN apt update && apt install -y /tmp/stable.deb  /tmp/radio-firmware.deb /tmp/router.deb \
-    && rm /tmp/stable.deb /tmp/router.deb /tmp/radio-firmware.deb \
+RUN apt update && apt install -y /tmp/stable.deb /tmp/router.deb \
+    && rm /tmp/stable.deb /tmp/router.deb \
     && mkdir -p /var/www/html/myrepo/dists/trixie/main/binary-${ARCH} \
     && mv /tmp/unstable.deb /var/www/html/myrepo/dists/trixie/main/binary-${ARCH}/
 

--- a/internal/e2e/updatetest/update_test.go
+++ b/internal/e2e/updatetest/update_test.go
@@ -29,7 +29,6 @@ func TestUpdatePackage(t *testing.T) {
 
 		tagAppCli := fetchDebPackageLatest(t, "build/stable", "arduino/arduino-app-cli")
 		fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
-		fetchDebPackageLatest(t, "build/stable", "bcmi-labs/arduino-deb-packages")
 
 		majorTag := genMajorTag(t, tagAppCli)
 		t.Logf("Updating from stable version %s to unstable version %s", tagAppCli, majorTag)
@@ -84,7 +83,6 @@ func TestUpdatePackage(t *testing.T) {
 
 		tagAppCli := fetchDebPackageLatest(t, "build", "arduino/arduino-app-cli")
 		fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
-		fetchDebPackageLatest(t, "build/stable", "bcmi-labs/arduino-deb-packages")
 
 		minorTag := genMinorTag(t, tagAppCli)
 		t.Logf("Updating from unstable version %s to stable version %s", minorTag, tagAppCli)


### PR DESCRIPTION
### Motivation
Remove arduino-radio-firmware from the update E2E tests, since it is no longer needed.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
