### PR TITLE
fix: some service images were not downloaded

### DIFF
--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -242,7 +242,13 @@ func isTemporaryDockerError(err error) bool {
 }
 
 // List of prefixes used to identify current or past Arduino images. Used both during 'system init' and during cleanup.
-var imagePrefixes = []string{"ghcr.io/bcmi-labs/", "public.ecr.aws/arduino/", "ghcr.io/arduino/", "influxdb"}
+var imagePrefixes = []string{
+	"ghcr.io/bcmi-labs/",
+	"public.ecr.aws/arduino/",
+	"ghcr.io/arduino/",
+	"influxdb",
+	"artifacts.codelinaro.org/iot-solutions-microservices/",
+}
 
 // Lists all the local docker images that could have been, or are downloaded by Arduino.
 // This is used both to avoid pulling already existing images and cleaning up unused old Arduino images.
@@ -255,10 +261,10 @@ func listImagesAlreadyPulled(ctx context.Context, docker dockerClient.APIClient)
 	result := make([]string, 0, len(images))
 	for _, image := range images {
 		for _, tag := range image.RepoTags {
-			for _, prefix := range imagePrefixes {
-				if strings.HasPrefix(tag, prefix) {
-					result = append(result, tag)
-				}
+			if slices.ContainsFunc(imagePrefixes, func(p string) bool {
+				return strings.HasPrefix(tag, p)
+			}) {
+				result = append(result, tag)
 			}
 		}
 	}
@@ -269,15 +275,13 @@ func listImagesAlreadyPulled(ctx context.Context, docker dockerClient.APIClient)
 func getAllSupportedBrickImages(bricksIndex *bricksindex.BricksIndex, servicesIndex *servicesindex.ServicesIndex) ([]string, error) {
 	var result []string
 	for _, brick := range bricksIndex.ListBricks() {
-		composeFile, ok := brick.GetComposeFile()
-		if !ok {
-			continue
+		if composeFile, ok := brick.GetComposeFile(); ok {
+			images, err := extractImagesFromCompose(composeFile)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, images...)
 		}
-		images, err := extractImagesFromCompose(composeFile)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, images...)
 
 		for _, r := range brick.RequiresServices {
 			service, ok := servicesIndex.FindServiceByID(r.ID)
@@ -317,10 +321,12 @@ func extractImagesFromCompose(composeFile *paths.Path) ([]string, error) {
 		return nil, err
 	}
 	for _, v := range prj.Services {
-		for _, prefix := range imagePrefixes {
-			if strings.HasPrefix(v.Image, prefix) {
-				result = append(result, v.Image)
-			}
+		if slices.ContainsFunc(imagePrefixes, func(p string) bool {
+			return strings.HasPrefix(v.Image, p)
+		}) {
+			result = append(result, v.Image)
+		} else {
+			slog.Warn("skipping image that does not match known prefixes", "image", v.Image, "prefixes", imagePrefixes)
 		}
 	}
 	return result, nil
@@ -370,17 +376,22 @@ func SystemCleanup(ctx context.Context, cfg config.Configuration, bricksindex *b
 	}
 
 	// Remove unused images
-	containersMustStay, err := getRequiredImages(cfg, bricksindex, servicesindex, modelsIndex)
+	imagesMustStay, err := getRequiredImages(cfg, bricksindex, servicesindex, modelsIndex)
 	if err != nil {
 		return result, err
 	}
+	slog.Debug("images that must stay", "imagesMustStay", imagesMustStay)
+
 	allImages, err := listImagesAlreadyPulled(ctx, docker.Client())
 	if err != nil {
 		return result, err
 	}
+	slog.Debug("all images already pulled", "allImages", allImages)
+
 	imagesToRemove := slices.DeleteFunc(allImages, func(v string) bool {
-		return slices.Contains(containersMustStay, v)
+		return slices.Contains(imagesMustStay, v)
 	})
+	slog.Info("images to remove", "imagesToRemove", imagesToRemove)
 
 	for _, image := range imagesToRemove {
 		imageSize, err := removeImage(ctx, docker.Client(), image)

--- a/internal/orchestrator/system_test.go
+++ b/internal/orchestrator/system_test.go
@@ -16,6 +16,9 @@ import (
 	dockerClient "github.com/docker/docker/client"
 	"github.com/stretchr/testify/require"
 	"go.bug.st/f"
+
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 )
 
 func TestListImagesAlreadyPulled(t *testing.T) {
@@ -115,6 +118,68 @@ func TestExtractImagesFromCompose(t *testing.T) {
 				require.NoError(t, err)
 				require.ElementsMatch(t, tt.expectedImages, got)
 			}
+		})
+	}
+}
+
+func TestGetAllSupportedBrickImages(t *testing.T) {
+	genieComposePath := paths.New("testdata", "composes", "service_compose_genie.yaml")
+	brickComposePath := paths.New("testdata", "composes", "service_compose_valid.yaml")
+
+	services := &servicesindex.ServicesIndex{
+		Services: []servicesindex.Service{
+			{ServiceID: "arduino:genie", ComposeFile: genieComposePath},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		builtIn        []bricksindex.Brick
+		expectedImages []string
+	}{
+		{
+			name: "brick without compose but with requires_services pulls service image",
+			builtIn: []bricksindex.Brick{
+				{
+					ID:               "arduino:vlm",
+					RequiresServices: bricksindex.RequiresServices{{ID: "arduino:genie"}},
+				},
+			},
+			expectedImages: []string{"ghcr.io/arduino/app-bricks/genie-service:1.0.0"},
+		},
+		{
+			name: "brick with compose and no requires_services",
+			builtIn: []bricksindex.Brick{
+				{ID: "arduino:runner", ComposeFile: brickComposePath},
+			},
+			expectedImages: []string{"ghcr.io/arduino/app-bricks/ollama-models-runner:dev-next"},
+		},
+		{
+			name: "brick with compose and requires_services returns both images deduped",
+			builtIn: []bricksindex.Brick{
+				{
+					ID:               "arduino:runner",
+					ComposeFile:      brickComposePath,
+					RequiresServices: bricksindex.RequiresServices{{ID: "arduino:genie"}},
+				},
+				{
+					ID:               "arduino:vlm",
+					RequiresServices: bricksindex.RequiresServices{{ID: "arduino:genie"}},
+				},
+			},
+			expectedImages: []string{
+				"ghcr.io/arduino/app-bricks/ollama-models-runner:dev-next",
+				"ghcr.io/arduino/app-bricks/genie-service:1.0.0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bIndex := &bricksindex.BricksIndex{BuiltInBricks: tt.builtIn}
+			got, err := getAllSupportedBrickImages(bIndex, services)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.expectedImages, got)
 		})
 	}
 }

--- a/internal/orchestrator/testdata/composes/service_compose_genie.yaml
+++ b/internal/orchestrator/testdata/composes/service_compose_genie.yaml
@@ -1,0 +1,3 @@
+services:
+  genie:
+    image: ghcr.io/arduino/app-bricks/genie-service:1.0.0


### PR DESCRIPTION
### Motivation

The  system init  command was failing to download some brick service Docker images. There were two issues:

1.  imagePrefixes  was missing some newly added image prefixes.
2. Services required by bricks without a Compose file were never resolved, so their images were skipped.

### Change description

- update the `imagesPrefixex` with codelinaro images
- fix the above-mentioned bug
- added a test for future regression

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
