### PR TITLE
fix: ei custom model selection

### DIFF
--- a/debian/arduino-app-cli/var/lib/arduino-app-cli/assets/0.10.1/bricks-list.yaml
+++ b/debian/arduino-app-cli/var/lib/arduino-app-cli/assets/0.10.1/bricks-list.yaml
@@ -19,6 +19,8 @@ bricks:
   model_name: fan-anomaly-detection
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_VIBRATION_ANOMALY_DETECTION_MODEL
   variables:
   - name: EI_VIBRATION_ANOMALY_DETECTION_MODEL
     default_value: /models/ootb/ei/fan-anomaly-detection.eim
@@ -140,6 +142,8 @@ bricks:
   - camera
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_V_CLASSIFICATION_MODEL
   variables:
   - name: EI_V_CLASSIFICATION_MODEL
     default_value: /models/ootb/ei/mobilenet-v2-224px.eim
@@ -176,6 +180,8 @@ bricks:
   model_name: updown-wave-motion-detection
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_MOTION_DETECTION_MODEL
   variables:
   - name: EI_MOTION_DETECTION_MODEL
     default_value: /models/ootb/ei/updown-wave-motion-detection.eim
@@ -206,6 +212,8 @@ bricks:
   model_name: glass-breaking
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_AUDIO_CLASSIFICATION_MODEL
   variables:
   - name: EI_AUDIO_CLASSIFICATION_MODEL
     default_value: /models/ootb/ei/glass-breaking.eim
@@ -284,6 +292,8 @@ bricks:
   - microphone
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_KEYWORD_SPOTTING_MODEL
   variables:
   - name: EI_KEYWORD_SPOTTING_MODEL
     default_value: /models/ootb/ei/keyword-spotting-hey-arduino.eim
@@ -406,6 +416,8 @@ bricks:
   model_name: yolox-object-detection
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_OBJ_DETECTION_MODEL
   variables:
   - name: EI_OBJ_DETECTION_MODEL
     default_value: /models/ootb/ei/yolo-x-nano.eim
@@ -458,6 +470,8 @@ bricks:
     model: yolox-object-detection
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_V_OBJ_DETECTION_MODEL
   variables:
   - name: CUSTOM_MODEL_PATH
     default_value: /home/arduino/.arduino-bricks/ei-models
@@ -536,6 +550,8 @@ bricks:
   model_name: mobilenet-image-classification
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_CLASSIFICATION_MODEL
   variables:
   - name: EI_CLASSIFICATION_MODEL
     default_value: /models/ootb/ei/mobilenet-v2-224px.eim

--- a/internal/e2e/daemon/testdata/assets/0.10.1/bricks-list.yaml
+++ b/internal/e2e/daemon/testdata/assets/0.10.1/bricks-list.yaml
@@ -19,6 +19,8 @@ bricks:
   model_name: fan-anomaly-detection
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_VIBRATION_ANOMALY_DETECTION_MODEL
   variables:
   - name: EI_VIBRATION_ANOMALY_DETECTION_MODEL
     default_value: /models/ootb/ei/fan-anomaly-detection.eim
@@ -140,6 +142,8 @@ bricks:
   - camera
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_V_CLASSIFICATION_MODEL
   variables:
   - name: EI_V_CLASSIFICATION_MODEL
     default_value: /models/ootb/ei/mobilenet-v2-224px.eim
@@ -176,6 +180,8 @@ bricks:
   model_name: updown-wave-motion-detection
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_MOTION_DETECTION_MODEL
   variables:
   - name: EI_MOTION_DETECTION_MODEL
     default_value: /models/ootb/ei/updown-wave-motion-detection.eim
@@ -206,6 +212,8 @@ bricks:
   model_name: glass-breaking
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_AUDIO_CLASSIFICATION_MODEL
   variables:
   - name: EI_AUDIO_CLASSIFICATION_MODEL
     default_value: /models/ootb/ei/glass-breaking.eim
@@ -284,6 +292,8 @@ bricks:
   - microphone
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_KEYWORD_SPOTTING_MODEL
   variables:
   - name: EI_KEYWORD_SPOTTING_MODEL
     default_value: /models/ootb/ei/keyword-spotting-hey-arduino.eim
@@ -406,6 +416,8 @@ bricks:
   model_name: yolox-object-detection
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_OBJ_DETECTION_MODEL
   variables:
   - name: EI_OBJ_DETECTION_MODEL
     default_value: /models/ootb/ei/yolo-x-nano.eim
@@ -458,6 +470,8 @@ bricks:
     model: yolox-object-detection
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_V_OBJ_DETECTION_MODEL
   variables:
   - name: CUSTOM_MODEL_PATH
     default_value: /home/arduino/.arduino-bricks/ei-models
@@ -536,6 +550,8 @@ bricks:
   model_name: mobilenet-image-classification
   ai_frameworks_compatibility:
   - edgeimpulse
+  model_configuration_variables:
+    - EI_CLASSIFICATION_MODEL
   variables:
   - name: EI_CLASSIFICATION_MODEL
     default_value: /models/ootb/ei/mobilenet-v2-224px.eim

--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -74,14 +74,15 @@ type Brick struct {
 	Category        string   `yaml:"category,omitempty"`
 	RequiresDisplay string   `yaml:"requires_display,omitempty"`
 	// Deprecated : the field `require_container` is deprecated, you can remove it from the brick config. It will be ignored if present.
-	RequireContainer          bool                      `yaml:"require_container"` // Deprecated
-	RequireModel              bool                      `yaml:"require_model"`
-	Variables                 []BrickVariable           `yaml:"variables,omitempty"`
-	Ports                     []string                  `yaml:"ports,omitempty"`
-	ModelName                 string                    `yaml:"model_name,omitempty"`
-	MountDevicesIntoContainer bool                      `yaml:"mount_devices_into_container,omitempty"`
-	RequiredDevices           []peripherals.DeviceClass `yaml:"required_devices,omitempty"`
-	RequiresServices          []string                  `yaml:"requires_services,omitempty"`
+	RequireContainer            bool                      `yaml:"require_container"` // Deprecated
+	RequireModel                bool                      `yaml:"require_model"`
+	Variables                   []BrickVariable           `yaml:"variables,omitempty"`
+	Ports                       []string                  `yaml:"ports,omitempty"`
+	ModelName                   string                    `yaml:"model_name,omitempty"`
+	MountDevicesIntoContainer   bool                      `yaml:"mount_devices_into_container,omitempty"`
+	RequiredDevices             []peripherals.DeviceClass `yaml:"required_devices,omitempty"`
+	RequiresServices            []string                  `yaml:"requires_services,omitempty"`
+	ModelConfigurationVariables []string                  `yaml:"model_configuration_variables,omitempty"`
 
 	Source string `yaml:"-"`
 

--- a/internal/orchestrator/models.go
+++ b/internal/orchestrator/models.go
@@ -381,7 +381,7 @@ func buildBrickConfigForEIModel(bricksIndex *bricksindex.BricksIndex, category *
 			}
 		}
 		for _, name := range brick.ModelConfigurationVariables {
-			// TODO: here we should use the `ai_frameworks_compatibility` for selecting only bricks compatible with edge impusle models.
+			// TODO: here we should use the `ai_frameworks_compatibility` for selecting only bricks compatible with Edge Impulse models.
 			if strings.HasPrefix(name, "EI_") && strings.HasSuffix(name, "_MODEL") {
 				// EI model variables (EI_*_MODEL) get the blob path
 				modelConfigPerBrick[name] = blobModelsDir.String()

--- a/internal/orchestrator/models.go
+++ b/internal/orchestrator/models.go
@@ -381,6 +381,7 @@ func buildBrickConfigForEIModel(bricksIndex *bricksindex.BricksIndex, category *
 			}
 		}
 		for _, name := range brick.ModelConfigurationVariables {
+			// TODO: here we should use the `ai_frameworks_compatibility` for selecting only bricks compatible with edge impusle models.
 			if strings.HasPrefix(name, "EI_") && strings.HasSuffix(name, "_MODEL") {
 				// EI model variables (EI_*_MODEL) get the blob path
 				modelConfigPerBrick[name] = blobModelsDir.String()

--- a/internal/orchestrator/models.go
+++ b/internal/orchestrator/models.go
@@ -373,15 +373,17 @@ func buildBrickConfigForEIModel(bricksIndex *bricksindex.BricksIndex, category *
 		modelConfigPerBrick := make(map[string]string)
 		for _, variable := range brick.Variables {
 			name := variable.Name
-			switch {
-			case name == "CUSTOM_MODEL_PATH":
+			if name == "CUSTOM_MODEL_PATH" {
 				modelConfigPerBrick[name] = edgeModelsDir.String()
-			case strings.HasPrefix(name, "EI_") && strings.HasSuffix(name, "_MODEL"):
-				// EI model variables (EI_*_MODEL) get the blob path
-				modelConfigPerBrick[name] = blobModelsDir.String()
-			default:
+			} else {
 				// Leave other variables unset here; they may be user-provided or have defaults
 				slog.Debug("skipping non-model variable for EI auto-config", "variable", name, "brick", brick.ID)
+			}
+		}
+		for _, name := range brick.ModelConfigurationVariables {
+			if strings.HasPrefix(name, "EI_") && strings.HasSuffix(name, "_MODEL") {
+				// EI model variables (EI_*_MODEL) get the blob path
+				modelConfigPerBrick[name] = blobModelsDir.String()
 			}
 		}
 

--- a/internal/orchestrator/models_test.go
+++ b/internal/orchestrator/models_test.go
@@ -31,85 +31,70 @@ func TestBuildBrickConfigForEIModel(t *testing.T) {
 	var yamlContent = `
 bricks:
 - id: arduino:image_classification
+  model_configuration_variables:
+    - EI_CLASSIFICATION_MODEL
   variables:
   - name: CUSTOM_MODEL_PATH
     default_value: /opt/models/ei/
     description: path to the custom model directory
-  - name: EI_CLASSIFICATION_MODEL
-    default_value: /models/ootb/ei/mobilenet-v2-224px.eim
-    description: path to the model file
 - id: arduino:object_detection
+  model_configuration_variables:
+    - EI_OBJ_DETECTION_MODEL
   variables:
   - name: CUSTOM_MODEL_PATH
     default_value: /opt/models/ei/
     description: path to the custom model directory
-  - name: EI_OBJ_DETECTION_MODEL
-    default_value: /models/ootb/ei/yolo-x-nano.eim
-    description: path to the model file
 - id: arduino:video_object_detection
+  model_configuration_variables:
+    - EI_V_OBJ_DETECTION_MODEL
   variables:
-  - name: EI_OBJ_DETECTION_MODEL
-    default_value: /models/ootb/ei/yolo-x-nano.eim
-    description: Path to the model file
-    hidden: true
   - name: CUSTOM_MODEL_PATH
     default_value: /home/arduino/.arduino-bricks/ei-models
     description: Path to the custom model directory
     hidden: true
 - id: arduino:visual_anomaly_detection
+  model_configuration_variables:
+    - EI_V_ANOMALY_DETECTION_MODEL
   variables:
   - name: CUSTOM_MODEL_PATH
     default_value: /opt/models/ei/
     description: path to the custom model directory
-  - name: EI_V_ANOMALY_DETECTION_MODEL
-    default_value: /models/ootb/ei/concrete-crack-anomaly-detection.eim
-    description: path to the model file
 - id: arduino:keyword_spotting
+  model_configuration_variables:
+    - EI_KEYWORD_SPOTTING_MODEL
   variables:
-  - name: EI_KEYWORD_SPOTTING_MODEL
-    default_value: /models/ootb/ei/keyword-spotting-hey-arduino.eim
-    description: Path to the model file
-    hidden: true
   - name: CUSTOM_MODEL_PATH
     default_value: /home/arduino/.arduino-bricks/ei-models
     description: Path to the custom model directory
     hidden: true
 - id: arduino:audio_classification
+  model_configuration_variables:
+    - EI_AUDIO_CLASSIFICATION_MODEL
   variables:
-  - name: EI_AUDIO_CLASSIFICATION_MODEL
-    default_value: /models/ootb/ei/glass-breaking.eim
-    description: Path to the model file
-    hidden: true
   - name: CUSTOM_MODEL_PATH
     default_value: /home/arduino/.arduino-bricks/ei-models
     description: Path to the custom model directory
     hidden: true
 - id: arduino:motion_detection
+  model_configuration_variables:
+    - EI_MOTION_DETECTION_MODEL
   variables:
-  - name: EI_MOTION_DETECTION_MODEL
-    default_value: /models/ootb/ei/updown-wave-motion-detection.eim
-    description: Path to the model file
-    hidden: true
   - name: CUSTOM_MODEL_PATH
     default_value: /home/arduino/.arduino-bricks/ei-models
     description: Path to the custom model directory
     hidden: true
 - id: arduino:vibration_anomaly_detection
+  model_configuration_variables:
+    - EI_VIBRATION_ANOMALY_DETECTION_MODEL
   variables:
-  - name: EI_VIBRATION_ANOMALY_DETECTION_MODEL
-    default_value: /models/ootb/ei/fan-anomaly-detection.eim
-    description: Path to the model file
-    hidden: true
   - name: CUSTOM_MODEL_PATH
     default_value: /home/arduino/.arduino-bricks/ei-models
     description: Path to the custom model directory
     hidden: true
 - id: arduino:video_image_classification
+  model_configuration_variables:
+    - EI_V_CLASSIFICATION_MODEL
   variables:
-  - name: EI_V_CLASSIFICATION_MODEL
-    default_value: /models/ootb/ei/mobilenet-v2-224px.eim
-    description: Path to the model file
-    hidden: true
   - name: CUSTOM_MODEL_PATH
     default_value: /home/arduino/.arduino-bricks/ei-models
     description: Path to the custom model directory
@@ -148,8 +133,8 @@ bricks:
 					"EI_OBJ_DETECTION_MODEL": "/models/custom-ei/ei-xxxx-yyyy",
 				},
 				{
-					"CUSTOM_MODEL_PATH":      "/models/custom-ei/ei-xxxx-yyyy",
-					"EI_OBJ_DETECTION_MODEL": "/models/custom-ei/ei-xxxx-yyyy",
+					"CUSTOM_MODEL_PATH":        "/models/custom-ei/ei-xxxx-yyyy",
+					"EI_V_OBJ_DETECTION_MODEL": "/models/custom-ei/ei-xxxx-yyyy",
 				},
 			},
 		},


### PR DESCRIPTION
### Motivation

Custom edge impulse model wasn't correctly configured for `arduino:video-object-detection` brick. So the user wasn't able to select the model, which caused the brick to use the default one.

### Change description

Use the `model_configuration_variables` instead of guessing it from the variables.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
