### PR TITLE
fix: expose only ExampleDirs

### DIFF
--- a/internal/orchestrator/app/app.go
+++ b/internal/orchestrator/app/app.go
@@ -20,8 +20,6 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/fatomic"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/platform"
 )
 
 const maxDescriptionLength = 150
@@ -333,25 +331,4 @@ func load(brickPath *paths.Path) (b bricksindex.Brick, err error) {
 	brick.ExamplesPath = brickPath.Join("examples")
 	brick.DocsAPIPath = brickPath.Join("docs/API.md")
 	return brick, nil
-}
-
-func FindExampleByName(platform platform.Platform, cfg config.Configuration, name string) (*paths.Path, error) {
-	platformExample := cfg.ExamplesDir().Join(fmt.Sprintf("platform_%s", platform.BoardName), name)
-	if platformExample.Exist() {
-		return platformExample, nil
-	}
-	return cfg.ExamplesDir().Join("common", name), nil
-}
-
-func ExampleNameFromPath(platform platform.Platform, cfg config.Configuration, path *paths.Path) (string, error) {
-	for _, root := range []*paths.Path{
-		cfg.ExamplesDir().Join("common"),
-		cfg.ExamplesDir().Join(fmt.Sprintf("platform_%s", platform.BoardName)),
-	} {
-		rel, err := path.RelFrom(root)
-		if err == nil && !strings.HasPrefix(rel.String(), "..") && rel.String() != "." {
-			return rel.String(), nil
-		}
-	}
-	return "", fmt.Errorf("path %q is not a valid example location", path)
 }

--- a/internal/orchestrator/app/id.go
+++ b/internal/orchestrator/app/id.go
@@ -85,23 +85,29 @@ func (p *IDProvider) IDFromPath(path *paths.Path) (ID, error) {
 		isFromKnownLocation bool
 		isExample           bool
 	)
-	switch {
-	case strings.HasPrefix(path.String(), p.cfg.AppsDir().String()):
+	if strings.HasPrefix(path.String(), p.cfg.AppsDir().String()) {
 		rel, err := path.RelFrom(p.cfg.AppsDir())
 		if err != nil {
 			return ID{}, ErrInvalidID
 		}
 		id = "user:" + rel.String()
 		isFromKnownLocation = true
-	case strings.HasPrefix(path.String(), p.cfg.ExamplesDir().String()):
-		name, err := ExampleNameFromPath(p.plat, p.cfg, path)
-		if err != nil {
-			return ID{}, ErrInvalidID
+	} else {
+		for _, example := range p.cfg.ExamplesDirs(p.plat) {
+			if strings.HasPrefix(path.String(), example.String()) {
+				rel, err := path.RelFrom(example)
+				if err != nil {
+					return ID{}, ErrInvalidID
+				}
+				id = "examples:" + rel.String()
+				isFromKnownLocation = true
+				isExample = true
+				break
+			}
 		}
-		id = "examples:" + name
-		isFromKnownLocation = true
-		isExample = true
-	default:
+	}
+
+	if id == "" {
 		id = path.String()
 	}
 
@@ -129,15 +135,22 @@ func (p *IDProvider) parseID(id string) (ID, error) {
 		case "user":
 			path = p.cfg.AppsDir().Join(appPath)
 		case "examples":
-			var err error
-			path, err = FindExampleByName(p.plat, p.cfg, appPath)
-			if err != nil {
-				return ID{}, ErrInvalidID
+			for _, examplePath := range p.cfg.ExamplesDirs(p.plat) {
+				examplePath = examplePath.Join(appPath)
+				if examplePath.Exist() {
+					path = examplePath
+					isExample = true
+					break
+				}
 			}
-			isExample = true
 		default:
 			return ID{}, ErrInvalidID
 		}
+
+		if path == nil {
+			return ID{}, ErrInvalidID
+		}
+
 		return ID{
 			path:                 path,
 			encodedID:            base64.RawURLEncoding.EncodeToString([]byte(id)),

--- a/internal/orchestrator/app/id_test.go
+++ b/internal/orchestrator/app/id_test.go
@@ -26,13 +26,15 @@ func TestNewIDFromPath(t *testing.T) {
 
 	orchestratorConfig, err := config.NewFromEnv()
 	require.NoError(t, err)
+	examplesBoardDir := orchestratorConfig.DataDir().Join("examples", "platform_unoq")
+	examplesCommonDir := orchestratorConfig.DataDir().Join("examples", "common")
 	require.NoError(t, orchestratorConfig.AppsDir().Join("user-app").MkdirAll())
-	require.NoError(t, orchestratorConfig.ExamplesDir().Join("common").Join("example-app").MkdirAll())
-	require.NoError(t, orchestratorConfig.ExamplesDir().Join("platform_unoq").Join("special-example-app").MkdirAll())
-	require.NoError(t, orchestratorConfig.ExamplesDir().Join("common").Join("duplicated-example-app").MkdirAll())
-	require.NoError(t, orchestratorConfig.ExamplesDir().Join("platform_unoq").Join("duplicated-example-app").MkdirAll())
-	require.NoError(t, orchestratorConfig.ExamplesDir().Join("common").Join("nested", "deep", "example-app").MkdirAll())
-	require.NoError(t, orchestratorConfig.ExamplesDir().Join("platform_unoq").Join("nested", "platform-example").MkdirAll())
+	require.NoError(t, examplesCommonDir.Join("example-app").MkdirAll())
+	require.NoError(t, examplesBoardDir.Join("special-example-app").MkdirAll())
+	require.NoError(t, examplesCommonDir.Join("duplicated-example-app").MkdirAll())
+	require.NoError(t, examplesBoardDir.Join("duplicated-example-app").MkdirAll())
+	require.NoError(t, examplesCommonDir.Join("nested", "deep", "example-app").MkdirAll())
+	require.NoError(t, examplesBoardDir.Join("nested", "platform-example").MkdirAll())
 	require.NoError(t, tmp.Join("other-app").MkdirAll())
 
 	idProvider := NewAppIDProvider(orchestratorConfig, unoQPlatform)
@@ -50,27 +52,27 @@ func TestNewIDFromPath(t *testing.T) {
 		},
 		{
 			name: "valid example id",
-			in:   orchestratorConfig.ExamplesDir().Join("common").Join("example-app"),
+			in:   examplesCommonDir.Join("example-app"),
 			want: f.Must(idProvider.ParseID("examples:example-app")),
 		},
 		{
 			name: "duplicated example id, the platform specific wins",
-			in:   orchestratorConfig.ExamplesDir().Join("platform_unoq").Join("duplicated-example-app"),
+			in:   examplesBoardDir.Join("duplicated-example-app"),
 			want: f.Must(idProvider.ParseID("examples:duplicated-example-app")),
 		},
 		{
 			name: "platform specific valid example id",
-			in:   orchestratorConfig.ExamplesDir().Join("platform_unoq").Join("special-example-app"),
+			in:   examplesBoardDir.Join("special-example-app"),
 			want: f.Must(idProvider.ParseID("examples:special-example-app")),
 		},
 		{
 			name: "nested common example id",
-			in:   orchestratorConfig.ExamplesDir().Join("common").Join("nested", "deep", "example-app"),
+			in:   examplesCommonDir.Join("nested", "deep", "example-app"),
 			want: f.Must(idProvider.ParseID("examples:nested/deep/example-app")),
 		},
 		{
 			name: "nested platform example id",
-			in:   orchestratorConfig.ExamplesDir().Join("platform_unoq").Join("nested", "platform-example"),
+			in:   examplesBoardDir.Join("nested", "platform-example"),
 			want: f.Must(idProvider.ParseID("examples:nested/platform-example")),
 		},
 
@@ -102,8 +104,11 @@ func TestParseID(t *testing.T) {
 	orchestratorConfig, err := config.NewFromEnv()
 	require.NoError(t, err)
 	require.NoError(t, tmp.Join("other-app").MkdirAll())
-	require.NoError(t, orchestratorConfig.ExamplesDir().Join("common").Join("nested", "deep", "example-app").MkdirAll())
-	require.NoError(t, orchestratorConfig.ExamplesDir().Join("platform_unoq").Join("nested", "platform-example").MkdirAll())
+	examplesBoardDir := orchestratorConfig.DataDir().Join("examples", "platform_unoq")
+	examplesCommonDir := orchestratorConfig.DataDir().Join("examples", "common")
+	require.NoError(t, examplesCommonDir.Join("example-app").MkdirAll())
+	require.NoError(t, examplesCommonDir.Join("nested", "deep", "example-app").MkdirAll())
+	require.NoError(t, examplesBoardDir.Join("nested", "platform-example").MkdirAll())
 
 	idProvider := NewAppIDProvider(orchestratorConfig, unoQPlatform)
 
@@ -121,17 +126,17 @@ func TestParseID(t *testing.T) {
 		{
 			name:     "valid example id",
 			in:       "examples:example-app",
-			wantPath: orchestratorConfig.ExamplesDir().Join("common", "example-app"),
+			wantPath: examplesCommonDir.Join("example-app"),
 		},
 		{
 			name:     "nested common example id",
 			in:       "examples:nested/deep/example-app",
-			wantPath: orchestratorConfig.ExamplesDir().Join("common", "nested", "deep", "example-app"),
+			wantPath: examplesCommonDir.Join("nested", "deep", "example-app"),
 		},
 		{
 			name:     "nested platform example id wins over common",
 			in:       "examples:nested/platform-example",
-			wantPath: orchestratorConfig.ExamplesDir().Join("platform_unoq", "nested", "platform-example"),
+			wantPath: examplesBoardDir.Join("nested", "platform-example"),
 		},
 		{
 			name:     "absolute path to app",

--- a/internal/orchestrator/bricks/bricks.go
+++ b/internal/orchestrator/bricks/bricks.go
@@ -261,7 +261,7 @@ func getBrickConfigVariableDetails(
 
 func getUsedByApps(cfg config.Configuration, brickId string, idProvider *app.IDProvider, platform platform.Platform) ([]AppReference, error) {
 	pathsToExplore := paths.NewPathList()
-	pathsToExplore.AddAll(cfg.ExamplesByBoard(platform))
+	pathsToExplore.AddAll(cfg.ExamplesDirs(platform))
 	pathsToExplore.Add(cfg.AppsDir())
 	appPaths, err := app.FindAppsInFolders(pathsToExplore)
 	if err != nil {

--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -150,7 +150,7 @@ func (c *Configuration) init() error {
 	if err := c.AppsDir().MkdirAll(); err != nil {
 		return err
 	}
-	if err := c.ExamplesDir().Join("common").MkdirAll(); err != nil {
+	if err := c.examplesDir().Join("common").MkdirAll(); err != nil {
 		return err
 	}
 	if err := c.AssetsDir().MkdirAll(); err != nil {
@@ -170,8 +170,16 @@ func (c *Configuration) DataDir() *paths.Path {
 	return c.dataDir
 }
 
-func (c *Configuration) ExamplesDir() *paths.Path {
+func (c *Configuration) examplesDir() *paths.Path {
 	return c.dataDir.Join("examples")
+}
+
+func (c *Configuration) ExamplesDirs(platform platform.Platform) paths.PathList {
+	boardExampleDir := c.examplesDir().Join(fmt.Sprintf("platform_%s", platform.BoardName))
+	if boardExampleDir.Exist() {
+		return paths.PathList{boardExampleDir, c.examplesDir().Join("common")}
+	}
+	return paths.PathList{c.examplesDir().Join("common")}
 }
 
 func (c *Configuration) RouterSocketPath() *paths.Path {
@@ -214,13 +222,4 @@ func getPythonImageAndTag(registryBase string) (string, string) {
 		usedPythonImageTag = pythonImage[idx+1:]
 	}
 	return pythonImage, usedPythonImageTag
-}
-
-func (c *Configuration) ExamplesByBoard(platform platform.Platform) paths.PathList {
-	result := paths.PathList{c.ExamplesDir().Join("common")}
-	boardExampleDir := c.ExamplesDir().Join(fmt.Sprintf("platform_%s", platform.BoardName))
-	if boardExampleDir.Exist() {
-		result.Add(boardExampleDir)
-	}
-	return result
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -494,7 +494,7 @@ func ListApps(
 	var pathsToExplore paths.PathList
 	var appPaths paths.PathList
 	if req.ShowExamples || req.ShowOnlyDefault {
-		pathsToExplore.AddAll(cfg.ExamplesByBoard(platform))
+		pathsToExplore.AddAll(cfg.ExamplesDirs(platform))
 	}
 	if req.ShowApps || req.ShowOnlyDefault {
 		pathsToExplore.Add(cfg.AppsDir())
@@ -1224,9 +1224,10 @@ type ConfigDirectories struct {
 func GetOrchestratorConfig(cfg config.Configuration) ConfigResponse {
 	return ConfigResponse{
 		Directories: ConfigDirectories{
-			Data:     cfg.DataDir().String(),
-			Apps:     cfg.AppsDir().String(),
-			Examples: cfg.ExamplesDir().String(),
+			Data: cfg.DataDir().String(),
+			Apps: cfg.AppsDir().String(),
+			// FIXME: ExamplesDir() is not the right directory, we should return the examples by board directory.
+			// Examples: cfg.ExamplesDir().String(),
 		},
 		PythonRunner: cfg.RunnerVersion,
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -548,7 +548,7 @@ func createApp(
 	require.NoError(t, err)
 	require.Empty(t, gCmp.Diff(f.Must(idProvider.ParseID("user:"+name)), res.ID))
 	if isExample {
-		newPath := cfg.ExamplesDir().Join("common").Join(name)
+		newPath := cfg.ExamplesDirs(platform.Platform{})[0].Join(name)
 		err = os.Rename(res.ID.ToPath().String(), newPath.String())
 		require.NoError(t, err)
 		newID, err := idProvider.IDFromPath(newPath)

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -580,7 +580,7 @@ func downloadLibsAndPlatformsUsedInExamples(ctx context.Context, cfg config.Conf
 	}
 
 	// Get a list of example apps
-	pathsToExplore := cfg.ExamplesByBoard(platform)
+	pathsToExplore := cfg.ExamplesDirs(platform)
 	exampleAppsPath, err := app.FindAppsInFolders(pathsToExplore)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Motivation

Expose only `ExamplesDirs` in cfg and remove `common` and `platform_%s` references in the other parts of the code.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
