### PR TITLE
fix: set Installed=true on AIModelItem returned by InstallEIModel

### DIFF
--- a/internal/orchestrator/models.go
+++ b/internal/orchestrator/models.go
@@ -323,7 +323,8 @@ func InstallEIModel(ctx context.Context, bricksIndex *bricksindex.BricksIndex, m
 		Bricks: f.Map(aimodel.ModelDescriptor.Bricks, func(b custommodel.BrickConfig) string {
 			return b.ID
 		}),
-		Metadata: aimodel.ModelDescriptor.Metadata,
+		Metadata:  aimodel.ModelDescriptor.Metadata,
+		Installed: true,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- `InstallEIModel` was returning an `AIModelItem` without setting `Installed: true`, so callers received a response indicating the model was not installed immediately after a successful installation.

## Test plan

- [ ] Call `PUT /v1/models/ei/projects/{id}` and verify the response includes `"installed": true`
- [ ] Verify existing model list and detail endpoints are unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)