### PR TITLE
fix: handle additional model installation events and log unknown event

### DIFF
--- a/internal/api/handlers/ai_models.go
+++ b/internal/api/handlers/ai_models.go
@@ -237,10 +237,14 @@ func HandleInstallModel(dockerClient command.Cli, cfg config.Configuration, mode
 				}
 			case modelsindex.ModelInstallEventComplete:
 				sseStream.Send(render.SSEEvent{Type: "progress", Data: &progress{Name: m.ID, Progress: 100}}) // used by the FE to understand that the installation is complete
+			case modelsindex.ModelInstallEventDone:
+				sseStream.Send(render.SSEEvent{Type: "progress", Data: &progress{Name: m.ID, Progress: 100}}) // used by the FE to understand that the installation is complete
 			case modelsindex.ModelInstallEventError:
 				sseStream.Send(render.SSEEvent{Type: "message", Data: log{Message: e.Description}})
+			case modelsindex.ModelInstallEventInfo:
+				sseStream.Send(render.SSEEvent{Type: "message", Data: log{Message: e.Description}})
 			default:
-				panic("unknown event")
+				panic(fmt.Sprintf("unknown event: %+v", e.Type))
 			}
 		}
 


### PR DESCRIPTION

### Motivation
There is a `info` message sent by some model downoaler (like  `melo-tts-zh`) that cause the panic
```
{ModelID: Type:info Description:Downloading model from: https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-models/models/melotts_zh/releases/v0.51.0/melotts_zh-voice_ai-mixed_with_float-qualcomm_qcs8275.zip Current:0 Total:0 Unit: Percentage: Artifacts:[]}"
```
### Change description

Add all the type of messages

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
