### PR TITLE
Update openapi server

### DIFF
--- a/cmd/gendoc/docs.go
+++ b/cmd/gendoc/docs.go
@@ -48,7 +48,7 @@ func NewOpenApiGenerator(version string) *Generator {
 	reflector := openapi3.NewReflector()
 	reflector.Spec.Info.WithTitle("Arduino-App-Cli").WithVersion(version)
 	reflector.Spec.Servers = append(reflector.Spec.Servers, openapi3.Server{
-		URL:         "http://localhost:6060",
+		URL:         "http://localhost:8800",
 		Description: new("local server"),
 	})
 

--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -4,7 +4,7 @@ info:
   version: 0.1.0
 servers:
 - description: local server
-  url: http://localhost:6060
+  url: http://localhost:8800
 tags:
 - name: Application
 - name: Brick


### PR DESCRIPTION
### Motivation

This allows to test app-cli api with openapi ui at `http://localhost:8800/v1/docs`. For some reason the config in Swagger UI was wrong.
