### PR TITLE
feat: allow to add external unit socket

### DIFF
--- a/debian/arduino-app-cli/etc/systemd/system/arduino-app-cli.service
+++ b/debian/arduino-app-cli/etc/systemd/system/arduino-app-cli.service
@@ -7,7 +7,6 @@ Wants=network-online.target docker.service arduino-router.service
 ExecStart=/usr/bin/arduino-app-cli daemon --port 8800 --log-level error
 User=1000
 Group=arduino
-Environment="ARDUINO_ROUTER_SOCKET=/var/run/arduino-router.sock"
 StandardOutput=journal
 StandardError=journal
 Restart=always

--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -25,7 +25,7 @@ var RunnerVersion = "0.11.0rc7"
 type Configuration struct {
 	appsDir                          *paths.Path
 	dataDir                          *paths.Path
-	requiredUnits                    []string
+	requiredRuntimes                 []string
 	customModelsDir                  *paths.Path
 	modelsDir                        *paths.Path
 	dockerRegistryBase               string
@@ -62,14 +62,14 @@ func NewFromEnv() (Configuration, error) {
 	}
 
 	// Required host units bind-mounted as /run/<unit> into app containers.
-	requiredUnitsEnv, ok := os.LookupEnv("ARDUINO_APP_CLI__REQUIRED_UNITS")
+	requiredRuntimesEnv, ok := os.LookupEnv("ARDUINO_APP_CLI__REQUIRED_RUNTIMES")
 	if !ok {
-		requiredUnitsEnv = "arduino-router,arduino-app-cloud"
+		requiredRuntimesEnv = "arduino-router,arduino-app-cloud"
 	}
-	var requiredUnits []string
-	for u := range strings.SplitSeq(requiredUnitsEnv, ",") {
+	var requiredRuntimes []string
+	for u := range strings.SplitSeq(requiredRuntimesEnv, ",") {
 		if u = strings.TrimSpace(u); u != "" {
-			requiredUnits = append(requiredUnits, u)
+			requiredRuntimes = append(requiredRuntimes, u)
 		}
 	}
 
@@ -133,7 +133,7 @@ func NewFromEnv() (Configuration, error) {
 	c := Configuration{
 		appsDir:                          appsDir,
 		dataDir:                          dataDir,
-		requiredUnits:                    requiredUnits,
+		requiredRuntimes:                 requiredRuntimes,
 		customModelsDir:                  customModelsDir,
 		modelsDir:                        modelsDir,
 		dockerRegistryBase:               registryBase,
@@ -184,7 +184,7 @@ func (c *Configuration) ExamplesDir() *paths.Path {
 // /var/run/<unit>.sock. The first existing entry per unit is returned.
 func (c *Configuration) RequiredUnitsPaths() paths.PathList {
 	var result paths.PathList
-	for _, unit := range c.requiredUnits {
+	for _, unit := range c.requiredRuntimes {
 		candidates := []*paths.Path{
 			paths.New("/run", unit),
 			paths.New("/var/run", unit),

--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -25,7 +25,6 @@ var RunnerVersion = "0.11.0rc7"
 type Configuration struct {
 	appsDir                          *paths.Path
 	dataDir                          *paths.Path
-	routerSocketPath                 *paths.Path
 	requiredUnits                    []string
 	customModelsDir                  *paths.Path
 	modelsDir                        *paths.Path
@@ -60,12 +59,6 @@ func NewFromEnv() (Configuration, error) {
 	dataDir := paths.New(os.Getenv("ARDUINO_APP_CLI__DATA_DIR"))
 	if dataDir == nil {
 		dataDir = paths.New("/var/lib/arduino-app-cli")
-	}
-
-	// FIXME: this should be removed at some point, when the router expose the new socket /run/arduino-router/arduno-router.sock
-	routerSocket := paths.New(os.Getenv("ARDUINO_ROUTER_SOCKET"))
-	if routerSocket == nil || routerSocket.NotExist() {
-		routerSocket = paths.New("/var/run/arduino-router.sock")
 	}
 
 	// Required host units bind-mounted as /run/<unit> into app containers.
@@ -140,7 +133,6 @@ func NewFromEnv() (Configuration, error) {
 	c := Configuration{
 		appsDir:                          appsDir,
 		dataDir:                          dataDir,
-		routerSocketPath:                 routerSocket,
 		requiredUnits:                    requiredUnits,
 		customModelsDir:                  customModelsDir,
 		modelsDir:                        modelsDir,
@@ -187,22 +179,31 @@ func (c *Configuration) ExamplesDir() *paths.Path {
 	return c.dataDir.Join("examples")
 }
 
-func (c *Configuration) RouterSocketPath() *paths.Path {
-	return c.routerSocketPath
-}
-
-// RequiredUnitsRuntimeDir returns existing /run/<unit> dirs for configured required units.
-func (c *Configuration) RequiredUnitsRuntimeDir() paths.PathList {
-	var requiredUnits paths.PathList
+// RequiredUnitsPaths returns the discovered host paths for configured required
+// units, searching in order: /run/<unit>, /var/run/<unit>, /run/<unit>.sock,
+// /var/run/<unit>.sock. The first existing entry per unit is returned.
+func (c *Configuration) RequiredUnitsPaths() paths.PathList {
+	var result paths.PathList
 	for _, unit := range c.requiredUnits {
-		unitRuntimeDir := paths.New("/run").Join(unit)
-		if unitRuntimeDir.Exist() {
-			requiredUnits.AddIfMissing(unitRuntimeDir)
-		} else {
-			slog.Debug("required unit runtime directory does not exist", "unit", unit, "path", unitRuntimeDir.String())
+		candidates := []*paths.Path{
+			paths.New("/run", unit),
+			paths.New("/var/run", unit),
+			paths.New("/run", unit+".sock"),
+			paths.New("/var/run", unit+".sock"),
+		}
+		found := false
+		for _, p := range candidates {
+			if p.Exist() {
+				result.AddIfMissing(p)
+				found = true
+				break
+			}
+		}
+		if !found {
+			slog.Debug("required unit not found on host", "unit", unit)
 		}
 	}
-	return requiredUnits
+	return result
 }
 
 func (c *Configuration) AssetsDir() *paths.Path {

--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -184,12 +184,12 @@ func (c *Configuration) ExamplesDir() *paths.Path {
 // /var/run/<unit>.sock. The first existing entry per unit is returned.
 func (c *Configuration) RequiredRuntimesPaths() paths.PathList {
 	var result paths.PathList
-	for _, unit := range c.requiredRuntimes {
+	for _, runtime := range c.requiredRuntimes {
 		candidates := []*paths.Path{
-			paths.New("/run", unit),
-			paths.New("/var/run", unit),
-			paths.New("/run", unit+".sock"),
-			paths.New("/var/run", unit+".sock"),
+			paths.New("/run", runtime),
+			paths.New("/var/run", runtime),
+			paths.New("/run", runtime+".sock"),
+			paths.New("/var/run", runtime+".sock"),
 		}
 		found := false
 		for _, p := range candidates {
@@ -200,7 +200,7 @@ func (c *Configuration) RequiredRuntimesPaths() paths.PathList {
 			}
 		}
 		if !found {
-			slog.Debug("required unit not found on host", "unit", unit)
+			slog.Debug("required runtime not found on host", "runtime", runtime)
 		}
 	}
 	return result

--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -26,6 +26,7 @@ type Configuration struct {
 	appsDir                          *paths.Path
 	dataDir                          *paths.Path
 	routerSocketPath                 *paths.Path
+	requiredUnits                    []string
 	customModelsDir                  *paths.Path
 	modelsDir                        *paths.Path
 	dockerRegistryBase               string
@@ -61,9 +62,22 @@ func NewFromEnv() (Configuration, error) {
 		dataDir = paths.New("/var/lib/arduino-app-cli")
 	}
 
+	// FIXME: this should be removed at some point, when the router expose the new socket /run/arduino-router/arduno-router.sock
 	routerSocket := paths.New(os.Getenv("ARDUINO_ROUTER_SOCKET"))
 	if routerSocket == nil || routerSocket.NotExist() {
 		routerSocket = paths.New("/var/run/arduino-router.sock")
+	}
+
+	// Required host units bind-mounted as /run/<unit> into app containers.
+	requiredUnitsEnv, ok := os.LookupEnv("ARDUINO_APP_CLI__REQUIRED_UNITS")
+	if !ok {
+		requiredUnitsEnv = "arduino-router,arduino-app-cloud"
+	}
+	var requiredUnits []string
+	for u := range strings.SplitSeq(requiredUnitsEnv, ",") {
+		if u = strings.TrimSpace(u); u != "" {
+			requiredUnits = append(requiredUnits, u)
+		}
 	}
 
 	// Directory where all AI models are installed.
@@ -127,6 +141,7 @@ func NewFromEnv() (Configuration, error) {
 		appsDir:                          appsDir,
 		dataDir:                          dataDir,
 		routerSocketPath:                 routerSocket,
+		requiredUnits:                    requiredUnits,
 		customModelsDir:                  customModelsDir,
 		modelsDir:                        modelsDir,
 		dockerRegistryBase:               registryBase,
@@ -174,6 +189,20 @@ func (c *Configuration) ExamplesDir() *paths.Path {
 
 func (c *Configuration) RouterSocketPath() *paths.Path {
 	return c.routerSocketPath
+}
+
+// RequiredUnitsRuntimeDir returns existing /run/<unit> dirs for configured required units.
+func (c *Configuration) RequiredUnitsRuntimeDir() paths.PathList {
+	var requiredUnits paths.PathList
+	for _, unit := range c.requiredUnits {
+		unitRuntimeDir := paths.New("/run").Join(unit)
+		if unitRuntimeDir.Exist() {
+			requiredUnits.AddIfMissing(unitRuntimeDir)
+		} else {
+			slog.Debug("required unit runtime directory does not exist", "unit", unit, "path", unitRuntimeDir.String())
+		}
+	}
+	return requiredUnits
 }
 
 func (c *Configuration) AssetsDir() *paths.Path {

--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -179,10 +179,10 @@ func (c *Configuration) ExamplesDir() *paths.Path {
 	return c.dataDir.Join("examples")
 }
 
-// RequiredUnitsPaths returns the discovered host paths for configured required
+// RequiredRuntimesPaths returns the discovered host paths for configured required
 // units, searching in order: /run/<unit>, /var/run/<unit>, /run/<unit>.sock,
 // /var/run/<unit>.sock. The first existing entry per unit is returned.
-func (c *Configuration) RequiredUnitsPaths() paths.PathList {
+func (c *Configuration) RequiredRuntimesPaths() paths.PathList {
 	var result paths.PathList
 	for _, unit := range c.requiredRuntimes {
 		candidates := []*paths.Path{

--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -339,11 +339,11 @@ func generateMainComposeFile(
 		},
 	}
 
-	for _, unitPath := range cfg.RequiredUnitsPaths() {
+	for _, p := range cfg.RequiredRuntimesPaths() {
 		volumes = append(volumes, volume{
 			Type:   "bind",
-			Source: unitPath.String(),
-			Target: unitPath.String(),
+			Source: p.String(),
+			Target: p.String(),
 		})
 	}
 

--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -338,20 +338,12 @@ func generateMainComposeFile(
 			ReadOnly: true,
 		},
 	}
-	slog.Debug("Adding UNIX socket", slog.Any("sock", cfg.RouterSocketPath().String()), slog.Bool("exists", cfg.RouterSocketPath().Exist()))
-	if cfg.RouterSocketPath().Exist() {
-		volumes = append(volumes, volume{
-			Type:   "bind",
-			Source: cfg.RouterSocketPath().String(),
-			Target: "/var/run/arduino-router.sock",
-		})
-	}
 
-	for _, unitDir := range cfg.RequiredUnitsRuntimeDir() {
+	for _, unitPath := range cfg.RequiredUnitsPaths() {
 		volumes = append(volumes, volume{
 			Type:   "bind",
-			Source: unitDir.String(),
-			Target: unitDir.String(),
+			Source: unitPath.String(),
+			Target: unitPath.String(),
 		})
 	}
 

--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -347,6 +347,14 @@ func generateMainComposeFile(
 		})
 	}
 
+	for _, unitDir := range cfg.RequiredUnitsRuntimeDir() {
+		volumes = append(volumes, volume{
+			Type:   "bind",
+			Source: unitDir.String(),
+			Target: unitDir.String(),
+		})
+	}
+
 	volumes = addLedControl(platform, volumes)
 	groups := lookupGroups("video", "audio", "render", "dialout")
 	// Support for NPU


### PR DESCRIPTION
### Motivation

We should have a general way to specify external service dependencies required by apps.

### Change description

With the new `ARDUINO_APP_CLI__REQUIRED_UNITS` we can specify a list of service, and the app-cli will auto-discover run folder either in `/run` or `/var/run`

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [x] PR addresses a single concern.
- [x] PR title and description are properly filled.
- [x] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
