### PR TITLE
feat: implement model download action 

### DIFF
--- a/internal/api/handlers/ai_models.go
+++ b/internal/api/handlers/ai_models.go
@@ -173,8 +173,13 @@ func HandleInstallModel(dockerClient command.Cli, cfg config.Configuration, mode
 			return
 		}
 
-		if _, found := modelsIndex.FindModelByID(id); !found {
+		m, found := modelsIndex.GetModelByID(r.Context(), id)
+		if !found {
 			render.EncodeResponse(w, http.StatusNotFound, models.ErrorResponse{Details: fmt.Sprintf("model %q not found", id)})
+			return
+		}
+		if m.Installed {
+			render.EncodeResponse(w, http.StatusConflict, models.ErrorResponse{Details: fmt.Sprintf("model %q already installed", id)})
 			return
 		}
 

--- a/internal/orchestrator/models.go
+++ b/internal/orchestrator/models.go
@@ -450,12 +450,6 @@ func InstallModelByHandler(ctx context.Context, cli client.APIClient, modelID st
 		return fmt.Errorf("%q: %w", modelID, ErrNotFound)
 	}
 
-	if model.Installed {
-		slog.Info("model already installed", "model", modelID)
-		cb(StreamMessage{data: "Model already installed"})
-		return nil
-	}
-
 	handler, ok := modelsIndex.Handlers.GetHandlerByID(model.Deployment.Handler)
 	if !ok {
 		return fmt.Errorf("handler %q not found for model %q", model.Deployment.Handler, modelID)
@@ -473,7 +467,7 @@ func InstallModelByHandler(ctx context.Context, cli client.APIClient, modelID st
 	installResponse := func(e modelsindex.ModelDownloadEvent) {
 		switch e.Type {
 		case modelsindex.ModelInstallEventStart:
-			cb(StreamMessage{data: "Starting model installation..."})
+			cb(StreamMessage{data: e.Description})
 		case modelsindex.ModelInstallEventUpdate:
 			if e.Total > 0 {
 				cb(StreamMessage{progress: &Progress{Name: modelID, Progress: float32(e.Current) * 100 / float32(e.Total)}})

--- a/internal/orchestrator/models.go
+++ b/internal/orchestrator/models.go
@@ -450,55 +450,46 @@ func InstallModelByHandler(ctx context.Context, cli client.APIClient, modelID st
 		return fmt.Errorf("%q: %w", modelID, ErrNotFound)
 	}
 
-	handler, ok := modelsIndex.Handlers.GetHandlerByID(model.Deployment.Handler)
-	if !ok {
-		return fmt.Errorf("handler %q not found for model %q", model.Deployment.Handler, modelID)
-	}
-
-	downloadPath := cfg.CustomModelsDir()
-	if err := downloadPath.MkdirAll(); err != nil {
-		return fmt.Errorf("cannot create download location %q: %w", downloadPath, err)
-	}
-
-	var envVars map[string]string
-	if model.Deployment != nil {
-		envVars = model.Deployment.VariablesForPlatform(plat.BoardName)
-	}
-
 	if model.Installed {
 		slog.Info("model already installed", "model", modelID)
 		cb(StreamMessage{data: "Model already installed"})
 		return nil
 	}
 
-	if info, err := fetchModelInfo(ctx, cli, *model, handler, downloadPath, envVars); err != nil {
-		slog.Warn("could not fetch model info", "model", modelID, "err", err)
-	} else if info != nil && info.sizeBytes > 0 {
-		if err := hasSufficientDiskSpace(downloadPath, info.sizeBytes); err != nil {
-			return err
-		}
+	handler, ok := modelsIndex.Handlers.GetHandlerByID(model.Deployment.Handler)
+	if !ok {
+		return fmt.Errorf("handler %q not found for model %q", model.Deployment.Handler, modelID)
 	}
 
-	slog.Info("installing model", "model", modelID, "path", downloadPath)
-	installResponse := func(e ModelInstallEvent) {
+	// TODO: move the fetch ModelInfo inise a RunModelInfo inside the modelsindex
+	// if info, err := fetchModelInfo(ctx, cli, *model, handler, downloadPath, envVars); err != nil {
+	// 	slog.Warn("could not fetch model info", "model", modelID, "err", err)
+	// } else if info != nil && info.sizeBytes > 0 {
+	// 	if err := hasSufficientDiskSpace(downloadPath, info.sizeBytes); err != nil {
+	// 		return err
+	// 	}
+	// }
+
+	installResponse := func(e modelsindex.ModelDownloadEvent) {
 		switch e.Type {
-		case ModelInstallEventStart:
+		case modelsindex.ModelInstallEventStart:
 			cb(StreamMessage{data: "Starting model installation..."})
-		case ModelInstallEventUpdate:
+		case modelsindex.ModelInstallEventUpdate:
 			if e.Total > 0 {
 				cb(StreamMessage{progress: &Progress{Name: modelID, Progress: float32(e.Current) * 100 / float32(e.Total)}})
 			} else {
 				cb(StreamMessage{progress: &Progress{Name: modelID, Progress: 0}})
 			}
-		case ModelInstallEventComplete:
+		case modelsindex.ModelInstallEventComplete:
 			cb(StreamMessage{progress: &Progress{Name: modelID, Progress: 100}}) // used by the FE to understand that the installation is complete
-		case ModelInstallEventError:
+		case modelsindex.ModelInstallEventError:
 			cb(StreamMessage{data: fmt.Sprintf("Error: %s", e.Description)})
 		default:
 			cb(StreamMessage{data: e.Description})
 		}
 	}
-	return runHandlerAction(ctx, cli, *model, handler.Image, handler.Actions.Download, handler.Volumes, downloadPath, envVars, installResponse)
+
+	return modelsindex.RunDownloadAction(ctx, cli, *model, handler, cfg, plat, installResponse)
 }
 
 type modelInfoResult struct {
@@ -523,24 +514,24 @@ func fetchModelInfo(ctx context.Context, cli client.APIClient, model modelsindex
 	return &result, nil
 }
 
-// hasSufficientDiskSpace checks whether the filesystem containing path has at
-// least requiredBytes of free space. It walks up to the first existing ancestor
-// if path does not yet exist.
-func hasSufficientDiskSpace(path *paths.Path, requiredBytes int64) error {
-	target := path
-	for target != nil && target.NotExist() {
-		target = target.Parent()
-	}
-	if target == nil {
-		return nil // cannot determine filesystem, skip check
-	}
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(target.String(), &stat); err != nil {
-		return fmt.Errorf("cannot check disk space: %w", err)
-	}
-	available := int64(stat.Bavail) * int64(stat.Bsize)
-	if available < requiredBytes {
-		return ErrInsufficientStorage
-	}
-	return nil
-}
+// // hasSufficientDiskSpace checks whether the filesystem containing path has at
+// // least requiredBytes of free space. It walks up to the first existing ancestor
+// // if path does not yet exist.
+// func hasSufficientDiskSpace(path *paths.Path, requiredBytes int64) error {
+// 	target := path
+// 	for target != nil && target.NotExist() {
+// 		target = target.Parent()
+// 	}
+// 	if target == nil {
+// 		return nil // cannot determine filesystem, skip check
+// 	}
+// 	var stat syscall.Statfs_t
+// 	if err := syscall.Statfs(target.String(), &stat); err != nil {
+// 		return fmt.Errorf("cannot check disk space: %w", err)
+// 	}
+// 	available := int64(stat.Bavail) * int64(stat.Bsize)
+// 	if available < requiredBytes {
+// 		return ErrInsufficientStorage
+// 	}
+// 	return nil
+// }

--- a/internal/orchestrator/modelsindex/handlers_index.go
+++ b/internal/orchestrator/modelsindex/handlers_index.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"github.com/docker/docker/client"
 
 	"github.com/arduino/arduino-app-cli/internal/dockerhandler"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
 
@@ -220,6 +222,109 @@ func runListAction(ctx context.Context, cli client.APIClient, listing *ListingCo
 	}
 
 	return output.Models, nil
+}
+
+func RunDownloadAction(ctx context.Context, cli client.APIClient, model AIModel, handler ModelHandler, config config.Configuration, plat platform.Platform, publish func(e ModelDownloadEvent)) error {
+	downloadPath := config.CustomModelsDir()
+	if err := downloadPath.MkdirAll(); err != nil {
+		return fmt.Errorf("cannot create download location %q: %w", downloadPath, err)
+	}
+
+	binds, volumeEnv := ResolveVolumes(handler.Volumes, map[string]string{
+		"ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR": downloadPath.String(),
+	})
+
+	var envVars map[string]string
+	if model.Deployment != nil {
+		envVars = model.Deployment.VariablesForPlatform(plat.BoardName)
+	}
+
+	env := make([]string, 0, len(envVars)+len(volumeEnv))
+	env = append(env, volumeEnv...)
+	for k, v := range envVars {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	slog.Debug("running download action", "model", model.ID)
+	return dockerhandler.Run(ctx, cli, dockerhandler.RunOptions{
+		Image: handler.Image,
+		Cmd:   handler.Actions.Download,
+		Binds: binds,
+		Env:   env,
+		LineCallback: func(line string) {
+			slog.Debug("download line", "model", model.ID, "line", line)
+			parseDownloadHandlerLine(line, publish)
+		},
+		Stderr: io.Discard,
+	})
+}
+
+type ModelInstallEventType string
+
+const (
+	// Container-emitted event types (match the Python script's event field).
+	ModelInstallEventStart    ModelInstallEventType = "start"
+	ModelInstallEventUpdate   ModelInstallEventType = "update"
+	ModelInstallEventComplete ModelInstallEventType = "complete"
+	ModelInstallEventInfo     ModelInstallEventType = "info"
+	ModelInstallEventError    ModelInstallEventType = "error"
+	// Synthetic event emitted by Go after the container exits.
+	ModelInstallEventDone ModelInstallEventType = "done"
+)
+
+type ModelDownloadEvent struct {
+	ModelID     string                `json:"model_id"`
+	Type        ModelInstallEventType `json:"type"`
+	Description string                `json:"description,omitempty"`
+	Current     int64                 `json:"current,omitempty"`
+	Total       int64                 `json:"total,omitempty"`
+	Unit        string                `json:"unit,omitempty"`
+	Percentage  string                `json:"percentage,omitempty"`
+	Artifacts   []string              `json:"artifacts,omitempty"`
+}
+
+func parseDownloadHandlerLine(line string, publish func(ModelDownloadEvent)) {
+	var raw struct {
+		Event       string   `json:"event"`
+		Description string   `json:"description"`
+		Current     int64    `json:"current"`
+		Total       int64    `json:"total"`
+		SizeMB      float64  `json:"size_mb"`
+		Unit        string   `json:"unit"`
+		Percentage  string   `json:"percentage"`
+		Artifacts   []string `json:"artifacts"`
+	}
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		slog.Debug("non-JSON stdout from handler", "line", line)
+		return
+	}
+	var eventType ModelInstallEventType
+	switch raw.Event {
+	case "start":
+		eventType = ModelInstallEventStart
+	case "update":
+		eventType = ModelInstallEventUpdate
+	case "complete":
+		eventType = ModelInstallEventComplete
+	case "error":
+		eventType = ModelInstallEventError
+	case "stat":
+		eventType = ModelInstallEventInfo
+		if raw.SizeMB > 0 {
+			raw.Total = int64(raw.SizeMB * 1024 * 1024)
+		}
+	default:
+		eventType = ModelInstallEventInfo
+	}
+	publish(ModelDownloadEvent{
+		Type:        eventType,
+		Description: raw.Description,
+		Current:     raw.Current,
+		Total:       raw.Total,
+		Unit:        raw.Unit,
+		Percentage:  raw.Percentage,
+		Artifacts:   raw.Artifacts,
+	})
 }
 
 type rawActionEntry struct {

--- a/internal/orchestrator/modelsindex/handlers_index_test.go
+++ b/internal/orchestrator/modelsindex/handlers_index_test.go
@@ -1,0 +1,96 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package modelsindex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDownloadHandlerLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		expected ModelDownloadEvent
+	}{
+		{
+			name: "start event",
+			line: `{"event":"start","description":"downloading"}`,
+			expected: ModelDownloadEvent{
+				Type:        ModelInstallEventStart,
+				Description: "downloading",
+			},
+		},
+		{
+			name: "update event",
+			line: `{"event":"update","current":64,"total":128,"unit":"bytes","percentage":"50%"}`,
+			expected: ModelDownloadEvent{
+				Type:       ModelInstallEventUpdate,
+				Current:    64,
+				Total:      128,
+				Unit:       "bytes",
+				Percentage: "50%",
+			},
+		},
+		{
+			name: "complete event with artifacts",
+			line: `{"event":"complete","artifacts":["model.eim","meta.json"]}`,
+			expected: ModelDownloadEvent{
+				Type:      ModelInstallEventComplete,
+				Artifacts: []string{"model.eim", "meta.json"},
+			},
+		},
+		{
+			name: "error event",
+			line: `{"event":"error","description":"network failure"}`,
+			expected: ModelDownloadEvent{
+				Type:        ModelInstallEventError,
+				Description: "network failure",
+			},
+		},
+		{
+			name: "stat event maps to info and converts size_mb",
+			line: `{"event":"stat","size_mb":1.5}`,
+			expected: ModelDownloadEvent{
+				Type:  ModelInstallEventInfo,
+				Total: int64(1.5 * 1024 * 1024),
+			},
+		},
+		{
+			name: "unknown event maps to info",
+			line: `{"event":"something-else","description":"note"}`,
+			expected: ModelDownloadEvent{
+				Type:        ModelInstallEventInfo,
+				Description: "note",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []ModelDownloadEvent
+
+			parseDownloadHandlerLine(tt.line, func(e ModelDownloadEvent) {
+				got = append(got, e)
+			})
+
+			require.Len(t, got, 1)
+			assert.Equal(t, tt.expected, got[0])
+		})
+	}
+
+	t.Run("invalid json does not publish", func(t *testing.T) {
+		called := false
+
+		parseDownloadHandlerLine("not-json", func(ModelDownloadEvent) {
+			called = true
+		})
+
+		assert.False(t, called)
+	})
+}

--- a/internal/orchestrator/modelsindex/handlers_index_test.go
+++ b/internal/orchestrator/modelsindex/handlers_index_test.go
@@ -94,3 +94,53 @@ func TestParseDownloadHandlerLine(t *testing.T) {
 		assert.False(t, called)
 	})
 }
+
+func TestResolveVolumes(t *testing.T) {
+	t.Run("it resolves variables and adds env only once", func(t *testing.T) {
+		vols := []string{
+			"${MODELS_DIR}:/models",
+			"${MODELS_DIR}:/backup",
+			"${CACHE_DIR:-/tmp/cache}:/cache",
+		}
+		vars := map[string]string{
+			"MODELS_DIR": "/var/models",
+		}
+
+		binds, envAdditions := ResolveVolumes(vols, vars)
+
+		assert.Equal(t, []string{
+			"/var/models:/models",
+			"/var/models:/backup",
+			"/tmp/cache:/cache",
+		}, binds)
+		assert.Equal(t, []string{"MODELS_DIR=/var/models"}, envAdditions)
+	})
+
+	t.Run("it uses provided value instead of default and tracks multiple variables", func(t *testing.T) {
+		vols := []string{
+			"${MODELS_DIR:-/tmp/models}:/models",
+			"${CACHE_DIR:-/tmp/cache}:/cache",
+		}
+		vars := map[string]string{
+			"MODELS_DIR": "/opt/models",
+			"CACHE_DIR":  "/opt/cache",
+		}
+
+		binds, envAdditions := ResolveVolumes(vols, vars)
+
+		assert.Equal(t, []string{
+			"/opt/models:/models",
+			"/opt/cache:/cache",
+		}, binds)
+		assert.Equal(t, []string{"MODELS_DIR=/opt/models", "CACHE_DIR=/opt/cache"}, envAdditions)
+	})
+
+	t.Run("it leaves empty substitution when variable is missing and no default", func(t *testing.T) {
+		vols := []string{"${UNSET_VAR}:/models"}
+
+		binds, envAdditions := ResolveVolumes(vols, map[string]string{})
+
+		assert.Equal(t, []string{":/models"}, binds)
+		assert.Empty(t, envAdditions)
+	})
+}

--- a/internal/orchestrator/modelsindex/models_index.go
+++ b/internal/orchestrator/modelsindex/models_index.go
@@ -177,7 +177,7 @@ func (m *ModelsIndex) setSizes(ctx context.Context, l []AIModel) []AIModel {
 		} else if size, ok := sizes[l[i].ID]; ok {
 			l[i].Size = size
 		}
-		//TODO Custom-EI are out from this flow.
+		// TODO Custom-EI are out from this flow.
 	}
 	return l
 }


### PR DESCRIPTION
### Motivation
Revise the download endpoint

### Change description
- return the sse events  
```
arduino@ventunoq:~$ curl -v -d "" -X PUT http://localhost:8800/v1/models/llamacpp:gemma-3-1b-it-Q4_0

event: message
data: {"message":"gemma-3-1b-it-Q4_0.gguf"}

event: progress
data: {"name":"llamacpp:gemma-3-1b-it-Q4_0","progress":0}

event: progress
data: {"name":"llamacpp:gemma-3-1b-it-Q4_0","progress":0.014675757}

event: progress
data: {"name":"llamacpp:gemma-3-1b-it-Q4_0","progress":0.91399306}

event: progress
data: {"name":"llamacpp:gemma-3-1b-it-Q4_0","progress":3.7820709}

event: progress
data: {"name":"llamacpp:gemma-3-1b-it-Q4_0","progress":22.366545}

event: progress
data: {"name":"llamacpp:gemma-3-1b-it-Q4_0","progress":35.461067}

event: progress
data: {"name":"llamacpp:gemma-3-1b-it-Q4_0","progress":64.5726}

event: progress
data: {"name":"llamacpp:gemma-3-1b-it-Q4_0","progress":73.86633}

event: progress
data: {"name":"llamacpp:gemma-3-1b-it-Q4_0","progress":83.15783}

event: progress
data: {"name":"llamacpp:gemma-3-1b-it-Q4_0","progress":100}

event: progress
data: {"name":"llamacpp:gemma-3-1b-it-Q4_0","progress":100}

event: progress
data: {"name":"llamacpp:gemma-3-1b-it-Q4_0","progress":100}

event: message
data: {"message":"Generated models.ini with 1 model(s)"}

event: error
data: {"code":"SERVER_CLOSED"}

```
- return 406 conflict if the model is already installed

```
arduino@ventunoq:~$ curl -v -d "" -X PUT http://localhost:8800/v1/models/llamacpp:gemma-3-1b-it-Q4_0

< HTTP/1.1 409 Conflict
< Content-Type: application/json
< Vary: Origin
< Date: Mon, 15 Jun 2026 13:34:06 GMT
< Content-Length: 70

{"details":"model \"llamacpp:gemma-3-1b-it-Q4_0\" already installed"}
```
### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
