### PR TITLE
feat(brick-template): enhance README template `@brick` decorator

### DIFF
--- a/internal/orchestrator/app/generator/app_generator_test.go
+++ b/internal/orchestrator/app/generator/app_generator_test.go
@@ -120,7 +120,6 @@ func TestGenerateAppBrick(t *testing.T) {
 
 		err = GenerateLocalBrick(a.GetBricksPath(), "my-brick", "a-brick-name")
 		require.NoError(t, err)
-
 		if os.Getenv("UPDATE_GOLDEN") == "true" {
 			t.Logf("UPDATE_GOLDEN=true: updating  golden files in %s", "testdata/app-with-brick.golden")
 			require.NoError(t, os.RemoveAll("testdata/app-with-brick.golden"))

--- a/internal/orchestrator/app/generator/brick_template/README.md.template
+++ b/internal/orchestrator/app/generator/brick_template/README.md.template
@@ -6,19 +6,54 @@ Custom Bricks are modular components that add reusable functionality to your app
 
 ## How to use it
 
-Write your Python logic inside `bricks/{{ .ID }}/__init__.py`
+Write your Python class inside `bricks/{{ .ID }}/__init__.py` and add the `@brick` decorator.
 ```python
 # bricks/{{ .ID }}/__init__.py
-def greet(name):
-    return f"Hello {name}, I am the {{ .Name }} brick"
+from arduino.app_utils import App, brick, Logger
+import time
+
+logger = Logger("GreeterBrick")
+
+@brick
+class Greeter:
+    def __init__(self, name="World"):
+        self.name = name
+
+    def start(self):
+        logger.info("Starting Greeter")
+
+    def stop(self):
+        logger.info("Stopping Greeter")
+
+    # This is a non-blocking method that will be called repeatedly
+    def loop(self):
+        logger.info(f"Hello, {self.name}!")
+        time.sleep(1)
+
 ```
 
 You can then import and use your Brick in your main application code:
 ```python
 # python/main.py
-from {{ .ID }} import greet
+from arduino.app_utils import App
+from greeter import Greeter
 
-print(greet("world"))
+g = Greeter()
+
+App.run()
+```
+
+When `App.run()` is executed, the framework automatically manages the application lifecycle and threading:
+```
+======== App is starting ============================
+2026-06-18 09:47:27.250 INFO - [MainThread] App:  App started
+2026-06-18 09:47:27.247 INFO - [MainThread] GreeterBrick:  Starting Greeter
+2026-06-18 09:47:27.249 INFO - [Greeter.loop] GreeterBrick:  Hello, World!
+2026-06-18 09:47:28.251 INFO - [Greeter.loop] GreeterBrick:  Hello, World!
+2026-06-18 09:47:29.251 INFO - [Greeter.loop] GreeterBrick:  Hello, World!
+2026-06-18 09:47:57.797 INFO - [MainThread] App:  App is shutting down
+2026-06-18 09:47:57.798 INFO - [MainThread] GreeterBrick:  Stopping Greeter
+======== App shutdown completed =====================
 ```
 
 ## What's in the brick folder
@@ -42,15 +77,11 @@ variables:
 ```
 Note: Variables defined in this file are automatically injected into your Brick as environment variables at runtime.
 
-You can then read this variable inside your Python code using the standard os module. It is good practice to provide a default value in case the variable isn't set:
+You can then read this variable inside your Python code using the standard os module.
 
 ``` python
 import os
-
-def greet():
-    # Read the environment variable
-    name = os.getenv("YOUR_NAME")
-    return f"Hello, {name}!"
+name = os.getenv("YOUR_NAME")
 ```
 
 ## Next

--- a/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/README.md
+++ b/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/README.md
@@ -6,19 +6,53 @@ Custom Bricks are modular components that add reusable functionality to your app
 
 ## How to use it
 
-Write your Python logic inside `bricks/my-brick/__init__.py`
+Write your Python class inside `bricks/my-brick/__init__.py` and add the `@brick` decorator.
 ```python
 # bricks/my-brick/__init__.py
-def greet(name):
-    return f"Hello {name}, I am the a-brick-name brick"
+from arduino.app_utils import App, brick, Logger
+import time
+
+logger = Logger("GreeterBrick")
+
+@brick
+class Greeter:
+    def __init__(self, name="World"):
+        self.name = name
+
+    def start(self):
+        logger.info("Starting Greeter")
+
+    def stop(self):
+        logger.info("Stopping Greeter")
+
+    # This is a non-blocking method that will be called repeatedly
+    def loop(self):
+        logger.info(f"Hello, {self.name}!")
+        time.sleep(1)
 ```
 
 You can then import and use your Brick in your main application code:
 ```python
 # python/main.py
-from my-brick import greet
+from arduino.app_utils import App
+from greeter import Greeter
 
-print(greet("world"))
+g = Greeter()
+
+App.run()
+```
+
+When `App.run()` is executed, the framework automatically manages the application lifecycle and threading:
+```
+======== App is starting ============================
+2026-06-18 09:47:27.250 INFO - [MainThread] App:  App started
+2026-06-18 09:47:27.247 INFO - [MainThread] GreeterBrick:  Starting Greeter
+2026-06-18 09:47:27.249 INFO - [Greeter.loop] GreeterBrick:  Hello, World!
+2026-06-18 09:47:28.251 INFO - [Greeter.loop] GreeterBrick:  Hello, World!
+2026-06-18 09:47:29.251 INFO - [Greeter.loop] GreeterBrick:  Hello, World!
+2026-06-18 09:47:57.797 INFO - [MainThread] App:  App is shutting down
+2026-06-18 09:47:57.798 INFO - [MainThread] GreeterBrick:  Stopping Greeter
+======== App shutdown completed =====================
 ```
 
 ## What's in the brick folder
@@ -42,15 +76,11 @@ variables:
 ```
 Note: Variables defined in this file are automatically injected into your Brick as environment variables at runtime.
 
-You can then read this variable inside your Python code using the standard os module. It is good practice to provide a default value in case the variable isn't set:
+You can then read this variable inside your Python code using the standard os module.
 
 ``` python
 import os
-
-def greet():
-    # Read the environment variable
-    name = os.getenv("YOUR_NAME")
-    return f"Hello, {name}!"
+name = os.getenv("YOUR_NAME")
 ```
 
 ## Next

--- a/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/README.md
+++ b/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/README.md
@@ -29,6 +29,7 @@ class Greeter:
     def loop(self):
         logger.info(f"Hello, {self.name}!")
         time.sleep(1)
+
 ```
 
 You can then import and use your Brick in your main application code:


### PR DESCRIPTION
### Motivation

Currently, the custom brick example in the README does not use the `@brick` decorator. Using the `@brick` decorator on a class, rather than using free functions, provides the following advantages:

* **Lifecycle Management:** The brick is natively managed by the App framework (handling the start, stop, and loop phases).
* **Code Reduction:** It significantly minimizes the boilerplate setup code required in `main.py`.

### Change Description

* Added a class-based brick to the README to serve as scaffolding and demonstrate the use of the `@brick` decorator.


### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
