### PR TITLE
fix: follow link in app export

### DIFF
--- a/internal/orchestrator/archive.go
+++ b/internal/orchestrator/archive.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 
 	"path/filepath"
@@ -52,37 +51,40 @@ func zipAppToBuffer(bricksIndex *bricksindex.BricksIndex, sourcePath string, roo
 	buf := new(bytes.Buffer)
 	zipWriter := zip.NewWriter(buf)
 
-	err := filepath.WalkDir(sourcePath, func(path string, d fs.DirEntry, err error) error {
+	skipFilter := func(p *paths.Path) bool {
+		name := p.Base()
+		if name == ".cache" {
+			return false
+		}
+		if !includeData && name == "data" {
+			return false
+		}
+		return true
+	}
+
+	entries, err := paths.New(sourcePath).ReadDirRecursiveFiltered(skipFilter, skipFilter)
+	if err != nil {
+		zipWriter.Close()
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		relPath, err := filepath.Rel(sourcePath, entry.String())
 		if err != nil {
-			return err
+			zipWriter.Close()
+			return nil, err
 		}
 
-		relPath, err := filepath.Rel(sourcePath, path)
+		info, err := entry.Stat() // follows symlinks
 		if err != nil {
-			return err
-		}
-		if relPath == "." {
-			return nil
-		}
-		if d.IsDir() {
-			name := d.Name()
-			// Always skip .cache
-			if name == ".cache" {
-				return filepath.SkipDir
-			}
-			// Conditionally skip data
-			if !includeData && name == "data" {
-				return filepath.SkipDir
-			}
+			zipWriter.Close()
+			return nil, err
 		}
 
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
 		header, err := zip.FileInfoHeader(info)
 		if err != nil {
-			return err
+			zipWriter.Close()
+			return nil, err
 		}
 
 		header.Name = filepath.ToSlash(filepath.Join(rootFolderName, relPath))
@@ -91,36 +93,41 @@ func zipAppToBuffer(bricksIndex *bricksindex.BricksIndex, sourcePath string, roo
 		} else {
 			header.Method = zip.Deflate
 		}
+
 		writer, err := zipWriter.CreateHeader(header)
 		if err != nil {
-			return err
+			zipWriter.Close()
+			return nil, err
 		}
 
 		if info.IsDir() {
-			return nil
+			continue
 		}
 
-		if d.Name() == "app.yaml" { // nolint:goconst
-			desc, err := app.ParseDescriptorFile(paths.New(path))
+		if entry.Base() == "app.yaml" { // nolint:goconst
+			desc, err := app.ParseDescriptorFile(entry)
 			if err != nil {
-				return err
+				zipWriter.Close()
+				return nil, err
 			}
 			redactSecrets(bricksIndex, &desc)
-			err = yaml.NewEncoder(writer).Encode(desc)
-			return err
-		} else {
-			file, err := os.Open(path) // nolint:gosec
-			if err != nil {
-				return err
+			if err := yaml.NewEncoder(writer).Encode(desc); err != nil {
+				zipWriter.Close()
+				return nil, err
 			}
-			defer file.Close()
-			_, err = io.Copy(writer, file)
-			return err
+		} else {
+			file, err := entry.Open() // nolint:gosec
+			if err != nil {
+				zipWriter.Close()
+				return nil, err
+			}
+			_, copyErr := io.Copy(writer, file)
+			file.Close()
+			if copyErr != nil {
+				zipWriter.Close()
+				return nil, copyErr
+			}
 		}
-	})
-	if err != nil {
-		zipWriter.Close()
-		return nil, err
 	}
 
 	if err := zipWriter.Close(); err != nil {

--- a/internal/orchestrator/archive.go
+++ b/internal/orchestrator/archive.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"syscall"
 
 	"path/filepath"
 	"strings"
@@ -77,6 +78,10 @@ func zipAppToBuffer(bricksIndex *bricksindex.BricksIndex, sourcePath string, roo
 
 		info, err := entry.Stat() // follows symlinks
 		if err != nil {
+			if errors.Is(err, syscall.ELOOP) {
+				// skip symlink loops
+				continue
+			}
 			zipWriter.Close()
 			return nil, err
 		}

--- a/internal/orchestrator/archive_test.go
+++ b/internal/orchestrator/archive_test.go
@@ -108,7 +108,7 @@ func TestExportAppZip(t *testing.T) {
 				"link-b": "link-a",
 			},
 			includeData:  false,
-			wantErr:      true,
+			wantErr:      false,
 			wantFilename: "circular-app.zip",
 			wantFiles:    []string{"app.yaml"},
 		},

--- a/internal/orchestrator/archive_test.go
+++ b/internal/orchestrator/archive_test.go
@@ -34,6 +34,7 @@ func TestExportAppZip(t *testing.T) {
 		name             string
 		appName          string
 		files            []string
+		symlinks         map[string]string // link name -> target
 		nonExistent      bool
 		includeData      bool
 		wantFiles        []string
@@ -78,6 +79,26 @@ func TestExportAppZip(t *testing.T) {
 			nonExistent: true,
 			wantErr:     true,
 		},
+		{
+			name:         "Symlink to file is included in zip",
+			appName:      "Symlink File App",
+			files:        []string{"app.yaml", "bricks-list.yaml"},
+			symlinks:     map[string]string{"bricks-copy.yaml": "bricks-list.yaml"},
+			includeData:  false,
+			wantErr:      false,
+			wantFilename: "symlink-file-app.zip",
+			wantFiles:    []string{"app.yaml", "bricks-list.yaml", "bricks-copy.yaml"},
+		},
+		{
+			name:         "Symlink to directory is included in zip",
+			appName:      "Symlink Dir App",
+			files:        []string{"app.yaml", "data/foo.txt"},
+			symlinks:     map[string]string{"data2": "data"},
+			includeData:  true,
+			wantErr:      false,
+			wantFilename: "symlink-dir-app.zip",
+			wantFiles:    []string{"app.yaml", "data/foo.txt", "data2/foo.txt"},
+		},
 	}
 
 	for _, tc := range tests {
@@ -85,6 +106,7 @@ func TestExportAppZip(t *testing.T) {
 			tmpDir := t.TempDir()
 
 			writeFiles(t, tmpDir, tc.files)
+			writeSymlinks(t, tmpDir, tc.symlinks)
 
 			appPath := tmpDir
 			if tc.nonExistent {
@@ -334,6 +356,16 @@ func writeFiles(t *testing.T, tmpPath string, files []string) {
 		dstPath := filepath.Join(tmpPath, path)
 		require.NoError(t, os.MkdirAll(filepath.Dir(dstPath), 0755))
 		require.NoError(t, os.WriteFile(dstPath, content, 0600))
+	}
+}
+
+func writeSymlinks(t *testing.T, tmpPath string, symlinks map[string]string) {
+	t.Helper()
+
+	for linkName, target := range symlinks {
+		linkPath := filepath.Join(tmpPath, linkName)
+		require.NoError(t, os.MkdirAll(filepath.Dir(linkPath), 0755))
+		require.NoError(t, os.Symlink(target, linkPath))
 	}
 }
 

--- a/internal/orchestrator/archive_test.go
+++ b/internal/orchestrator/archive_test.go
@@ -99,6 +99,19 @@ func TestExportAppZip(t *testing.T) {
 			wantFilename: "symlink-dir-app.zip",
 			wantFiles:    []string{"app.yaml", "data/foo.txt", "data2/foo.txt"},
 		},
+		{
+    name:    "Circular symlink does not loop",
+    appName: "Circular App",
+    files:   []string{"app.yaml"},
+    symlinks: map[string]string{
+        "link-a": "link-b",
+        "link-b": "link-a",
+    },
+    includeData:  false,
+    wantErr:      true, 
+    wantFilename: "circular-app.zip",
+    wantFiles:    []string{"app.yaml"},
+},
 	}
 
 	for _, tc := range tests {

--- a/internal/orchestrator/archive_test.go
+++ b/internal/orchestrator/archive_test.go
@@ -100,18 +100,18 @@ func TestExportAppZip(t *testing.T) {
 			wantFiles:    []string{"app.yaml", "data/foo.txt", "data2/foo.txt"},
 		},
 		{
-    name:    "Circular symlink does not loop",
-    appName: "Circular App",
-    files:   []string{"app.yaml"},
-    symlinks: map[string]string{
-        "link-a": "link-b",
-        "link-b": "link-a",
-    },
-    includeData:  false,
-    wantErr:      true, 
-    wantFilename: "circular-app.zip",
-    wantFiles:    []string{"app.yaml"},
-},
+			name:    "Circular symlink does not loop",
+			appName: "Circular App",
+			files:   []string{"app.yaml"},
+			symlinks: map[string]string{
+				"link-a": "link-b",
+				"link-b": "link-a",
+			},
+			includeData:  false,
+			wantErr:      true,
+			wantFilename: "circular-app.zip",
+			wantFiles:    []string{"app.yaml"},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
### Motivation

App export fails if the app folder has some links.

### Change description

Add the link following in the zip creation. 

Removed [filepath.WalkDir](https://pkg.go.dev/path/filepath#WalkDir), which doesn't follow links and uses https://github.com/arduino/go-paths-helper/blob/master/readdir.go#L78

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [x] PR addresses a single concern.
- [x] PR title and description are properly filled.
- [x] Changes will be merged in `main`.
- [x] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
