### PR TITLE
[CLI] adding inline json output stream for init cmd

### DIFF
--- a/cmd/arduino-app-cli/main.go
+++ b/cmd/arduino-app-cli/main.go
@@ -60,7 +60,7 @@ func run(configuration cfg.Configuration) error {
 		SilenceErrors: true,
 	}
 
-	rootCmd.PersistentFlags().StringVar(&format, "format", "text", "Output format (text, json, jsonmini, json-lines)")
+	rootCmd.PersistentFlags().StringVar(&format, "format", "text", "Output format (text, json, json-lines)")
 	rootCmd.PersistentFlags().StringVar(&logLevelStr, "log-level", "error", "Set the log level (debug, info, warn, error)")
 
 	rootCmd.AddCommand(

--- a/cmd/arduino-app-cli/main.go
+++ b/cmd/arduino-app-cli/main.go
@@ -60,7 +60,7 @@ func run(configuration cfg.Configuration) error {
 		SilenceErrors: true,
 	}
 
-	rootCmd.PersistentFlags().StringVar(&format, "format", "text", "Output format (text, json)")
+	rootCmd.PersistentFlags().StringVar(&format, "format", "text", "Output format (text, json, jsonmini, json-lines)")
 	rootCmd.PersistentFlags().StringVar(&logLevelStr, "log-level", "error", "Set the log level (debug, info, warn, error)")
 
 	rootCmd.AddCommand(

--- a/cmd/arduino-app-cli/system/system.go
+++ b/cmd/arduino-app-cli/system/system.go
@@ -50,10 +50,21 @@ func newDownloadImageCmd(cfg config.Configuration) *cobra.Command {
 		Args:   cobra.ExactArgs(0),
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return orchestrator.SystemInit(cmd.Context(), cfg, servicelocator.GetPlatform(), servicelocator.GetBricksIndex(), servicelocator.GetServicesIndex(), servicelocator.GetModelsIndex(), servicelocator.GetDockerClient(), orchestrator.SystemInitOptions{
+			stdout, _, err := feedback.DirectStreams()
+			if err != nil {
+				return err
+			}
+			progressCB := func(progress orchestrator.InitProgress) {
+				percentage := float64(progress.Curr) / float64(progress.Total) * 100
+				fmt.Fprintf(stdout, "%s: %.2f%% (%d/%d)\r", progress.Label, percentage, progress.Curr, progress.Total)
+				if progress.Curr == progress.Total {
+					fmt.Fprintln(stdout)
+				}
+			}
+			return orchestrator.SystemInit(cmd.Context(), cfg, servicelocator.GetPlatform(), servicelocator.GetBricksIndex(), servicelocator.GetServicesIndex(), servicelocator.GetDockerClient(), servicelocator.GetModelsIndex(), orchestrator.SystemInitOptions{
 				OnlyDockerImages:    onlyImages,
 				OnlyPlatformAndLibs: onlyPlatformAndLibraries,
-			})
+			}, progressCB)
 		},
 	}
 

--- a/cmd/arduino-app-cli/system/system.go
+++ b/cmd/arduino-app-cli/system/system.go
@@ -6,9 +6,7 @@
 package system
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"slices"
 	"strings"
 
@@ -44,89 +42,10 @@ func NewSystemCmd(cfg config.Configuration) *cobra.Command {
 	return cmd
 }
 
-// jsonInitEvent is the JSON-lines representation of a single event emitted by
-// `system init --json-feedback`. The Type field ("log" | "progress") is a
-// discriminator that tells the consumer which fields are meaningful.
-type jsonInitEvent struct {
-	Type    string `json:"type"`
-	Message string `json:"message,omitempty"`
-	Label   string `json:"label,omitempty"`
-	Current int64  `json:"current,omitempty"`
-	Total   int64  `json:"total,omitempty"`
-	Percent int    `json:"percent,omitempty"`
-}
-
-// newInitEventCallback builds the single callback that renders SystemInit events
-// to stdout. The same events are emitted regardless of the flag; only the
-// formatting differs (plain text lines vs JSON lines). Progress events are
-// throttled so consecutive updates with the same integer percentage are dropped.
-func newInitEventCallback(stdout io.Writer, jsonFeedback bool) orchestrator.InitEventCallback {
-	var render orchestrator.InitEventCallback
-	if jsonFeedback {
-		// One JSON object per line (JSONL). json.Encoder.Encode writes a trailing
-		// newline after each object, which is exactly the framing a line-based
-		// consumer needs.
-		enc := json.NewEncoder(stdout)
-		render = func(e orchestrator.InitEvent) {
-			switch e.Type {
-			case orchestrator.InitLogEvent:
-				_ = enc.Encode(jsonInitEvent{Type: "log", Message: e.Message})
-			case orchestrator.InitProgressEvent:
-				p := e.Progress
-				var percentage int
-				if p.Total > 0 {
-					percentage = int(float64(p.Curr) / float64(p.Total) * 100)
-				}
-				_ = enc.Encode(jsonInitEvent{
-					Type:    "progress",
-					Label:   p.Label,
-					Current: p.Curr,
-					Total:   p.Total,
-					Percent: percentage,
-				})
-			}
-		}
-	} else {
-		render = func(e orchestrator.InitEvent) {
-			switch e.Type {
-			case orchestrator.InitLogEvent:
-				fmt.Fprintln(stdout, e.Message)
-			case orchestrator.InitProgressEvent:
-				p := e.Progress
-				percentage := float64(p.Curr) / float64(p.Total) * 100
-				fmt.Fprintf(stdout, "%s: %.0f%%\n", p.Label, percentage)
-			}
-		}
-	}
-	return throttleProgress(render)
-}
-
-// throttleProgress wraps an event callback so that consecutive progress events
-// for the same label are only forwarded when their integer percentage changes.
-// Log events always pass through. This bounds the output volume (~100 progress
-// lines per label) without dropping any log line, identically in both formats.
-func throttleProgress(next orchestrator.InitEventCallback) orchestrator.InitEventCallback {
-	lastPct := map[string]int{}
-	return func(e orchestrator.InitEvent) {
-		if e.Type == orchestrator.InitProgressEvent {
-			p := e.Progress
-			if p.Total <= 0 {
-				return
-			}
-			pct := int(float64(p.Curr) / float64(p.Total) * 100)
-			if last, ok := lastPct[p.Label]; ok && last == pct {
-				return
-			}
-			lastPct[p.Label] = pct
-		}
-		next(e)
-	}
-}
-
 func newDownloadImageCmd(cfg config.Configuration) *cobra.Command {
 	var onlyImages bool
 	var onlyPlatformAndLibraries bool
-	var jsonFeedback bool
+	var jsonStream bool
 	cmd := &cobra.Command{
 		Use:    "init",
 		Args:   cobra.ExactArgs(0),
@@ -136,20 +55,9 @@ func newDownloadImageCmd(cfg config.Configuration) *cobra.Command {
 			if err != nil {
 				return err
 			}
-<<<<<<< HEAD
-			progressCB := func(progress orchestrator.InitProgress) {
-				percentage := float64(progress.Curr) / float64(progress.Total) * 100
-				fmt.Fprintf(stdout, "%s: %.2f%% (%d/%d)\r", progress.Label, percentage, progress.Curr, progress.Total)
-				if progress.Curr == progress.Total {
-					fmt.Fprintln(stdout)
-				}
-			}
-			return orchestrator.SystemInit(cmd.Context(), cfg, servicelocator.GetPlatform(), servicelocator.GetBricksIndex(), servicelocator.GetServicesIndex(), servicelocator.GetDockerClient(), servicelocator.GetModelsIndex(), orchestrator.SystemInitOptions{
-=======
 
-			eventCB := newInitEventCallback(stdout, jsonFeedback)
-			return orchestrator.SystemInit(cmd.Context(), cfg, servicelocator.GetPlatform(), servicelocator.GetBricksIndex(), servicelocator.GetServicesIndex(), servicelocator.GetDockerClient(), orchestrator.SystemInitOptions{
->>>>>>> ede498ed2 (add json output and refactoring)
+			eventCB := newInitEventCallback(stdout, jsonStream)
+			return orchestrator.SystemInit(cmd.Context(), cfg, servicelocator.GetPlatform(), servicelocator.GetBricksIndex(), servicelocator.GetServicesIndex(), servicelocator.GetDockerClient(), servicelocator.GetModelsIndex(), orchestrator.SystemInitOptions{
 				OnlyDockerImages:    onlyImages,
 				OnlyPlatformAndLibs: onlyPlatformAndLibraries,
 			}, eventCB)
@@ -158,7 +66,7 @@ func newDownloadImageCmd(cfg config.Configuration) *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&onlyImages, "only-docker-images", false, "Only download the application docker images")
 	cmd.PersistentFlags().BoolVar(&onlyPlatformAndLibraries, "only-arduino-platform", false, "Only download the Arduino platform and libraries")
-	cmd.PersistentFlags().BoolVar(&jsonFeedback, "json-feedback", false, "Emit logs and progress as JSON lines (one event per line) instead of plain text")
+	cmd.PersistentFlags().BoolVar(&jsonStream, "json-stream", false, "Emit logs and progress as JSON lines (one event per line) instead of plain text")
 
 	return cmd
 }

--- a/cmd/arduino-app-cli/system/system.go
+++ b/cmd/arduino-app-cli/system/system.go
@@ -45,18 +45,17 @@ func NewSystemCmd(cfg config.Configuration) *cobra.Command {
 func newDownloadImageCmd(cfg config.Configuration) *cobra.Command {
 	var onlyImages bool
 	var onlyPlatformAndLibraries bool
-	var jsonStream bool
 	cmd := &cobra.Command{
 		Use:    "init",
 		Args:   cobra.ExactArgs(0),
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			stdout, _, err := feedback.DirectStreams()
+			printEvent, err := feedback.NewResultStream()
 			if err != nil {
 				return err
 			}
 
-			eventCB := newInitEventCallback(stdout, jsonStream)
+			eventCB := newInitEventCallback(printEvent)
 			return orchestrator.SystemInit(cmd.Context(), cfg, servicelocator.GetPlatform(), servicelocator.GetBricksIndex(), servicelocator.GetServicesIndex(), servicelocator.GetDockerClient(), servicelocator.GetModelsIndex(), orchestrator.SystemInitOptions{
 				OnlyDockerImages:    onlyImages,
 				OnlyPlatformAndLibs: onlyPlatformAndLibraries,
@@ -66,7 +65,6 @@ func newDownloadImageCmd(cfg config.Configuration) *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&onlyImages, "only-docker-images", false, "Only download the application docker images")
 	cmd.PersistentFlags().BoolVar(&onlyPlatformAndLibraries, "only-arduino-platform", false, "Only download the Arduino platform and libraries")
-	cmd.PersistentFlags().BoolVar(&jsonStream, "json-stream", false, "Emit logs and progress as JSON lines (one event per line) instead of plain text")
 
 	return cmd
 }

--- a/cmd/arduino-app-cli/system/system.go
+++ b/cmd/arduino-app-cli/system/system.go
@@ -6,7 +6,9 @@
 package system
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 
@@ -42,9 +44,89 @@ func NewSystemCmd(cfg config.Configuration) *cobra.Command {
 	return cmd
 }
 
+// jsonInitEvent is the JSON-lines representation of a single event emitted by
+// `system init --json-feedback`. The Type field ("log" | "progress") is a
+// discriminator that tells the consumer which fields are meaningful.
+type jsonInitEvent struct {
+	Type    string `json:"type"`
+	Message string `json:"message,omitempty"`
+	Label   string `json:"label,omitempty"`
+	Current int64  `json:"current,omitempty"`
+	Total   int64  `json:"total,omitempty"`
+	Percent int    `json:"percent,omitempty"`
+}
+
+// newInitEventCallback builds the single callback that renders SystemInit events
+// to stdout. The same events are emitted regardless of the flag; only the
+// formatting differs (plain text lines vs JSON lines). Progress events are
+// throttled so consecutive updates with the same integer percentage are dropped.
+func newInitEventCallback(stdout io.Writer, jsonFeedback bool) orchestrator.InitEventCallback {
+	var render orchestrator.InitEventCallback
+	if jsonFeedback {
+		// One JSON object per line (JSONL). json.Encoder.Encode writes a trailing
+		// newline after each object, which is exactly the framing a line-based
+		// consumer needs.
+		enc := json.NewEncoder(stdout)
+		render = func(e orchestrator.InitEvent) {
+			switch e.Type {
+			case orchestrator.InitLogEvent:
+				_ = enc.Encode(jsonInitEvent{Type: "log", Message: e.Message})
+			case orchestrator.InitProgressEvent:
+				p := e.Progress
+				var percentage int
+				if p.Total > 0 {
+					percentage = int(float64(p.Curr) / float64(p.Total) * 100)
+				}
+				_ = enc.Encode(jsonInitEvent{
+					Type:    "progress",
+					Label:   p.Label,
+					Current: p.Curr,
+					Total:   p.Total,
+					Percent: percentage,
+				})
+			}
+		}
+	} else {
+		render = func(e orchestrator.InitEvent) {
+			switch e.Type {
+			case orchestrator.InitLogEvent:
+				fmt.Fprintln(stdout, e.Message)
+			case orchestrator.InitProgressEvent:
+				p := e.Progress
+				percentage := float64(p.Curr) / float64(p.Total) * 100
+				fmt.Fprintf(stdout, "%s: %.0f%%\n", p.Label, percentage)
+			}
+		}
+	}
+	return throttleProgress(render)
+}
+
+// throttleProgress wraps an event callback so that consecutive progress events
+// for the same label are only forwarded when their integer percentage changes.
+// Log events always pass through. This bounds the output volume (~100 progress
+// lines per label) without dropping any log line, identically in both formats.
+func throttleProgress(next orchestrator.InitEventCallback) orchestrator.InitEventCallback {
+	lastPct := map[string]int{}
+	return func(e orchestrator.InitEvent) {
+		if e.Type == orchestrator.InitProgressEvent {
+			p := e.Progress
+			if p.Total <= 0 {
+				return
+			}
+			pct := int(float64(p.Curr) / float64(p.Total) * 100)
+			if last, ok := lastPct[p.Label]; ok && last == pct {
+				return
+			}
+			lastPct[p.Label] = pct
+		}
+		next(e)
+	}
+}
+
 func newDownloadImageCmd(cfg config.Configuration) *cobra.Command {
 	var onlyImages bool
 	var onlyPlatformAndLibraries bool
+	var jsonFeedback bool
 	cmd := &cobra.Command{
 		Use:    "init",
 		Args:   cobra.ExactArgs(0),
@@ -54,6 +136,7 @@ func newDownloadImageCmd(cfg config.Configuration) *cobra.Command {
 			if err != nil {
 				return err
 			}
+<<<<<<< HEAD
 			progressCB := func(progress orchestrator.InitProgress) {
 				percentage := float64(progress.Curr) / float64(progress.Total) * 100
 				fmt.Fprintf(stdout, "%s: %.2f%% (%d/%d)\r", progress.Label, percentage, progress.Curr, progress.Total)
@@ -62,14 +145,20 @@ func newDownloadImageCmd(cfg config.Configuration) *cobra.Command {
 				}
 			}
 			return orchestrator.SystemInit(cmd.Context(), cfg, servicelocator.GetPlatform(), servicelocator.GetBricksIndex(), servicelocator.GetServicesIndex(), servicelocator.GetDockerClient(), servicelocator.GetModelsIndex(), orchestrator.SystemInitOptions{
+=======
+
+			eventCB := newInitEventCallback(stdout, jsonFeedback)
+			return orchestrator.SystemInit(cmd.Context(), cfg, servicelocator.GetPlatform(), servicelocator.GetBricksIndex(), servicelocator.GetServicesIndex(), servicelocator.GetDockerClient(), orchestrator.SystemInitOptions{
+>>>>>>> ede498ed2 (add json output and refactoring)
 				OnlyDockerImages:    onlyImages,
 				OnlyPlatformAndLibs: onlyPlatformAndLibraries,
-			}, progressCB)
+			}, eventCB)
 		},
 	}
 
 	cmd.PersistentFlags().BoolVar(&onlyImages, "only-docker-images", false, "Only download the application docker images")
 	cmd.PersistentFlags().BoolVar(&onlyPlatformAndLibraries, "only-arduino-platform", false, "Only download the Arduino platform and libraries")
+	cmd.PersistentFlags().BoolVar(&jsonFeedback, "json-feedback", false, "Emit logs and progress as JSON lines (one event per line) instead of plain text")
 
 	return cmd
 }

--- a/cmd/arduino-app-cli/system/system.go
+++ b/cmd/arduino-app-cli/system/system.go
@@ -55,11 +55,20 @@ func newDownloadImageCmd(cfg config.Configuration) *cobra.Command {
 				return err
 			}
 
-			eventCB := newInitEventCallback(printEvent)
-			return orchestrator.SystemInit(cmd.Context(), cfg, servicelocator.GetPlatform(), servicelocator.GetBricksIndex(), servicelocator.GetServicesIndex(), servicelocator.GetDockerClient(), servicelocator.GetModelsIndex(), orchestrator.SystemInitOptions{
-				OnlyDockerImages:    onlyImages,
-				OnlyPlatformAndLibs: onlyPlatformAndLibraries,
-			}, eventCB)
+			return orchestrator.SystemInit(
+				cmd.Context(),
+				cfg,
+				servicelocator.GetPlatform(),
+				servicelocator.GetBricksIndex(),
+				servicelocator.GetServicesIndex(),
+				servicelocator.GetDockerClient(),
+				servicelocator.GetModelsIndex(),
+				orchestrator.SystemInitOptions{
+					OnlyDockerImages:    onlyImages,
+					OnlyPlatformAndLibs: onlyPlatformAndLibraries,
+				},
+				newInitEventCallback(printEvent),
+			)
 		},
 	}
 

--- a/cmd/arduino-app-cli/system/system_helper.go
+++ b/cmd/arduino-app-cli/system/system_helper.go
@@ -1,0 +1,81 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package system
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+)
+
+type jsonInitEvent struct {
+	Type    string `json:"type"`
+	Source  string `json:"source,omitempty"`
+	Message string `json:"message,omitempty"`
+	Label   string `json:"label,omitempty"`
+	Current int64  `json:"current,omitempty"`
+	Total   int64  `json:"total,omitempty"`
+	Percent int    `json:"percent,omitempty"`
+}
+
+func newInitEventCallback(stdout io.Writer, jsonStream bool) orchestrator.InitEventCallback {
+	var render orchestrator.InitEventCallback
+	if jsonStream {
+		enc := json.NewEncoder(stdout)
+		render = func(e orchestrator.InitEvent) {
+			switch e.Type {
+			case orchestrator.InitLogEvent:
+				_ = enc.Encode(jsonInitEvent{Type: "log", Source: string(e.Source), Message: e.Message})
+			case orchestrator.InitProgressEvent:
+				p := e.Progress
+				var percentage int
+				if p.Total > 0 {
+					percentage = int(float64(p.Curr) / float64(p.Total) * 100)
+				}
+				_ = enc.Encode(jsonInitEvent{
+					Type:    "progress",
+					Source:  string(e.Source),
+					Label:   p.Label,
+					Current: p.Curr,
+					Total:   p.Total,
+					Percent: percentage,
+				})
+			}
+		}
+	} else {
+		render = func(e orchestrator.InitEvent) {
+			switch e.Type {
+			case orchestrator.InitLogEvent:
+				fmt.Fprintln(stdout, e.Message)
+			case orchestrator.InitProgressEvent:
+				p := e.Progress
+				percentage := float64(p.Curr) / float64(p.Total) * 100
+				fmt.Fprintf(stdout, "%s: %.0f%%\n", p.Label, percentage)
+			}
+		}
+	}
+	return throttleProgress(render)
+}
+
+func throttleProgress(next orchestrator.InitEventCallback) orchestrator.InitEventCallback {
+	lastPct := map[string]int{}
+	return func(e orchestrator.InitEvent) {
+		if e.Type == orchestrator.InitProgressEvent {
+			p := e.Progress
+			if p.Total <= 0 {
+				return
+			}
+			pct := int(float64(p.Curr) / float64(p.Total) * 100)
+			if last, ok := lastPct[p.Label]; ok && last == pct {
+				return
+			}
+			lastPct[p.Label] = pct
+		}
+		next(e)
+	}
+}

--- a/cmd/arduino-app-cli/system/system_helper.go
+++ b/cmd/arduino-app-cli/system/system_helper.go
@@ -42,7 +42,7 @@ func (e *initEvent) String() string {
 	return e.Message
 }
 
-func newInitEvent(e orchestrator.InitEvent) *initEvent {
+func fromInitEvent(e orchestrator.InitEvent) *initEvent {
 	switch e.Type {
 	case orchestrator.InitLogEvent:
 		return &initEvent{
@@ -83,7 +83,7 @@ func newInitEventCallback(printEvent func(feedback.Result)) orchestrator.InitEve
 func throttleProgress(next func(*initEvent)) orchestrator.InitEventCallback {
 	lastPct := map[string]int{}
 	return func(event orchestrator.InitEvent) {
-		e := newInitEvent(event)
+		e := fromInitEvent(event)
 		if e == nil {
 			return
 		}

--- a/cmd/arduino-app-cli/system/system_helper.go
+++ b/cmd/arduino-app-cli/system/system_helper.go
@@ -17,9 +17,9 @@ const (
 	initProgressEventType = "progress"
 )
 
-var _ feedback.Result = (*initEvent)(nil)
+var _ feedback.Result = (*initResult)(nil)
 
-type initEvent struct {
+type initResult struct {
 	Type    string `json:"type"`
 	Source  string `json:"source,omitempty"`
 	Message string `json:"message,omitempty"`
@@ -30,29 +30,29 @@ type initEvent struct {
 }
 
 // Data implements feedback.Result.
-func (e *initEvent) Data() any {
+func (e *initResult) Data() any {
 	return e
 }
 
 // String implements feedback.Result.
-func (e *initEvent) String() string {
+func (e *initResult) String() string {
 	if e.Type == initProgressEventType {
 		return fmt.Sprintf("%s: %d%%", e.Label, e.Percent)
 	}
 	return e.Message
 }
 
-func fromInitEvent(e orchestrator.InitEvent) *initEvent {
+func fromInitEvent(e orchestrator.InitEvent) *initResult {
 	switch e.Type {
 	case orchestrator.InitLogEvent:
-		return &initEvent{
+		return &initResult{
 			Type:    initLogEventType,
 			Source:  string(e.Source),
 			Message: e.Message,
 		}
 	case orchestrator.InitProgressEvent:
 		p := e.Progress
-		return &initEvent{
+		return &initResult{
 			Type:    initProgressEventType,
 			Source:  string(e.Source),
 			Label:   p.Label,
@@ -73,14 +73,14 @@ func percent(curr, total int64) int {
 }
 
 func newInitEventCallback(printEvent func(feedback.Result)) orchestrator.InitEventCallback {
-	return throttleProgress(func(e *initEvent) {
+	return throttleProgress(func(e *initResult) {
 		printEvent(e)
 	})
 }
 
 // throttleProgress drops the progress events that would render the same
 // percentage twice in a row for a given label.
-func throttleProgress(next func(*initEvent)) orchestrator.InitEventCallback {
+func throttleProgress(next func(*initResult)) orchestrator.InitEventCallback {
 	lastPct := map[string]int{}
 	return func(event orchestrator.InitEvent) {
 		e := fromInitEvent(event)

--- a/cmd/arduino-app-cli/system/system_helper.go
+++ b/cmd/arduino-app-cli/system/system_helper.go
@@ -6,14 +6,20 @@
 package system
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 
+	"github.com/arduino/arduino-app-cli/cmd/feedback"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 )
 
-type jsonInitEvent struct {
+const (
+	initLogEventType      = "log"
+	initProgressEventType = "progress"
+)
+
+var _ feedback.Result = (*initEvent)(nil)
+
+type initEvent struct {
 	Type    string `json:"type"`
 	Source  string `json:"source,omitempty"`
 	Message string `json:"message,omitempty"`
@@ -23,58 +29,72 @@ type jsonInitEvent struct {
 	Percent int    `json:"percent,omitempty"`
 }
 
-func newInitEventCallback(stdout io.Writer, jsonStream bool) orchestrator.InitEventCallback {
-	var render orchestrator.InitEventCallback
-	if jsonStream {
-		enc := json.NewEncoder(stdout)
-		render = func(e orchestrator.InitEvent) {
-			switch e.Type {
-			case orchestrator.InitLogEvent:
-				_ = enc.Encode(jsonInitEvent{Type: "log", Source: string(e.Source), Message: e.Message})
-			case orchestrator.InitProgressEvent:
-				p := e.Progress
-				var percentage int
-				if p.Total > 0 {
-					percentage = int(float64(p.Curr) / float64(p.Total) * 100)
-				}
-				_ = enc.Encode(jsonInitEvent{
-					Type:    "progress",
-					Source:  string(e.Source),
-					Label:   p.Label,
-					Current: p.Curr,
-					Total:   p.Total,
-					Percent: percentage,
-				})
-			}
-		}
-	} else {
-		render = func(e orchestrator.InitEvent) {
-			switch e.Type {
-			case orchestrator.InitLogEvent:
-				fmt.Fprintln(stdout, e.Message)
-			case orchestrator.InitProgressEvent:
-				p := e.Progress
-				percentage := float64(p.Curr) / float64(p.Total) * 100
-				fmt.Fprintf(stdout, "%s: %.0f%%\n", p.Label, percentage)
-			}
-		}
-	}
-	return throttleProgress(render)
+// Data implements feedback.Result.
+func (e *initEvent) Data() any {
+	return e
 }
 
-func throttleProgress(next orchestrator.InitEventCallback) orchestrator.InitEventCallback {
+// String implements feedback.Result.
+func (e *initEvent) String() string {
+	if e.Type == initProgressEventType {
+		return fmt.Sprintf("%s: %d%%", e.Label, e.Percent)
+	}
+	return e.Message
+}
+
+func newInitEvent(e orchestrator.InitEvent) *initEvent {
+	switch e.Type {
+	case orchestrator.InitLogEvent:
+		return &initEvent{
+			Type:    initLogEventType,
+			Source:  string(e.Source),
+			Message: e.Message,
+		}
+	case orchestrator.InitProgressEvent:
+		p := e.Progress
+		return &initEvent{
+			Type:    initProgressEventType,
+			Source:  string(e.Source),
+			Label:   p.Label,
+			Current: p.Curr,
+			Total:   p.Total,
+			Percent: percent(p.Curr, p.Total),
+		}
+	default:
+		return nil
+	}
+}
+
+func percent(curr, total int64) int {
+	if total <= 0 {
+		return 0
+	}
+	return int(float64(curr) / float64(total) * 100)
+}
+
+func newInitEventCallback(printEvent func(feedback.Result)) orchestrator.InitEventCallback {
+	return throttleProgress(func(e *initEvent) {
+		printEvent(e)
+	})
+}
+
+// throttleProgress drops the progress events that would render the same
+// percentage twice in a row for a given label.
+func throttleProgress(next func(*initEvent)) orchestrator.InitEventCallback {
 	lastPct := map[string]int{}
-	return func(e orchestrator.InitEvent) {
-		if e.Type == orchestrator.InitProgressEvent {
-			p := e.Progress
-			if p.Total <= 0 {
+	return func(event orchestrator.InitEvent) {
+		e := newInitEvent(event)
+		if e == nil {
+			return
+		}
+		if e.Type == initProgressEventType {
+			if e.Total <= 0 {
 				return
 			}
-			pct := int(float64(p.Curr) / float64(p.Total) * 100)
-			if last, ok := lastPct[p.Label]; ok && last == pct {
+			if last, ok := lastPct[e.Label]; ok && last == e.Percent {
 				return
 			}
-			lastPct[p.Label] = pct
+			lastPct[e.Label] = e.Percent
 		}
 		next(e)
 	}

--- a/cmd/arduino-app-cli/system/system_test.go
+++ b/cmd/arduino-app-cli/system/system_test.go
@@ -6,8 +6,11 @@
 package system
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/arduino/arduino-app-cli/cmd/feedback"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 )
 
@@ -22,9 +25,9 @@ func TestThrottleProgress(t *testing.T) {
 		return orchestrator.InitEvent{Type: orchestrator.InitLogEvent, Message: msg}
 	}
 
-	var got []orchestrator.InitEvent
-	cb := throttleProgress(func(e orchestrator.InitEvent) {
-		got = append(got, e)
+	var got []initEvent
+	cb := throttleProgress(func(e *initEvent) {
+		got = append(got, *e)
 	})
 
 	// Sequence: same integer percentage is collapsed; each new integer step and
@@ -38,13 +41,13 @@ func TestThrottleProgress(t *testing.T) {
 	cb(progress("other", 5, 100)) // 5%  -> forwarded (different label tracked separately)
 	cb(logEvt("done"))            //     -> forwarded
 
-	want := []orchestrator.InitEvent{
-		progress("img", 0, 100),
-		progress("img", 4, 100),
-		logEvt("hello"),
-		progress("img", 5, 100),
-		progress("other", 5, 100),
-		logEvt("done"),
+	want := []initEvent{
+		*newInitEvent(progress("img", 0, 100)),
+		*newInitEvent(progress("img", 4, 100)),
+		*newInitEvent(logEvt("hello")),
+		*newInitEvent(progress("img", 5, 100)),
+		*newInitEvent(progress("other", 5, 100)),
+		*newInitEvent(logEvt("done")),
 	}
 
 	if len(got) != len(want) {
@@ -54,5 +57,102 @@ func TestThrottleProgress(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("event %d = %+v, want %+v", i, got[i], want[i])
 		}
+	}
+}
+
+// The rendering of a result stream per output format is covered in the feedback
+// package, here we only check that the events reach the stream, throttled.
+func TestNewInitEventCallback(t *testing.T) {
+	var got []feedback.Result
+	cb := newInitEventCallback(func(res feedback.Result) {
+		got = append(got, res)
+	})
+
+	cb(orchestrator.InitEvent{Type: orchestrator.InitLogEvent, Message: "pulling image"})
+	cb(orchestrator.InitEvent{
+		Type:     orchestrator.InitProgressEvent,
+		Progress: orchestrator.InitProgress{Label: "img", Curr: 25, Total: 50},
+	})
+	// Same integer percentage as the previous event, dropped by the throttle.
+	cb(orchestrator.InitEvent{
+		Type:     orchestrator.InitProgressEvent,
+		Progress: orchestrator.InitProgress{Label: "img", Curr: 250, Total: 500},
+	})
+
+	want := []string{"pulling image", "img: 50%"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d results, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].String() != want[i] {
+			t.Errorf("result %d = %q, want %q", i, got[i].String(), want[i])
+		}
+	}
+}
+
+func TestInitEventJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		event orchestrator.InitEvent
+		want  string
+	}{
+		{
+			name:  "log event",
+			event: orchestrator.InitEvent{Type: orchestrator.InitLogEvent, Message: "pulling image"},
+			want:  `{"type":"log","message":"pulling image"}`,
+		},
+		{
+			name: "progress event",
+			event: orchestrator.InitEvent{
+				Type:     orchestrator.InitProgressEvent,
+				Progress: orchestrator.InitProgress{Label: "img", Curr: 25, Total: 50},
+			},
+			want: `{"type":"progress","label":"img","current":25,"total":50,"percent":50}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Each event must serialize to a single line, so that the JSON output
+			// is a stream of JSON lines, one object per event.
+			d, err := json.Marshal(newInitEvent(tt.event).Data())
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+			if got := string(d); got != tt.want {
+				t.Errorf("Data() = %s, want %s", got, tt.want)
+			}
+			if strings.Contains(string(d), "\n") {
+				t.Errorf("Data() spans multiple lines: %s", d)
+			}
+		})
+	}
+}
+
+func TestInitEventString(t *testing.T) {
+	tests := []struct {
+		name  string
+		event orchestrator.InitEvent
+		want  string
+	}{
+		{
+			name:  "log event renders its message",
+			event: orchestrator.InitEvent{Type: orchestrator.InitLogEvent, Message: "pulling image"},
+			want:  "pulling image",
+		},
+		{
+			name: "progress event renders label and percentage",
+			event: orchestrator.InitEvent{
+				Type:     orchestrator.InitProgressEvent,
+				Progress: orchestrator.InitProgress{Label: "img", Curr: 25, Total: 50},
+			},
+			want: "img: 50%",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newInitEvent(tt.event).String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/cmd/arduino-app-cli/system/system_test.go
+++ b/cmd/arduino-app-cli/system/system_test.go
@@ -1,0 +1,58 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package system
+
+import (
+	"testing"
+
+	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+)
+
+func TestThrottleProgress(t *testing.T) {
+	progress := func(label string, curr, total int64) orchestrator.InitEvent {
+		return orchestrator.InitEvent{
+			Type:     orchestrator.InitProgressEvent,
+			Progress: orchestrator.InitProgress{Label: label, Curr: curr, Total: total},
+		}
+	}
+	logEvt := func(msg string) orchestrator.InitEvent {
+		return orchestrator.InitEvent{Type: orchestrator.InitLogEvent, Message: msg}
+	}
+
+	var got []orchestrator.InitEvent
+	cb := throttleProgress(func(e orchestrator.InitEvent) {
+		got = append(got, e)
+	})
+
+	// Sequence: same integer percentage is collapsed; each new integer step and
+	// every log line passes through.
+	cb(progress("img", 0, 100))   // 0%  -> forwarded
+	cb(progress("img", 4, 100))   // 4%  -> forwarded
+	cb(progress("img", 49, 1000)) // 4%  -> dropped (same integer pct)
+	cb(logEvt("hello"))           //     -> forwarded (logs always pass)
+	cb(progress("img", 5, 100))   // 5%  -> forwarded
+	cb(progress("img", 5, 0))     //     -> dropped (Total <= 0)
+	cb(progress("other", 5, 100)) // 5%  -> forwarded (different label tracked separately)
+	cb(logEvt("done"))            //     -> forwarded
+
+	want := []orchestrator.InitEvent{
+		progress("img", 0, 100),
+		progress("img", 4, 100),
+		logEvt("hello"),
+		progress("img", 5, 100),
+		progress("other", 5, 100),
+		logEvt("done"),
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d events, want %d:\n got:  %+v\n want: %+v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("event %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}

--- a/cmd/arduino-app-cli/system/system_test.go
+++ b/cmd/arduino-app-cli/system/system_test.go
@@ -42,12 +42,12 @@ func TestThrottleProgress(t *testing.T) {
 	cb(logEvt("done"))            //     -> forwarded
 
 	want := []initEvent{
-		*newInitEvent(progress("img", 0, 100)),
-		*newInitEvent(progress("img", 4, 100)),
-		*newInitEvent(logEvt("hello")),
-		*newInitEvent(progress("img", 5, 100)),
-		*newInitEvent(progress("other", 5, 100)),
-		*newInitEvent(logEvt("done")),
+		*fromInitEvent(progress("img", 0, 100)),
+		*fromInitEvent(progress("img", 4, 100)),
+		*fromInitEvent(logEvt("hello")),
+		*fromInitEvent(progress("img", 5, 100)),
+		*fromInitEvent(progress("other", 5, 100)),
+		*fromInitEvent(logEvt("done")),
 	}
 
 	if len(got) != len(want) {
@@ -114,7 +114,7 @@ func TestInitEventJSON(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Each event must serialize to a single line, so that the JSON output
 			// is a stream of JSON lines, one object per event.
-			d, err := json.Marshal(newInitEvent(tt.event).Data())
+			d, err := json.Marshal(fromInitEvent(tt.event).Data())
 			if err != nil {
 				t.Fatalf("Marshal() error = %v", err)
 			}
@@ -150,7 +150,7 @@ func TestInitEventString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := newInitEvent(tt.event).String(); got != tt.want {
+			if got := fromInitEvent(tt.event).String(); got != tt.want {
 				t.Errorf("String() = %q, want %q", got, tt.want)
 			}
 		})

--- a/cmd/arduino-app-cli/system/system_test.go
+++ b/cmd/arduino-app-cli/system/system_test.go
@@ -25,8 +25,8 @@ func TestThrottleProgress(t *testing.T) {
 		return orchestrator.InitEvent{Type: orchestrator.InitLogEvent, Message: msg}
 	}
 
-	var got []initEvent
-	cb := throttleProgress(func(e *initEvent) {
+	var got []initResult
+	cb := throttleProgress(func(e *initResult) {
 		got = append(got, *e)
 	})
 
@@ -41,7 +41,7 @@ func TestThrottleProgress(t *testing.T) {
 	cb(progress("other", 5, 100)) // 5%  -> forwarded (different label tracked separately)
 	cb(logEvt("done"))            //     -> forwarded
 
-	want := []initEvent{
+	want := []initResult{
 		*fromInitEvent(progress("img", 0, 100)),
 		*fromInitEvent(progress("img", 4, 100)),
 		*fromInitEvent(logEvt("hello")),

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -8,6 +8,7 @@ package feedback
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -22,16 +23,19 @@ type OutputFormat int
 const (
 	// Text is the plain text format, suitable for interactive terminals
 	Text OutputFormat = iota
-	// JSON format
+	// JSON is a single, indented JSON document
 	JSON
-	// MinifiedJSON format
+	// MinifiedJSON is a single, compact JSON document
 	MinifiedJSON
+	// JSONLines is a stream of compact JSON documents
+	JSONLines
 )
 
 var formats = map[string]OutputFormat{
-	"json":     JSON,
-	"jsonmini": MinifiedJSON,
-	"text":     Text,
+	"json":       JSON,
+	"jsonmini":   MinifiedJSON,
+	"json-lines": JSONLines,
+	"text":       Text,
 }
 
 func (f OutputFormat) String() string {
@@ -190,7 +194,7 @@ func Fatal(errorMsg string, exitCode ExitCode) {
 	switch format {
 	case JSON:
 		d, _ = json.MarshalIndent(augment(res), "", "  ")
-	case MinifiedJSON:
+	case MinifiedJSON, JSONLines:
 		d, _ = json.Marshal(augment(res))
 	default:
 		panic("unknown output format")
@@ -230,7 +234,8 @@ func PrintResult(res Result) {
 			Fatal(i18n.Tr("Error during JSON encoding of the output: %v", err), ErrGeneric)
 		}
 		data = string(d)
-	case MinifiedJSON:
+	case MinifiedJSON, JSONLines:
+		// A single result under JSONLines is just one compact line.
 		d, err := json.Marshal(augment(res.Data()))
 		if err != nil {
 			Fatal(i18n.Tr("Error during JSON encoding of the output: %v", err), ErrGeneric)
@@ -249,5 +254,36 @@ func PrintResult(res Result) {
 	}
 	if dataErr != "" {
 		fmt.Fprintln(stdErr, dataErr)
+	}
+}
+
+// NewResultStream returns a function to print an unbounded stream of Results,
+// like the events emitted by a long running command. The results are written to
+// the out writer as they come, they are not accumulated, so this is the
+// counterpart of PrintResult for a stream (and the two must not be mixed).
+//
+// The JSON and MinifiedJSON formats are single-document formats, so they are
+// not available for a stream and the function errors: JSONLines must be used
+// instead, it renders the stream as one JSON object per line.
+func NewResultStream() (func(Result), error) {
+	if !formatSelected {
+		panic("output format not yet selected")
+	}
+	switch format {
+	case Text:
+		return func(res Result) {
+			if data := res.String(); data != "" {
+				fmt.Fprintln(stdOut, data)
+			}
+		}, nil
+	case JSONLines:
+		enc := json.NewEncoder(stdOut)
+		return func(res Result) {
+			// Encode writes a single line per result, the warnings are not
+			// augmented in: they would be repeated in every result of the stream.
+			_ = enc.Encode(res.Data())
+		}, nil
+	default:
+		return nil, errors.New(i18n.Tr("streaming output is not available in %[1]s format, use %[2]s to get one JSON object per line", format, JSONLines))
 	}
 }

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -257,14 +257,9 @@ func PrintResult(res Result) {
 	}
 }
 
-// NewResultStream returns a function to print an unbounded stream of Results,
-// like the events emitted by a long running command. The results are written to
-// the out writer as they come, they are not accumulated, so this is the
-// counterpart of PrintResult for a stream (and the two must not be mixed).
-//
-// The JSON and MinifiedJSON formats are single-document formats, so they are
-// not available for a stream and the function errors: JSONLines must be used
-// instead, it renders the stream as one JSON object per line.
+// NewResultStream returns a function that prints Results one at a time as they
+// arrive, for long-running commands. It is the streaming counterpart of
+// PrintResult (don't mix the two) and requires the JSONLines format.
 func NewResultStream() (func(Result), error) {
 	if !formatSelected {
 		panic("output format not yet selected")

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -25,15 +25,12 @@ const (
 	Text OutputFormat = iota
 	// JSON is a single, indented JSON document
 	JSON
-	// MinifiedJSON is a single, compact JSON document
-	MinifiedJSON
 	// JSONLines is a stream of compact JSON documents
 	JSONLines
 )
 
 var formats = map[string]OutputFormat{
 	"json":       JSON,
-	"jsonmini":   MinifiedJSON,
 	"json-lines": JSONLines,
 	"text":       Text,
 }
@@ -194,7 +191,7 @@ func Fatal(errorMsg string, exitCode ExitCode) {
 	switch format {
 	case JSON:
 		d, _ = json.MarshalIndent(augment(res), "", "  ")
-	case MinifiedJSON, JSONLines:
+	case JSONLines:
 		d, _ = json.Marshal(augment(res))
 	default:
 		panic("unknown output format")
@@ -234,7 +231,7 @@ func PrintResult(res Result) {
 			Fatal(i18n.Tr("Error during JSON encoding of the output: %v", err), ErrGeneric)
 		}
 		data = string(d)
-	case MinifiedJSON, JSONLines:
+	case JSONLines:
 		// A single result under JSONLines is just one compact line.
 		d, err := json.Marshal(augment(res.Data()))
 		if err != nil {

--- a/cmd/feedback/feedback_test.go
+++ b/cmd/feedback/feedback_test.go
@@ -146,16 +146,12 @@ func TestResultStreamOnJSONLinesFormat(t *testing.T) {
 	require.Equal(t, "{\"success\":true}\n{\"success\":false}\n", myOut.String())
 }
 
-func TestResultStreamIsNotAvailableOnSingleDocumentFormats(t *testing.T) {
-	// A stream can't be rendered as a single JSON document, minified or not.
-	for _, format := range []OutputFormat{JSON, MinifiedJSON} {
-		t.Run(format.String(), func(t *testing.T) {
-			reset()
-			SetOut(&bytes.Buffer{})
-			SetFormat(format)
+func TestResultStreamIsNotAvailableOnSingleDocumentFormat(t *testing.T) {
+	// A stream can't be rendered as a single JSON document.
+	reset()
+	SetOut(&bytes.Buffer{})
+	SetFormat(JSON)
 
-			_, err := NewResultStream()
-			require.Error(t, err)
-		})
-	}
+	_, err := NewResultStream()
+	require.Error(t, err)
 }

--- a/cmd/feedback/feedback_test.go
+++ b/cmd/feedback/feedback_test.go
@@ -112,3 +112,50 @@ func (r *testResult) String() string {
 	}
 	return "Failure"
 }
+
+func TestResultStreamOnTextFormat(t *testing.T) {
+	reset()
+
+	myOut := &bytes.Buffer{}
+	SetOut(myOut)
+	SetFormat(Text)
+
+	printResult, err := NewResultStream()
+	require.NoError(t, err)
+
+	printResult(&testResult{Success: true})
+	printResult(&testResult{Success: false})
+
+	require.Equal(t, "Success\nFailure\n", myOut.String())
+}
+
+func TestResultStreamOnJSONLinesFormat(t *testing.T) {
+	reset()
+
+	myOut := &bytes.Buffer{}
+	SetOut(myOut)
+	SetFormat(JSONLines)
+
+	printResult, err := NewResultStream()
+	require.NoError(t, err)
+
+	printResult(&testResult{Success: true})
+	printResult(&testResult{Success: false})
+
+	// The stream is rendered as one JSON object per line.
+	require.Equal(t, "{\"success\":true}\n{\"success\":false}\n", myOut.String())
+}
+
+func TestResultStreamIsNotAvailableOnSingleDocumentFormats(t *testing.T) {
+	// A stream can't be rendered as a single JSON document, minified or not.
+	for _, format := range []OutputFormat{JSON, MinifiedJSON} {
+		t.Run(format.String(), func(t *testing.T) {
+			reset()
+			SetOut(&bytes.Buffer{})
+			SetFormat(format)
+
+			_, err := NewResultStream()
+			require.Error(t, err)
+		})
+	}
+}

--- a/internal/orchestrator/bricks/testdata/dummy-app-brick-override-temp/app.yaml
+++ b/internal/orchestrator/bricks/testdata/dummy-app-brick-override-temp/app.yaml
@@ -1,4 +1,9 @@
 name: Copy of Blinking LED from Arduino Cloud
 description: Control the LED from the Arduino IoT Cloud using RPC calls
 ports: []
+bricks:
+- arduino:arduino_cloud:
+    variables:
+      ARDUINO_DEVICE_ID: this-is-a-device-id
+      ARDUINO_SECRET: this-is-a-secret
 icon: ☁️

--- a/internal/orchestrator/bricks/testdata/dummy-app-brick-override-temp/app.yaml
+++ b/internal/orchestrator/bricks/testdata/dummy-app-brick-override-temp/app.yaml
@@ -1,9 +1,4 @@
 name: Copy of Blinking LED from Arduino Cloud
 description: Control the LED from the Arduino IoT Cloud using RPC calls
 ports: []
-bricks:
-- arduino:arduino_cloud:
-    variables:
-      ARDUINO_DEVICE_ID: this-is-a-device-id
-      ARDUINO_SECRET: this-is-a-secret
 icon: ☁️

--- a/internal/orchestrator/docker.go
+++ b/internal/orchestrator/docker.go
@@ -7,7 +7,6 @@ package orchestrator
 
 import (
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -76,23 +75,6 @@ func imageDisplayName(image string) string {
 		return name[idx+1:]
 	}
 	return name
-}
-
-// Returns the number of bytes that would be downloaded when pulling the new docker image while the old one is
-// already present locally. It accounts for image layers that are already present locally.
-func GetBytesToDownload(localRefStr string, remoteRefStr string) (int64, error) {
-	layers, err := missingLayers(localRefStr, remoteRefStr)
-	if err != nil {
-		return 0, err
-	}
-
-	var downloadBytes int64
-	for _, l := range layers {
-		downloadBytes += l.Size
-	}
-
-	slog.Debug("docker image bytes to download", "image", remoteRefStr, "byte", downloadBytes)
-	return downloadBytes, nil
 }
 
 // missingLayers returns the layers present in the remote image but not already

--- a/internal/orchestrator/docker.go
+++ b/internal/orchestrator/docker.go
@@ -67,6 +67,17 @@ func parseDockerImage(image string) (name string, version string) {
 	return image, ""
 }
 
+// imageDisplayName returns a short, human-friendly name for a docker image
+// reference, e.g. "python-apps-base" for
+// "ghcr.io/arduino/app-bricks/python-apps-base:0.11.0rc6".
+func imageDisplayName(image string) string {
+	name, _ := parseDockerImage(image)
+	if idx := strings.LastIndex(name, "/"); idx != -1 {
+		return name[idx+1:]
+	}
+	return name
+}
+
 // Returns the number of bytes that would be downloaded when pulling the new docker image while the old one is
 // already present locally. It accounts for image layers that are already present locally.
 func GetBytesToDownload(localRefStr string, remoteRefStr string) (int64, error) {

--- a/internal/orchestrator/docker.go
+++ b/internal/orchestrator/docker.go
@@ -66,14 +66,11 @@ func parseDockerImage(image string) (name string, version string) {
 	return image, ""
 }
 
-// imageDisplayName returns a short, human-friendly name for a docker image
-// reference, e.g. "python-apps-base" for
+// imageName returns the docker image reference without its tag/digest, e.g.
+// "ghcr.io/arduino/app-bricks/python-apps-base" for
 // "ghcr.io/arduino/app-bricks/python-apps-base:0.11.0rc6".
-func imageDisplayName(image string) string {
+func imageName(image string) string {
 	name, _ := parseDockerImage(image)
-	if idx := strings.LastIndex(name, "/"); idx != -1 {
-		return name[idx+1:]
-	}
 	return name
 }
 

--- a/internal/orchestrator/docker.go
+++ b/internal/orchestrator/docker.go
@@ -70,14 +70,31 @@ func parseDockerImage(image string) (name string, version string) {
 // Returns the number of bytes that would be downloaded when pulling the new docker image while the old one is
 // already present locally. It accounts for image layers that are already present locally.
 func GetBytesToDownload(localRefStr string, remoteRefStr string) (int64, error) {
-	localLayers, err := getImageLayers(localRefStr)
+	layers, err := missingLayers(localRefStr, remoteRefStr)
 	if err != nil {
 		return 0, err
 	}
 
+	var downloadBytes int64
+	for _, l := range layers {
+		downloadBytes += l.Size
+	}
+
+	slog.Debug("docker image bytes to download", "image", remoteRefStr, "byte", downloadBytes)
+	return downloadBytes, nil
+}
+
+// missingLayers returns the layers present in the remote image but not already
+// available locally, i.e. the layers that actually need to be downloaded.
+func missingLayers(localRefStr string, remoteRefStr string) ([]dockerImageLayer, error) {
+	localLayers, err := getImageLayers(localRefStr)
+	if err != nil {
+		return nil, err
+	}
+
 	remoteLayers, err := getImageLayers(remoteRefStr)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	localDigests := map[string]struct{}{}
@@ -85,18 +102,32 @@ func GetBytesToDownload(localRefStr string, remoteRefStr string) (int64, error) 
 		localDigests[l.Hash] = struct{}{}
 	}
 
-	var downloadBytes int64
+	var missing []dockerImageLayer
 	for _, l := range remoteLayers {
 		if _, ok := localDigests[l.Hash]; ok {
 			continue
 		}
+		missing = append(missing, l)
+	}
+	return missing, nil
+}
 
-		// The layer is missing, so sum its size to the total to download.
-		downloadBytes += l.Size
+// sumUniqueLayers sums the sizes of the layers across all images, counting each
+// distinct layer (by digest) only once. Shared layers are downloaded a single
+// time, so this yields the real total number of bytes to download.
+func sumUniqueLayers(layersPerImage [][]dockerImageLayer) int64 {
+	uniq := map[string]int64{}
+	for _, layers := range layersPerImage {
+		for _, l := range layers {
+			uniq[l.Hash] = l.Size
+		}
 	}
 
-	slog.Debug("docker image bytes to download", "image", remoteRefStr, "byte", downloadBytes)
-	return downloadBytes, nil
+	var total int64
+	for _, size := range uniq {
+		total += size
+	}
+	return total
 }
 
 type dockerImageLayer struct {

--- a/internal/orchestrator/docker.go
+++ b/internal/orchestrator/docker.go
@@ -102,15 +102,13 @@ func missingLayers(localRefStr string, remoteRefStr string) ([]dockerImageLayer,
 	return missing, nil
 }
 
-// sumUniqueLayers sums the sizes of the layers across all images, counting each
-// distinct layer (by digest) only once. Shared layers are downloaded a single
-// time, so this yields the real total number of bytes to download.
-func sumUniqueLayers(layersPerImage [][]dockerImageLayer) int64 {
+// sumUniqueLayers sums the sizes of the given layers, counting each distinct
+// layer (by digest) only once. Shared layers are downloaded a single time, so
+// this yields the real total number of bytes to download.
+func sumUniqueLayers(layers []dockerImageLayer) int64 {
 	uniq := map[string]int64{}
-	for _, layers := range layersPerImage {
-		for _, l := range layers {
-			uniq[l.Hash] = l.Size
-		}
+	for _, l := range layers {
+		uniq[l.Hash] = l.Size
 	}
 
 	var total int64

--- a/internal/orchestrator/docker_test.go
+++ b/internal/orchestrator/docker_test.go
@@ -203,3 +203,20 @@ func TestUpdateLayerProgress(t *testing.T) {
 		t.Errorf("got %d, want 350 (empty id ignored)", got)
 	}
 }
+
+func TestImageDisplayName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"ghcr.io/arduino/app-bricks/python-apps-base:0.11.0rc6", "python-apps-base"},
+		{"influxdb:2.7-alpine", "influxdb"},
+		{"ghcr.io/arduino/app-bricks/ei-models-runner@sha256:abc", "ei-models-runner"},
+		{"nginx", "nginx"},
+	}
+	for _, tt := range tests {
+		if got := imageDisplayName(tt.input); got != tt.expected {
+			t.Errorf("imageDisplayName(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}

--- a/internal/orchestrator/docker_test.go
+++ b/internal/orchestrator/docker_test.go
@@ -204,19 +204,19 @@ func TestUpdateLayerProgress(t *testing.T) {
 	}
 }
 
-func TestImageDisplayName(t *testing.T) {
+func TestImageName(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected string
 	}{
-		{"ghcr.io/arduino/app-bricks/python-apps-base:0.11.0rc6", "python-apps-base"},
+		{"ghcr.io/arduino/app-bricks/python-apps-base:0.11.0rc6", "ghcr.io/arduino/app-bricks/python-apps-base"},
 		{"influxdb:2.7-alpine", "influxdb"},
-		{"ghcr.io/arduino/app-bricks/ei-models-runner@sha256:abc", "ei-models-runner"},
+		{"ghcr.io/arduino/app-bricks/ei-models-runner@sha256:abc", "ghcr.io/arduino/app-bricks/ei-models-runner"},
 		{"nginx", "nginx"},
 	}
 	for _, tt := range tests {
-		if got := imageDisplayName(tt.input); got != tt.expected {
-			t.Errorf("imageDisplayName(%q) = %q, want %q", tt.input, got, tt.expected)
+		if got := imageName(tt.input); got != tt.expected {
+			t.Errorf("imageName(%q) = %q, want %q", tt.input, got, tt.expected)
 		}
 	}
 }

--- a/internal/orchestrator/docker_test.go
+++ b/internal/orchestrator/docker_test.go
@@ -145,26 +145,24 @@ func TestGetHighestVersion(t *testing.T) {
 func TestSumUniqueLayers(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    [][]dockerImageLayer
+		input    []dockerImageLayer
 		expected int64
 	}{
 		{
-			name:     "no images",
+			name:     "no layers",
 			input:    nil,
 			expected: 0,
 		},
 		{
-			name: "single image",
-			input: [][]dockerImageLayer{
-				{{Hash: "a", Size: 100}, {Hash: "b", Size: 50}},
-			},
+			name:     "single image",
+			input:    []dockerImageLayer{{Hash: "a", Size: 100}, {Hash: "b", Size: 50}},
 			expected: 150,
 		},
 		{
 			name: "shared layer counted once",
-			input: [][]dockerImageLayer{
-				{{Hash: "base", Size: 200}, {Hash: "a", Size: 50}},
-				{{Hash: "base", Size: 200}, {Hash: "b", Size: 30}},
+			input: []dockerImageLayer{
+				{Hash: "base", Size: 200}, {Hash: "a", Size: 50},
+				{Hash: "base", Size: 200}, {Hash: "b", Size: 30},
 			},
 			expected: 280, // base(200) once + a(50) + b(30)
 		},

--- a/internal/orchestrator/docker_test.go
+++ b/internal/orchestrator/docker_test.go
@@ -141,3 +141,65 @@ func TestGetHighestVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestSumUniqueLayers(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    [][]dockerImageLayer
+		expected int64
+	}{
+		{
+			name:     "no images",
+			input:    nil,
+			expected: 0,
+		},
+		{
+			name: "single image",
+			input: [][]dockerImageLayer{
+				{{Hash: "a", Size: 100}, {Hash: "b", Size: 50}},
+			},
+			expected: 150,
+		},
+		{
+			name: "shared layer counted once",
+			input: [][]dockerImageLayer{
+				{{Hash: "base", Size: 200}, {Hash: "a", Size: 50}},
+				{{Hash: "base", Size: 200}, {Hash: "b", Size: 30}},
+			},
+			expected: 280, // base(200) once + a(50) + b(30)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sumUniqueLayers(tt.input); got != tt.expected {
+				t.Errorf("sumUniqueLayers() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestUpdateLayerProgress(t *testing.T) {
+	layerProgress := map[string]int64{}
+
+	// Two layers downloading in parallel: latest value per layer wins.
+	if got := updateLayerProgress(layerProgress, "Downloading", "layer1", 100); got != 100 {
+		t.Errorf("got %d, want 100", got)
+	}
+	if got := updateLayerProgress(layerProgress, "Downloading", "layer2", 50); got != 150 {
+		t.Errorf("got %d, want 150", got)
+	}
+	if got := updateLayerProgress(layerProgress, "Downloading", "layer1", 300); got != 350 {
+		t.Errorf("got %d, want 350 (layer1 updated, not added)", got)
+	}
+
+	// Extracting must not contribute (no double counting of the decompress phase).
+	if got := updateLayerProgress(layerProgress, "Extracting", "layer1", 999); got != 350 {
+		t.Errorf("got %d, want 350 (Extracting ignored)", got)
+	}
+
+	// Events without an ID must not contribute.
+	if got := updateLayerProgress(layerProgress, "Downloading", "", 999); got != 350 {
+		t.Errorf("got %d, want 350 (empty id ignored)", got)
+	}
+}

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -61,11 +61,26 @@ const (
 	InitProgressEvent
 )
 
+// InitEventSource identifies which part of SystemInit produced an event, so a
+// consumer can route events (e.g. drive a docker-specific progress bar) without
+// discarding the others.
+type InitEventSource string
+
+const (
+	// InitSourceDocker is emitted while pulling docker images.
+	InitSourceDocker InitEventSource = "docker"
+	// InitSourceLibs is emitted while downloading Arduino libs and platforms.
+	InitSourceLibs InitEventSource = "libs"
+	// InitSourcePlatform is emitted while installing the platform debian package.
+	InitSourcePlatform InitEventSource = "platform"
+)
+
 // InitEvent is the single unit of output emitted during SystemInit. The Type
 // field selects which payload is meaningful: Message for InitLogEvent, Progress
-// for InitProgressEvent.
+// for InitProgressEvent. Source tells which stage produced the event.
 type InitEvent struct {
 	Type     InitEventType
+	Source   InitEventSource
 	Message  string
 	Progress InitProgress
 }
@@ -74,6 +89,16 @@ type InitEvent struct {
 // rendering-agnostic: it emits semantic events and the caller decides how to
 // render them (e.g. raw text lines or JSON lines).
 type InitEventCallback func(event InitEvent)
+
+// withSource returns a callback that stamps every event with the given source
+// before forwarding it. This lets each stage emit events without repeating the
+// source at every call site.
+func withSource(cb InitEventCallback, source InitEventSource) InitEventCallback {
+	return func(e InitEvent) {
+		e.Source = source
+		cb(e)
+	}
+}
 
 type SystemInitOptions struct {
 	OnlyDockerImages    bool
@@ -106,19 +131,20 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 		downloadDockerImages = true
 	}
 
-	if err := installPlatformPackage(ctx, platform, eventCB); err != nil {
+	if err := installPlatformPackage(ctx, platform, withSource(eventCB, InitSourcePlatform)); err != nil {
 		slog.Error("failed to install platform package", "error", err)
 	}
 
 	if downloadPlatformAndLibs {
-		eventCB(InitEvent{Type: InitLogEvent, Message: "Downloading libs and platforms used in examples ..."})
-		if err := downloadLibsAndPlatformsUsedInExamples(ctx, cfg, platform, eventCB); err != nil {
+		libsCB := withSource(eventCB, InitSourceLibs)
+		libsCB(InitEvent{Type: InitLogEvent, Message: "Downloading libs and platforms used in examples ..."})
+		if err := downloadLibsAndPlatformsUsedInExamples(ctx, cfg, platform, libsCB); err != nil {
 			return fmt.Errorf("failed to download libs and platforms used in examples: %w", err)
 		}
 	}
 
 	if downloadDockerImages {
-		if err := downloadSupportedImages(ctx, cfg, bricksindex, servicesindex, modelsIndex, docker, eventCB); err != nil {
+		if err := downloadSupportedImages(ctx, cfg, bricksindex, servicesindex, modelsIndex, docker, withSource(eventCB, InitSourceDocker)); err != nil {
 			return fmt.Errorf("failed to download container images used in examples: %w", err)
 		}
 	}
@@ -144,15 +170,11 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 		return err
 	}
 
-	// Filter out container images that are alredy pulled
+	// Filter out container images that are already pulled
 	imagesToPreinstall = slices.DeleteFunc(imagesToPreinstall, func(v string) bool {
 		return slices.Contains(pulledImages, v)
 	})
 
-	// First pass: resolve the layers that actually need to be downloaded for each
-	// image. We keep the per-image bytes for the disk-space check, and compute the
-	// global total from the union of unique layers (shared layers count once), so
-	// the aggregated download progress can reach 100%.
 	type imageToPull struct {
 		ref   string
 		bytes int64
@@ -163,7 +185,6 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 		previousExistingImage := GetHighestVersion(image, pulledImages)
 		layers, err := missingLayers(previousExistingImage, image)
 		if err != nil {
-			// In case of errors getting the layers to download, proceed anyway.
 			slog.Warn("Unable to get the new image layers size", "image", image, "error", err)
 		}
 		var bytes int64
@@ -177,8 +198,6 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 	totalBytes := sumUniqueLayers(layersPerImage)
 	slog.Info("total docker images download size", "bytes", totalBytes)
 
-	// Second pass: pull the images, accumulating downloaded bytes across all of
-	// them so progress reflects the global download status.
 	layerProgress := map[string]int64{}
 	var lastLabel string
 	for i, img := range imagesToPull {

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -195,11 +195,6 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 		}
 	}
 
-	// The per-byte accounting from the docker pull stream rarely sums exactly to
-	// the computed total (the last "Downloading" event of a layer stops short of
-	// its full size before docker moves on to extraction), so the aggregate
-	// progress would otherwise stall a few points below 100%. Emit a final
-	// progress event to guarantee a clean 100% once every image has been pulled.
 	if totalBytes > 0 && len(imagesToPull) > 0 {
 		eventCB(InitEvent{Type: InitProgressEvent, Source: InitSourceDocker, Progress: InitProgress{Label: lastLabel, Curr: totalBytes, Total: totalBytes}})
 	}
@@ -211,11 +206,6 @@ const minDelay = 1 * time.Second
 const maxDelay = 10 * time.Second
 
 // updateLayerProgress records the bytes downloaded so far for a single layer
-// from a docker pull stream payload and returns the new global downloaded total
-// (the sum across all tracked layers). Only "Downloading" events contribute, so
-// the "Extracting" (decompression) phase is not double-counted. layerProgress is
-// keyed by layer ID and holds the latest reported value, which makes the count
-// safe across pull retries.
 func updateLayerProgress(layerProgress map[string]int64, status, id string, current int64) int64 {
 	if status == "Downloading" && id != "" {
 		layerProgress[id] = current
@@ -273,9 +263,7 @@ func pullImage(ctx context.Context, docker dockerClient.APIClient, imageName str
 		var payload Payload
 		if err := json.Unmarshal(scanner.Bytes(), &payload); err == nil {
 			// Accumulate the downloaded bytes across all layers/images and report
-			// the global download progress. The per-layer docker status lines are
-			// intentionally not emitted: they are redundant with this aggregate
-			// progress and would otherwise flood the output stream.
+			// the global download progress.
 			downloaded := updateLayerProgress(layerProgress, payload.Status, payload.ID, payload.ProgressDetail.Current)
 			if totalBytes > 0 && eventCB != nil {
 				if downloaded > totalBytes {

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -189,7 +189,7 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceDocker, Message: fmt.Sprintf("Pulling container image %s ...", img.ref)})
 		// The percentage stays global (across all images); the label tells the
 		// user which image is currently being pulled.
-		lastLabel = fmt.Sprintf("Pulling image %d/%d (%s)", i+1, len(imagesToPull), imageDisplayName(img.ref))
+		lastLabel = fmt.Sprintf("Pulling image %d/%d (%s)", i+1, len(imagesToPull), imageName(img.ref))
 		if err := pullImage(ctx, docker.Client(), img.ref, layerProgress, totalBytes, lastLabel, eventCB); err != nil {
 			return fmt.Errorf("failed to pull image %s: %w", img.ref, err)
 		}

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -153,12 +153,8 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 		return slices.Contains(pulledImages, v)
 	})
 
-	type imageToPull struct {
-		ref   string
-		bytes int64
-	}
-	imagesToPull := make([]imageToPull, 0, len(imagesToPreinstall))
-	layersPerImage := make([][]dockerImageLayer, 0, len(imagesToPreinstall))
+	imagesToPull := make([]string, 0, len(imagesToPreinstall))
+	allLayers := make([]dockerImageLayer, 0, len(imagesToPreinstall))
 	for _, image := range imagesToPreinstall {
 		previousExistingImage := GetHighestVersion(image, pulledImages)
 		layers, err := missingLayers(previousExistingImage, image)
@@ -169,32 +165,32 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 		for _, l := range layers {
 			bytes += l.Size
 		}
-		imagesToPull = append(imagesToPull, imageToPull{ref: image, bytes: bytes})
-		layersPerImage = append(layersPerImage, layers)
+		imagesToPull = append(imagesToPull, image)
+		allLayers = append(allLayers, layers...)
 		slog.Info("docker image to download", "image", image, "bytes", bytes)
 	}
-	totalBytes := sumUniqueLayers(layersPerImage)
+	totalBytes := sumUniqueLayers(allLayers)
 	slog.Info("total docker images download size", "bytes", totalBytes)
+
+	// Check that there is enough disk space for all the layers to download.
+	// Shared layers are counted once, so this is the real download size.
+	freeSpace, err := GetDockerFreeSpace()
+	if err != nil {
+		return err
+	}
+	if uint64(float64(totalBytes)*2.5) > freeSpace {
+		return ErrDockerOutOfSpace
+	}
 
 	layerProgress := map[string]int64{}
 	var lastLabel string
-	for i, img := range imagesToPull {
-		freeSpace, err := GetDockerFreeSpace()
-		if err != nil {
-			return err
-		}
-
-		// Check that there is enough disk space for the additional layers needed by the image.
-		if uint64(float64(img.bytes)*2.5) > freeSpace {
-			return ErrDockerOutOfSpace
-		}
-
-		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceDocker, Message: fmt.Sprintf("Pulling container image %s ...", img.ref)})
+	for i, image := range imagesToPull {
+		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceDocker, Message: fmt.Sprintf("Pulling container image %s ...", image)})
 		// The percentage stays global (across all images); the label tells the
 		// user which image is currently being pulled.
-		lastLabel = fmt.Sprintf("Pulling image %d/%d (%s)", i+1, len(imagesToPull), imageName(img.ref))
-		if err := pullImage(ctx, docker.Client(), img.ref, layerProgress, totalBytes, lastLabel, eventCB); err != nil {
-			return fmt.Errorf("failed to pull image %s: %w", img.ref, err)
+		lastLabel = fmt.Sprintf("Pulling image %d/%d (%s)", i+1, len(imagesToPull), imageName(image))
+		if err := pullImage(ctx, docker.Client(), image, layerProgress, totalBytes, lastLabel, eventCB); err != nil {
+			return fmt.Errorf("failed to pull image %s: %w", image, err)
 		}
 	}
 

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -92,6 +92,9 @@ func (o SystemInitOptions) Validate() error {
 // sketch libraries used in the example apps. Can be used to pre-install docker images/libraries on an
 // empty system, or to update all the docker images/libraries that need it.
 func SystemInit(ctx context.Context, cfg config.Configuration, platform platform.Platform, bricksindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, docker *command.DockerCli, modelsIndex *modelsindex.ModelsIndex, options SystemInitOptions, eventCB InitEventCallback) error {
+	if eventCB == nil {
+		eventCB = func(InitEvent) {}
+	}
 	if err := options.Validate(); err != nil {
 		return err
 	}
@@ -265,7 +268,7 @@ func pullImage(ctx context.Context, docker dockerClient.APIClient, imageName str
 			// Accumulate the downloaded bytes across all layers/images and report
 			// the global download progress.
 			downloaded := updateLayerProgress(layerProgress, payload.Status, payload.ID, payload.ProgressDetail.Current)
-			if totalBytes > 0 && eventCB != nil {
+			if totalBytes > 0 {
 				if downloaded > totalBytes {
 					downloaded = totalBytes
 				}

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -61,9 +61,9 @@ const (
 type InitEventSource string
 
 const (
-	InitSourceDocker   InitEventSource = "docker"
-	InitSourceLibs     InitEventSource = "libs"
-	InitSourcePlatform InitEventSource = "platform"
+	InitSourceDocker  InitEventSource = "docker"
+	InitSourceArduino InitEventSource = "arduino"
+	InitSourceDeb     InitEventSource = "deb"
 )
 
 type InitEvent struct {
@@ -115,7 +115,7 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 	}
 
 	if downloadPlatformAndLibs {
-		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceLibs, Message: "Downloading libs and platforms used in examples ..."})
+		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceArduino, Message: "Downloading libs and platforms used in examples ..."})
 		if err := downloadLibsAndPlatformsUsedInExamples(ctx, cfg, platform, eventCB); err != nil {
 			return fmt.Errorf("failed to download libs and platforms used in examples: %w", err)
 		}
@@ -551,11 +551,11 @@ func installPlatformPackage(ctx context.Context, plat platform.Platform, eventCB
 	case "ventunoq":
 		packageName = "arduino-ventunoq"
 	default:
-		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourcePlatform, Message: fmt.Sprintf("no platform-specific debian package to install for board '%s'", plat.BoardName)})
+		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceDeb, Message: fmt.Sprintf("no platform-specific debian package to install for board '%s'", plat.BoardName)})
 		return nil
 	}
 
-	eventCB(InitEvent{Type: InitLogEvent, Source: InitSourcePlatform, Message: fmt.Sprintf("Installing package '%s'", packageName)})
+	eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceDeb, Message: fmt.Sprintf("Installing package '%s'", packageName)})
 
 	cmd, err := paths.NewProcess(nil, "sudo", "apt-get", "install", "-y", packageName)
 	if err != nil {
@@ -563,7 +563,7 @@ func installPlatformPackage(ctx context.Context, plat platform.Platform, eventCB
 	}
 	// Route the subprocess output through the event callback, one log event per line.
 	subprocessOut := NewCallbackWriter(func(line string) {
-		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourcePlatform, Message: line})
+		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceDeb, Message: line})
 	})
 	cmd.RedirectStderrTo(subprocessOut)
 	cmd.RedirectStdoutTo(subprocessOut)
@@ -603,7 +603,7 @@ func downloadLibsAndPlatformsUsedInExamples(ctx context.Context, cfg config.Conf
 		}
 		if update := curr.GetUpdate(); update != nil {
 			totalSize = update.GetTotalSize()
-			eventCB(InitEvent{Type: InitProgressEvent, Source: InitSourceLibs, Progress: InitProgress{
+			eventCB(InitEvent{Type: InitProgressEvent, Source: InitSourceArduino, Progress: InitProgress{
 				Label: currLabel,
 				Curr:  update.GetDownloaded(),
 				Total: totalSize,

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -45,13 +45,16 @@ var ErrDockerOutOfSpace = errors.New("not enough disk space to pull the docker i
 
 const ExitCodeDockerOutOfSpace = 80
 
-type initProgress struct {
-	label string
-	curr  int64
-	total int64
+// InitProgress represents a single progress update emitted during SystemInit.
+type InitProgress struct {
+	Label string
+	Curr  int64
+	Total int64
 }
 
-type initProgressCallback func(progress initProgress)
+// InitProgressCallback is invoked by SystemInit to report progress updates.
+// It is provided by the caller, which decides how to render the progress.
+type InitProgressCallback func(progress InitProgress)
 
 type SystemInitOptions struct {
 	OnlyDockerImages    bool
@@ -68,7 +71,7 @@ func (o SystemInitOptions) Validate() error {
 // SystemInit pulls all the docker images needed for the current version of the software to run and the
 // sketch libraries used in the example apps. Can be used to pre-install docker images/libraries on an
 // empty system, or to update all the docker images/libraries that need it.
-func SystemInit(ctx context.Context, cfg config.Configuration, platform platform.Platform, bricksindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, modelsIndex *modelsindex.ModelsIndex, docker *command.DockerCli, options SystemInitOptions) error {
+func SystemInit(ctx context.Context, cfg config.Configuration, platform platform.Platform, bricksindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, docker *command.DockerCli, modelsIndex *modelsindex.ModelsIndex, options SystemInitOptions, progressCB InitProgressCallback) error {
 	if err := options.Validate(); err != nil {
 		return err
 	}
@@ -77,15 +80,6 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 	if err != nil {
 		feedback.Fatal(err.Error(), feedback.ErrBadArgument)
 		return nil
-	}
-
-	// TODO: Move this callback up in the call chain, closer to Cobra command definition
-	progressCB := func(progress initProgress) {
-		percentage := float64(progress.curr) / float64(progress.total) * 100
-		fmt.Fprintf(stdout, "%s: %.2f%% (%d/%d)\r", progress.label, percentage, progress.curr, progress.total)
-		if progress.curr == progress.total {
-			fmt.Fprintln(stdout)
-		}
 	}
 
 	var downloadPlatformAndLibs, downloadDockerImages bool
@@ -518,7 +512,7 @@ func installPlatformPackage(ctx context.Context, plat platform.Platform, stdout 
 	return nil
 }
 
-func downloadLibsAndPlatformsUsedInExamples(ctx context.Context, cfg config.Configuration, platform platform.Platform, progressCB initProgressCallback) error {
+func downloadLibsAndPlatformsUsedInExamples(ctx context.Context, cfg config.Configuration, platform platform.Platform, progressCB InitProgressCallback) error {
 	// Start an Arduino Core Server RPC server
 	logrus.SetOutput(io.Discard) // Suppress logs from Arduino CLI
 	var cliInstance *rpc.Instance
@@ -547,10 +541,10 @@ func downloadLibsAndPlatformsUsedInExamples(ctx context.Context, cfg config.Conf
 		}
 		if update := curr.GetUpdate(); update != nil {
 			totalSize = update.GetTotalSize()
-			progressCB(initProgress{
-				label: currLabel,
-				curr:  update.GetDownloaded(),
-				total: totalSize,
+			progressCB(InitProgress{
+				Label: currLabel,
+				Curr:  update.GetDownloaded(),
+				Total: totalSize,
 			})
 		}
 	}

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -119,7 +119,7 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 	}
 
 	if downloadDockerImages {
-		if err := downloadSupportedImages(ctx, cfg, bricksindex, servicesindex, modelsIndex, docker, withSource(eventCB, InitSourceDocker)); err != nil {
+		if err := downloadSupportedImages(ctx, cfg, bricksindex, servicesindex, modelsIndex, docker, eventCB); err != nil {
 			return fmt.Errorf("failed to download container images used in examples: %w", err)
 		}
 	}
@@ -128,7 +128,7 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 }
 
 func downloadSupportedImages(ctx context.Context, cfg config.Configuration, brickindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, modelsIndex *modelsindex.ModelsIndex, docker *command.DockerCli, eventCB InitEventCallback) error {
-	eventCB(InitEvent{Type: InitLogEvent, Message: "Pulling the latest docker images ..."})
+	eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceDocker, Message: "Pulling the latest docker images ..."})
 	imagesToPreinstall := []string{cfg.PythonImage}
 	brickImages, err := getAllSupportedBrickImages(brickindex, servicesindex)
 	if err != nil {

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -45,16 +45,35 @@ var ErrDockerOutOfSpace = errors.New("not enough disk space to pull the docker i
 
 const ExitCodeDockerOutOfSpace = 80
 
-// InitProgress represents a single progress update emitted during SystemInit.
 type InitProgress struct {
 	Label string
 	Curr  int64
 	Total int64
 }
 
-// InitProgressCallback is invoked by SystemInit to report progress updates.
-// It is provided by the caller, which decides how to render the progress.
-type InitProgressCallback func(progress InitProgress)
+// InitEventType discriminates the kind of event emitted during SystemInit.
+type InitEventType int
+
+const (
+	// InitLogEvent carries a human-readable status line.
+	InitLogEvent InitEventType = iota
+	// InitProgressEvent carries a structured progress update.
+	InitProgressEvent
+)
+
+// InitEvent is the single unit of output emitted during SystemInit. The Type
+// field selects which payload is meaningful: Message for InitLogEvent, Progress
+// for InitProgressEvent.
+type InitEvent struct {
+	Type     InitEventType
+	Message  string
+	Progress InitProgress
+}
+
+// InitEventCallback is the sole output sink for SystemInit. The orchestrator is
+// rendering-agnostic: it emits semantic events and the caller decides how to
+// render them (e.g. raw text lines or JSON lines).
+type InitEventCallback func(event InitEvent)
 
 type SystemInitOptions struct {
 	OnlyDockerImages    bool
@@ -71,15 +90,9 @@ func (o SystemInitOptions) Validate() error {
 // SystemInit pulls all the docker images needed for the current version of the software to run and the
 // sketch libraries used in the example apps. Can be used to pre-install docker images/libraries on an
 // empty system, or to update all the docker images/libraries that need it.
-func SystemInit(ctx context.Context, cfg config.Configuration, platform platform.Platform, bricksindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, docker *command.DockerCli, modelsIndex *modelsindex.ModelsIndex, options SystemInitOptions, progressCB InitProgressCallback) error {
+func SystemInit(ctx context.Context, cfg config.Configuration, platform platform.Platform, bricksindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, docker *command.DockerCli, modelsIndex *modelsindex.ModelsIndex, options SystemInitOptions, eventCB InitEventCallback) error {
 	if err := options.Validate(); err != nil {
 		return err
-	}
-
-	stdout, _, err := feedback.DirectStreams()
-	if err != nil {
-		feedback.Fatal(err.Error(), feedback.ErrBadArgument)
-		return nil
 	}
 
 	var downloadPlatformAndLibs, downloadDockerImages bool
@@ -93,20 +106,19 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 		downloadDockerImages = true
 	}
 
-	if err := installPlatformPackage(ctx, platform, stdout); err != nil {
+	if err := installPlatformPackage(ctx, platform, eventCB); err != nil {
 		slog.Error("failed to install platform package", "error", err)
 	}
 
 	if downloadPlatformAndLibs {
-		fmt.Fprintf(stdout, "Downloading libs and platforms used in examples ...\n")
-		if err := downloadLibsAndPlatformsUsedInExamples(ctx, cfg, platform, progressCB); err != nil {
+		eventCB(InitEvent{Type: InitLogEvent, Message: "Downloading libs and platforms used in examples ..."})
+		if err := downloadLibsAndPlatformsUsedInExamples(ctx, cfg, platform, eventCB); err != nil {
 			return fmt.Errorf("failed to download libs and platforms used in examples: %w", err)
 		}
 	}
 
 	if downloadDockerImages {
-		// TODO: use progressCB instead of stdout
-		if err := downloadSupportedImages(ctx, cfg, bricksindex, servicesindex, modelsIndex, docker, stdout, progressCB); err != nil {
+		if err := downloadSupportedImages(ctx, cfg, bricksindex, servicesindex, modelsIndex, docker, eventCB); err != nil {
 			return fmt.Errorf("failed to download container images used in examples: %w", err)
 		}
 	}
@@ -114,8 +126,8 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 	return nil
 }
 
-func downloadSupportedImages(ctx context.Context, cfg config.Configuration, brickindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, modelsIndex *modelsindex.ModelsIndex, docker *command.DockerCli, stdout io.Writer, progressCB InitProgressCallback) error {
-	fmt.Fprintf(stdout, "Pulling the latest docker images ...\n")
+func downloadSupportedImages(ctx context.Context, cfg config.Configuration, brickindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, modelsIndex *modelsindex.ModelsIndex, docker *command.DockerCli, eventCB InitEventCallback) error {
+	eventCB(InitEvent{Type: InitLogEvent, Message: "Pulling the latest docker images ..."})
 	imagesToPreinstall := []string{cfg.PythonImage}
 	brickImages, err := getAllSupportedBrickImages(brickindex, servicesindex)
 	if err != nil {
@@ -168,6 +180,7 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 	// Second pass: pull the images, accumulating downloaded bytes across all of
 	// them so progress reflects the global download status.
 	layerProgress := map[string]int64{}
+	var lastLabel string
 	for i, img := range imagesToPull {
 		freeSpace, err := GetDockerFreeSpace()
 		if err != nil {
@@ -179,13 +192,22 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 			return ErrDockerOutOfSpace
 		}
 
-		feedback.Printf("Pulling container image %s ...", img.ref)
+		eventCB(InitEvent{Type: InitLogEvent, Message: fmt.Sprintf("Pulling container image %s ...", img.ref)})
 		// The percentage stays global (across all images); the label tells the
 		// user which image is currently being pulled.
-		label := fmt.Sprintf("Pulling image %d/%d (%s)", i+1, len(imagesToPull), imageDisplayName(img.ref))
-		if err := pullImage(ctx, stdout, docker.Client(), img.ref, layerProgress, totalBytes, label, progressCB); err != nil {
+		lastLabel = fmt.Sprintf("Pulling image %d/%d (%s)", i+1, len(imagesToPull), imageDisplayName(img.ref))
+		if err := pullImage(ctx, docker.Client(), img.ref, layerProgress, totalBytes, lastLabel, eventCB); err != nil {
 			return fmt.Errorf("failed to pull image %s: %w", img.ref, err)
 		}
+	}
+
+	// The per-byte accounting from the docker pull stream rarely sums exactly to
+	// the computed total (the last "Downloading" event of a layer stops short of
+	// its full size before docker moves on to extraction), so the aggregate
+	// progress would otherwise stall a few points below 100%. Emit a final
+	// progress event to guarantee a clean 100% once every image has been pulled.
+	if totalBytes > 0 && len(imagesToPull) > 0 {
+		eventCB(InitEvent{Type: InitProgressEvent, Progress: InitProgress{Label: lastLabel, Curr: totalBytes, Total: totalBytes}})
 	}
 
 	return nil
@@ -212,7 +234,7 @@ func updateLayerProgress(layerProgress map[string]int64, status, id string, curr
 	return downloaded
 }
 
-func pullImage(ctx context.Context, stdout io.Writer, docker dockerClient.APIClient, imageName string, layerProgress map[string]int64, totalBytes int64, progressLabel string, progressCB InitProgressCallback) error {
+func pullImage(ctx context.Context, docker dockerClient.APIClient, imageName string, layerProgress map[string]int64, totalBytes int64, progressLabel string, eventCB InitEventCallback) error {
 	delay := minDelay
 	var out io.ReadCloser
 	var allErr error
@@ -228,7 +250,7 @@ func pullImage(ctx context.Context, stdout io.Writer, docker dockerClient.APICli
 			return allErr // Non-retryable error
 		}
 
-		feedback.Warnf("received 'toomanyrequests' error from Docker registry, retrying in %s ...", delay)
+		eventCB(InitEvent{Type: InitLogEvent, Message: fmt.Sprintf("received 'toomanyrequests' error from Docker registry, retrying in %s ...", delay)})
 
 		select {
 		case <-ctx.Done():
@@ -256,23 +278,16 @@ func pullImage(ctx context.Context, stdout io.Writer, docker dockerClient.APICli
 
 		var payload Payload
 		if err := json.Unmarshal(scanner.Bytes(), &payload); err == nil {
-			if payload.Status != "" {
-				fmt.Fprintf(stdout, "%s", payload.Status)
-			}
-			if payload.Progress != "" {
-				fmt.Fprintf(stdout, "[%s] %s\r", payload.ID, payload.Progress)
-			} else {
-				fmt.Fprintln(stdout)
-			}
-
 			// Accumulate the downloaded bytes across all layers/images and report
-			// the global download progress.
+			// the global download progress. The per-layer docker status lines are
+			// intentionally not emitted: they are redundant with this aggregate
+			// progress and would otherwise flood the output stream.
 			downloaded := updateLayerProgress(layerProgress, payload.Status, payload.ID, payload.ProgressDetail.Current)
-			if totalBytes > 0 && progressCB != nil {
+			if totalBytes > 0 && eventCB != nil {
 				if downloaded > totalBytes {
 					downloaded = totalBytes
 				}
-				progressCB(InitProgress{Label: progressLabel, Curr: downloaded, Total: totalBytes})
+				eventCB(InitEvent{Type: InitProgressEvent, Progress: InitProgress{Label: progressLabel, Curr: downloaded, Total: totalBytes}})
 			}
 		}
 	}
@@ -546,7 +561,7 @@ func removeDanglingNetworks(ctx context.Context, docker dockerClient.APIClient) 
 	return counter, nil
 }
 
-func installPlatformPackage(ctx context.Context, plat platform.Platform, stdout io.Writer) error {
+func installPlatformPackage(ctx context.Context, plat platform.Platform, eventCB InitEventCallback) error {
 	var packageName string
 
 	switch plat.BoardName {
@@ -555,18 +570,22 @@ func installPlatformPackage(ctx context.Context, plat platform.Platform, stdout 
 	case "ventunoq":
 		packageName = "arduino-ventunoq"
 	default:
-		fmt.Fprintf(stdout, "no platform-specific debian package to install for board '%s'\n", plat.BoardName)
+		eventCB(InitEvent{Type: InitLogEvent, Message: fmt.Sprintf("no platform-specific debian package to install for board '%s'", plat.BoardName)})
 		return nil
 	}
 
-	fmt.Fprintf(stdout, "Installing package '%s'\n", packageName)
+	eventCB(InitEvent{Type: InitLogEvent, Message: fmt.Sprintf("Installing package '%s'", packageName)})
 
 	cmd, err := paths.NewProcess(nil, "sudo", "apt-get", "install", "-y", packageName)
 	if err != nil {
 		return err
 	}
-	cmd.RedirectStderrTo(stdout)
-	cmd.RedirectStdoutTo(stdout)
+	// Route the subprocess output through the event callback, one log event per line.
+	subprocessOut := NewCallbackWriter(func(line string) {
+		eventCB(InitEvent{Type: InitLogEvent, Message: line})
+	})
+	cmd.RedirectStderrTo(subprocessOut)
+	cmd.RedirectStdoutTo(subprocessOut)
 
 	if err := cmd.RunWithinContext(ctx); err != nil {
 		return err
@@ -574,7 +593,7 @@ func installPlatformPackage(ctx context.Context, plat platform.Platform, stdout 
 	return nil
 }
 
-func downloadLibsAndPlatformsUsedInExamples(ctx context.Context, cfg config.Configuration, platform platform.Platform, progressCB InitProgressCallback) error {
+func downloadLibsAndPlatformsUsedInExamples(ctx context.Context, cfg config.Configuration, platform platform.Platform, eventCB InitEventCallback) error {
 	// Start an Arduino Core Server RPC server
 	logrus.SetOutput(io.Discard) // Suppress logs from Arduino CLI
 	var cliInstance *rpc.Instance
@@ -603,11 +622,11 @@ func downloadLibsAndPlatformsUsedInExamples(ctx context.Context, cfg config.Conf
 		}
 		if update := curr.GetUpdate(); update != nil {
 			totalSize = update.GetTotalSize()
-			progressCB(InitProgress{
+			eventCB(InitEvent{Type: InitProgressEvent, Progress: InitProgress{
 				Label: currLabel,
 				Curr:  update.GetDownloaded(),
 				Total: totalSize,
-			})
+			}})
 		}
 	}
 

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -51,33 +51,21 @@ type InitProgress struct {
 	Total int64
 }
 
-// InitEventType discriminates the kind of event emitted during SystemInit.
 type InitEventType int
 
 const (
-	// InitLogEvent carries a human-readable status line.
 	InitLogEvent InitEventType = iota
-	// InitProgressEvent carries a structured progress update.
 	InitProgressEvent
 )
 
-// InitEventSource identifies which part of SystemInit produced an event, so a
-// consumer can route events (e.g. drive a docker-specific progress bar) without
-// discarding the others.
 type InitEventSource string
 
 const (
-	// InitSourceDocker is emitted while pulling docker images.
-	InitSourceDocker InitEventSource = "docker"
-	// InitSourceLibs is emitted while downloading Arduino libs and platforms.
-	InitSourceLibs InitEventSource = "libs"
-	// InitSourcePlatform is emitted while installing the platform debian package.
+	InitSourceDocker   InitEventSource = "docker"
+	InitSourceLibs     InitEventSource = "libs"
 	InitSourcePlatform InitEventSource = "platform"
 )
 
-// InitEvent is the single unit of output emitted during SystemInit. The Type
-// field selects which payload is meaningful: Message for InitLogEvent, Progress
-// for InitProgressEvent. Source tells which stage produced the event.
 type InitEvent struct {
 	Type     InitEventType
 	Source   InitEventSource
@@ -85,20 +73,8 @@ type InitEvent struct {
 	Progress InitProgress
 }
 
-// InitEventCallback is the sole output sink for SystemInit. The orchestrator is
-// rendering-agnostic: it emits semantic events and the caller decides how to
-// render them (e.g. raw text lines or JSON lines).
+// InitEventCallback is the sole output sink for SystemInit.
 type InitEventCallback func(event InitEvent)
-
-// withSource returns a callback that stamps every event with the given source
-// before forwarding it. This lets each stage emit events without repeating the
-// source at every call site.
-func withSource(cb InitEventCallback, source InitEventSource) InitEventCallback {
-	return func(e InitEvent) {
-		e.Source = source
-		cb(e)
-	}
-}
 
 type SystemInitOptions struct {
 	OnlyDockerImages    bool
@@ -131,14 +107,13 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 		downloadDockerImages = true
 	}
 
-	if err := installPlatformPackage(ctx, platform, withSource(eventCB, InitSourcePlatform)); err != nil {
+	if err := installPlatformPackage(ctx, platform, eventCB); err != nil {
 		slog.Error("failed to install platform package", "error", err)
 	}
 
 	if downloadPlatformAndLibs {
-		libsCB := withSource(eventCB, InitSourceLibs)
-		libsCB(InitEvent{Type: InitLogEvent, Message: "Downloading libs and platforms used in examples ..."})
-		if err := downloadLibsAndPlatformsUsedInExamples(ctx, cfg, platform, libsCB); err != nil {
+		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceLibs, Message: "Downloading libs and platforms used in examples ..."})
+		if err := downloadLibsAndPlatformsUsedInExamples(ctx, cfg, platform, eventCB); err != nil {
 			return fmt.Errorf("failed to download libs and platforms used in examples: %w", err)
 		}
 	}
@@ -211,7 +186,7 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 			return ErrDockerOutOfSpace
 		}
 
-		eventCB(InitEvent{Type: InitLogEvent, Message: fmt.Sprintf("Pulling container image %s ...", img.ref)})
+		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceDocker, Message: fmt.Sprintf("Pulling container image %s ...", img.ref)})
 		// The percentage stays global (across all images); the label tells the
 		// user which image is currently being pulled.
 		lastLabel = fmt.Sprintf("Pulling image %d/%d (%s)", i+1, len(imagesToPull), imageDisplayName(img.ref))
@@ -226,7 +201,7 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 	// progress would otherwise stall a few points below 100%. Emit a final
 	// progress event to guarantee a clean 100% once every image has been pulled.
 	if totalBytes > 0 && len(imagesToPull) > 0 {
-		eventCB(InitEvent{Type: InitProgressEvent, Progress: InitProgress{Label: lastLabel, Curr: totalBytes, Total: totalBytes}})
+		eventCB(InitEvent{Type: InitProgressEvent, Source: InitSourceDocker, Progress: InitProgress{Label: lastLabel, Curr: totalBytes, Total: totalBytes}})
 	}
 
 	return nil
@@ -269,7 +244,7 @@ func pullImage(ctx context.Context, docker dockerClient.APIClient, imageName str
 			return allErr // Non-retryable error
 		}
 
-		eventCB(InitEvent{Type: InitLogEvent, Message: fmt.Sprintf("received 'toomanyrequests' error from Docker registry, retrying in %s ...", delay)})
+		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceDocker, Message: fmt.Sprintf("received 'toomanyrequests' error from Docker registry, retrying in %s ...", delay)})
 
 		select {
 		case <-ctx.Done():
@@ -306,7 +281,7 @@ func pullImage(ctx context.Context, docker dockerClient.APIClient, imageName str
 				if downloaded > totalBytes {
 					downloaded = totalBytes
 				}
-				eventCB(InitEvent{Type: InitProgressEvent, Progress: InitProgress{Label: progressLabel, Curr: downloaded, Total: totalBytes}})
+				eventCB(InitEvent{Type: InitProgressEvent, Source: InitSourceDocker, Progress: InitProgress{Label: progressLabel, Curr: downloaded, Total: totalBytes}})
 			}
 		}
 	}
@@ -589,11 +564,11 @@ func installPlatformPackage(ctx context.Context, plat platform.Platform, eventCB
 	case "ventunoq":
 		packageName = "arduino-ventunoq"
 	default:
-		eventCB(InitEvent{Type: InitLogEvent, Message: fmt.Sprintf("no platform-specific debian package to install for board '%s'", plat.BoardName)})
+		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourcePlatform, Message: fmt.Sprintf("no platform-specific debian package to install for board '%s'", plat.BoardName)})
 		return nil
 	}
 
-	eventCB(InitEvent{Type: InitLogEvent, Message: fmt.Sprintf("Installing package '%s'", packageName)})
+	eventCB(InitEvent{Type: InitLogEvent, Source: InitSourcePlatform, Message: fmt.Sprintf("Installing package '%s'", packageName)})
 
 	cmd, err := paths.NewProcess(nil, "sudo", "apt-get", "install", "-y", packageName)
 	if err != nil {
@@ -601,7 +576,7 @@ func installPlatformPackage(ctx context.Context, plat platform.Platform, eventCB
 	}
 	// Route the subprocess output through the event callback, one log event per line.
 	subprocessOut := NewCallbackWriter(func(line string) {
-		eventCB(InitEvent{Type: InitLogEvent, Message: line})
+		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourcePlatform, Message: line})
 	})
 	cmd.RedirectStderrTo(subprocessOut)
 	cmd.RedirectStdoutTo(subprocessOut)
@@ -641,7 +616,7 @@ func downloadLibsAndPlatformsUsedInExamples(ctx context.Context, cfg config.Conf
 		}
 		if update := curr.GetUpdate(); update != nil {
 			totalSize = update.GetTotalSize()
-			eventCB(InitEvent{Type: InitProgressEvent, Progress: InitProgress{
+			eventCB(InitEvent{Type: InitProgressEvent, Source: InitSourceLibs, Progress: InitProgress{
 				Label: currLabel,
 				Curr:  update.GetDownloaded(),
 				Total: totalSize,

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -106,7 +106,7 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 
 	if downloadDockerImages {
 		// TODO: use progressCB instead of stdout
-		if err := downloadSupportedImages(ctx, cfg, bricksindex, servicesindex, modelsIndex, docker, stdout); err != nil {
+		if err := downloadSupportedImages(ctx, cfg, bricksindex, servicesindex, modelsIndex, docker, stdout, progressCB); err != nil {
 			return fmt.Errorf("failed to download container images used in examples: %w", err)
 		}
 	}
@@ -114,7 +114,7 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 	return nil
 }
 
-func downloadSupportedImages(ctx context.Context, cfg config.Configuration, brickindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, modelsIndex *modelsindex.ModelsIndex, docker *command.DockerCli, stdout io.Writer) error {
+func downloadSupportedImages(ctx context.Context, cfg config.Configuration, brickindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, modelsIndex *modelsindex.ModelsIndex, docker *command.DockerCli, stdout io.Writer, progressCB InitProgressCallback) error {
 	fmt.Fprintf(stdout, "Pulling the latest docker images ...\n")
 	imagesToPreinstall := []string{cfg.PythonImage}
 	brickImages, err := getAllSupportedBrickImages(brickindex, servicesindex)
@@ -137,24 +137,51 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 		return slices.Contains(pulledImages, v)
 	})
 
+	// First pass: resolve the layers that actually need to be downloaded for each
+	// image. We keep the per-image bytes for the disk-space check, and compute the
+	// global total from the union of unique layers (shared layers count once), so
+	// the aggregated download progress can reach 100%.
+	type imageToPull struct {
+		ref   string
+		bytes int64
+	}
+	imagesToPull := make([]imageToPull, 0, len(imagesToPreinstall))
+	layersPerImage := make([][]dockerImageLayer, 0, len(imagesToPreinstall))
 	for _, image := range imagesToPreinstall {
+		previousExistingImage := GetHighestVersion(image, pulledImages)
+		layers, err := missingLayers(previousExistingImage, image)
+		if err != nil {
+			// In case of errors getting the layers to download, proceed anyway.
+			slog.Warn("Unable to get the new image layers size", "image", image, "error", err)
+		}
+		var bytes int64
+		for _, l := range layers {
+			bytes += l.Size
+		}
+		imagesToPull = append(imagesToPull, imageToPull{ref: image, bytes: bytes})
+		layersPerImage = append(layersPerImage, layers)
+		slog.Info("docker image to download", "image", image, "bytes", bytes)
+	}
+	totalBytes := sumUniqueLayers(layersPerImage)
+	slog.Info("total docker images download size", "bytes", totalBytes)
+
+	// Second pass: pull the images, accumulating downloaded bytes across all of
+	// them so progress reflects the global download status.
+	layerProgress := map[string]int64{}
+	for _, img := range imagesToPull {
 		freeSpace, err := GetDockerFreeSpace()
 		if err != nil {
 			return err
 		}
 
 		// Check that there is enough disk space for the additional layers needed by the image.
-		previousExistingImage := GetHighestVersion(image, pulledImages)
-		if toDownload, err := GetBytesToDownload(previousExistingImage, image); err != nil {
-			// In case of errors getting the size to download, proceed anyway.
-			slog.Warn("Unable to get the new image layers size", "image", image, "error", err)
-		} else if uint64(float64(toDownload)*2.5) > freeSpace {
+		if uint64(float64(img.bytes)*2.5) > freeSpace {
 			return ErrDockerOutOfSpace
 		}
 
-		feedback.Printf("Pulling container image %s ...", image)
-		if err := pullImage(ctx, stdout, docker.Client(), image); err != nil {
-			return fmt.Errorf("failed to pull image %s: %w", image, err)
+		feedback.Printf("Pulling container image %s ...", img.ref)
+		if err := pullImage(ctx, stdout, docker.Client(), img.ref, layerProgress, totalBytes, progressCB); err != nil {
+			return fmt.Errorf("failed to pull image %s: %w", img.ref, err)
 		}
 	}
 
@@ -164,7 +191,25 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 const minDelay = 1 * time.Second
 const maxDelay = 10 * time.Second
 
-func pullImage(ctx context.Context, stdout io.Writer, docker dockerClient.APIClient, imageName string) error {
+// updateLayerProgress records the bytes downloaded so far for a single layer
+// from a docker pull stream payload and returns the new global downloaded total
+// (the sum across all tracked layers). Only "Downloading" events contribute, so
+// the "Extracting" (decompression) phase is not double-counted. layerProgress is
+// keyed by layer ID and holds the latest reported value, which makes the count
+// safe across pull retries.
+func updateLayerProgress(layerProgress map[string]int64, status, id string, current int64) int64 {
+	if status == "Downloading" && id != "" {
+		layerProgress[id] = current
+	}
+
+	var downloaded int64
+	for _, c := range layerProgress {
+		downloaded += c
+	}
+	return downloaded
+}
+
+func pullImage(ctx context.Context, stdout io.Writer, docker dockerClient.APIClient, imageName string, layerProgress map[string]int64, totalBytes int64, progressCB InitProgressCallback) error {
 	delay := minDelay
 	var out io.ReadCloser
 	var allErr error
@@ -197,9 +242,13 @@ func pullImage(ctx context.Context, stdout io.Writer, docker dockerClient.APICli
 	scanner := bufio.NewScanner(out)
 	for scanner.Scan() {
 		type Payload struct {
-			Status   string `json:"status"`
-			Progress string `json:"progress"`
-			ID       string `json:"id"`
+			Status         string `json:"status"`
+			Progress       string `json:"progress"`
+			ID             string `json:"id"`
+			ProgressDetail struct {
+				Current int64 `json:"current"`
+				Total   int64 `json:"total"`
+			} `json:"progressDetail"`
 		}
 
 		var payload Payload
@@ -211,6 +260,16 @@ func pullImage(ctx context.Context, stdout io.Writer, docker dockerClient.APICli
 				fmt.Fprintf(stdout, "[%s] %s\r", payload.ID, payload.Progress)
 			} else {
 				fmt.Fprintln(stdout)
+			}
+
+			// Accumulate the downloaded bytes across all layers/images and report
+			// the global download progress.
+			downloaded := updateLayerProgress(layerProgress, payload.Status, payload.ID, payload.ProgressDetail.Current)
+			if totalBytes > 0 && progressCB != nil {
+				if downloaded > totalBytes {
+					downloaded = totalBytes
+				}
+				progressCB(InitProgress{Label: "Downloading container images", Curr: downloaded, Total: totalBytes})
 			}
 		}
 	}

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -168,7 +168,7 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 	// Second pass: pull the images, accumulating downloaded bytes across all of
 	// them so progress reflects the global download status.
 	layerProgress := map[string]int64{}
-	for _, img := range imagesToPull {
+	for i, img := range imagesToPull {
 		freeSpace, err := GetDockerFreeSpace()
 		if err != nil {
 			return err
@@ -180,7 +180,10 @@ func downloadSupportedImages(ctx context.Context, cfg config.Configuration, bric
 		}
 
 		feedback.Printf("Pulling container image %s ...", img.ref)
-		if err := pullImage(ctx, stdout, docker.Client(), img.ref, layerProgress, totalBytes, progressCB); err != nil {
+		// The percentage stays global (across all images); the label tells the
+		// user which image is currently being pulled.
+		label := fmt.Sprintf("Pulling image %d/%d (%s)", i+1, len(imagesToPull), imageDisplayName(img.ref))
+		if err := pullImage(ctx, stdout, docker.Client(), img.ref, layerProgress, totalBytes, label, progressCB); err != nil {
 			return fmt.Errorf("failed to pull image %s: %w", img.ref, err)
 		}
 	}
@@ -209,7 +212,7 @@ func updateLayerProgress(layerProgress map[string]int64, status, id string, curr
 	return downloaded
 }
 
-func pullImage(ctx context.Context, stdout io.Writer, docker dockerClient.APIClient, imageName string, layerProgress map[string]int64, totalBytes int64, progressCB InitProgressCallback) error {
+func pullImage(ctx context.Context, stdout io.Writer, docker dockerClient.APIClient, imageName string, layerProgress map[string]int64, totalBytes int64, progressLabel string, progressCB InitProgressCallback) error {
 	delay := minDelay
 	var out io.ReadCloser
 	var allErr error
@@ -269,7 +272,7 @@ func pullImage(ctx context.Context, stdout io.Writer, docker dockerClient.APICli
 				if downloaded > totalBytes {
 					downloaded = totalBytes
 				}
-				progressCB(InitProgress{Label: "Downloading container images", Curr: downloaded, Total: totalBytes})
+				progressCB(InitProgress{Label: progressLabel, Curr: downloaded, Total: totalBytes})
 			}
 		}
 	}


### PR DESCRIPTION
### Motivation

closes https://github.com/bcmi-labs/orchestrator/issues/521 (check it for the full context, limitations, integration, realated issue) 

### Change description

- Single typed `InitEvent callback` (log/progress) as the only path to `stdout` for system init.
- Per-layer Docker logs removed and replaced by progress aggregated globally across all images.
- Added `arduino-app-cli system init --format json-lines` flag to system init(extending feedback pkg. this could be used for system update command too), emitting JSONL with `type`, `source`, `label`, `current`, `total`, `percent `fields.
- The `source ` field (docker/libs/platform) it will be used by the consumers (it will be used in the upgrade flow, where system init is called as a sub-process to distinguish between the update source events): I preferred to keep all the logs instead of returning just the Docker ones to avoid losing logs.
- Disk space check refactoring(GetBytesToDownload removed).


### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
