### PR TITLE
chore: remove unused import of App from README templates

### DIFF
--- a/internal/orchestrator/app/generator/brick_template/README.md.template
+++ b/internal/orchestrator/app/generator/brick_template/README.md.template
@@ -9,7 +9,7 @@ Custom Bricks are modular components that add reusable functionality to your app
 Write your Python class inside `bricks/{{ .ID }}/__init__.py` and add the `@brick` decorator.
 ```python
 # bricks/{{ .ID }}/__init__.py
-from arduino.app_utils import App, brick, Logger
+from arduino.app_utils import brick, Logger
 import time
 
 logger = Logger("GreeterBrick")

--- a/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/README.md
+++ b/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/README.md
@@ -9,7 +9,7 @@ Custom Bricks are modular components that add reusable functionality to your app
 Write your Python class inside `bricks/my-brick/__init__.py` and add the `@brick` decorator.
 ```python
 # bricks/my-brick/__init__.py
-from arduino.app_utils import App, brick, Logger
+from arduino.app_utils import brick, Logger
 import time
 
 logger = Logger("GreeterBrick")


### PR DESCRIPTION
### Motivation
The importerd `App` is not used in the brick code.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
