### PR TITLE
Update event inconsistency

### DIFF
--- a/cmd/gendoc/docs.go
+++ b/cmd/gendoc/docs.go
@@ -1030,6 +1030,9 @@ Contains a JSON object with the details of an error.
 				ContentType:   "text/event-stream",
 				DataStructure: "",
 				Description: `A stream of Server-Sent Events (SSE) that notifies the progress of the update process.
+The 'done' event is the only terminal event: an 'error' reports a step that failed but does
+not end the operation, so the client should collect the errors received during the stream and
+present a final summary once 'done' arrives.
 The client will receive events formatted as follows:
 
 **Event 'log'**:
@@ -1054,9 +1057,16 @@ Contains a string with the message that the upgrade is completed and the system 
 'data: Upgrade completed. Restarting'
 
 **Event 'error'**:
-Contains a JSON object with the details of an error.
+Contains a JSON object with the details of a step that failed. It does not end the operation:
+the upgrade continues and 'done' is emitted anyway.
 'event: error'
 'data: {"code":"internal_service_err","message":"An error occurred during operation"}'
+
+**Event 'done'**:
+Contains a string with the message that the update process is complete. It is always emitted
+last, whether or not 'error' events were received.
+'event: done'
+'data: Update completed'
 `,
 			},
 			PossibleErrors: []ErrorResponse{

--- a/cmd/gendoc/docs.go
+++ b/cmd/gendoc/docs.go
@@ -1030,7 +1030,7 @@ Contains a JSON object with the details of an error.
 				ContentType:   "text/event-stream",
 				DataStructure: "",
 				Description: `A stream of Server-Sent Events (SSE) that notifies the progress of the update process.
-The 'done' event is the only terminal event: an 'error' reports a step that failed but does
+The 'done' and 'restarting' events are the only terminal event: an 'error' reports a step that failed but does
 not end the operation, so the client should collect the errors received during the stream and
 present a final summary once 'done' arrives.
 The client will receive events formatted as follows:
@@ -1063,8 +1063,8 @@ the upgrade continues and 'done' is emitted anyway.
 'data: {"code":"internal_service_err","message":"An error occurred during operation"}'
 
 **Event 'done'**:
-Contains a string with the message that the update process is complete. It is always emitted
-last, whether or not 'error' events were received.
+Contains a string with the message that the update process is complete. It is emitted last,
+also when 'error' events were received. 
 'event: done'
 'data: Update completed'
 `,

--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -1335,6 +1335,9 @@ paths:
                 type: string
           description: |
             A stream of Server-Sent Events (SSE) that notifies the progress of the update process.
+            The 'done' event is the only terminal event: an 'error' reports a step that failed but does
+            not end the operation, so the client should collect the errors received during the stream and
+            present a final summary once 'done' arrives.
             The client will receive events formatted as follows:
 
             **Event 'log'**:
@@ -1359,9 +1362,16 @@ paths:
             'data: Upgrade completed. Restarting'
 
             **Event 'error'**:
-            Contains a JSON object with the details of an error.
+            Contains a JSON object with the details of a step that failed. It does not end the operation:
+            the upgrade continues and 'done' is emitted anyway.
             'event: error'
             'data: {"code":"internal_service_err","message":"An error occurred during operation"}'
+
+            **Event 'done'**:
+            Contains a string with the message that the update process is complete. It is always emitted
+            last, whether or not 'error' events were received.
+            'event: done'
+            'data: Update completed'
         "500":
           $ref: '#/components/responses/InternalServerError'
       summary: SSE stream of the update process

--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -1368,8 +1368,10 @@ paths:
             'data: {"code":"internal_service_err","message":"An error occurred during operation"}'
 
             **Event 'done'**:
-            Contains a string with the message that the update process is complete. It is always emitted
-            last, whether or not 'error' events were received.
+            Contains a string with the message that the update process is complete. It is emitted last,
+            also when 'error' events were received. Note that if the upgrade restarts arduino-app-cli
+            itself, the stream can end before 'done' is delivered: clients should treat the stream
+            closing as an end condition too.
             'event: done'
             'data: Update completed'
         "500":

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -163,7 +163,9 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 			}
 		}); err != nil {
 			m.broadcast(NewErrorEvent(fmt.Errorf("failed to upgrade APT packages: %w", err)))
-			return
+
+			// continue: errors are reported to the subscribers but do not end the
+			// operation, DoneEvent is always broadcast as the only terminal event.
 		}
 
 		m.broadcast(NewProgressEvent("upgrade", 100.0))

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -189,7 +189,7 @@ func TestManagerUpgradePackages(t *testing.T) {
 		packages   []UpgradablePackage
 		svc1Err    error
 		svc2Err    error
-		expectEvts []EventType // expected last event type from broadcast
+		expectEvts []EventType // expected event sequence from broadcast
 	}{
 		{
 			name:       "both services upgrade successfully",
@@ -206,8 +206,15 @@ func TestManagerUpgradePackages(t *testing.T) {
 			name:     "deb service fails",
 			packages: []UpgradablePackage{{Type: Debian, Name: "pkg1", ToVersion: "1.1"}},
 			svc2Err:  errors.New("deb upgrade failed"),
-			// FIXME: we should alwas return Done?
-			expectEvts: []EventType{ErrorEvent},
+			// The error does not interrupt the sequence: done is still the last event.
+			expectEvts: []EventType{ErrorEvent, ProgressEvent, DoneEvent},
+		},
+		{
+			name:       "both services fail",
+			packages:   []UpgradablePackage{{Type: Arduino, Name: "arduino:zephyr", ToVersion: "2.0"}, {Type: Debian, Name: "pkg1", ToVersion: "1.1"}},
+			svc1Err:    errors.New("arduino upgrade failed"),
+			svc2Err:    errors.New("deb upgrade failed"),
+			expectEvts: []EventType{ErrorEvent, ErrorEvent, ProgressEvent, DoneEvent},
 		},
 	}
 
@@ -231,7 +238,7 @@ func TestManagerUpgradePackages(t *testing.T) {
 			err := m.UpgradePackages(context.Background(), tc.packages)
 			require.NoError(t, err, "unexpected error starting upgrade")
 
-			// Collect the last event
+			// Collect the events until the terminal done event (or timeout).
 			timeout := time.After(1 * time.Second)
 			var events []EventType
 		loop:


### PR DESCRIPTION
### Motivation

closes #382
When the apt upgrade failed, the stream stopped after the `error` event without
emitting any terminal event, so clients had no reliable way to know the
operation had ended.

### Change description

- `error` events no longer end the operation
- `done` is the terminal event, always emitted last, also after errors
- If the upgrade restarts `arduino-app-cli` itself, the stream can be cut before
`done` is delivered. in this case, `restart` is the last event
- SSE documentation and tests updated

### Additional Notes


### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
