### PR TITLE
fix: change log level to debug for platform config usage

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -84,7 +84,7 @@ func GetPlatform(dir *paths.Path) Platform {
 		}
 	}
 
-	slog.Info("using platform config", "platform", platform)
+	slog.Debug("using platform config", "platform", platform)
 	return platform
 }
 


### PR DESCRIPTION
### Motivation
The log was printed  in any cli command

```
arduino@dido4g:/var/lib/arduino-app-cli/examples$ arduino-app-cli app list
2026/07/06 15:47:46 INFO using platform config platform="{BoardName:unoq FQBN:arduino:zephyr:unoq PlatformID:arduino:zephyr CompileJobs:2 Linux:{BoardLeds:[/sys/class/leds/blue:user /sys/class/leds/green:user /sys/class/leds/red:user /sys/class/leds/blue:bt /sys/class/leds/green:wlan /sys/class/leds/red:panic]} Micro:{ResetPin:{Chip:gpiochip1 Number:38}}}"
ID                                             NAME                                ICON STATUS        EXAMPLE
examples:color-your-leds                       Color your LEDs                     🎨   stopped       true
examples:edge-ai-assistant                     Edge AI Assistant                   💬   uninitialized true
examples:unoq-pin-toggle                       UNO Q Pin Toggle                    📌   uninitialized true
```
json
```
$ arduino-app-cli app list --format=json
2026/07/06 15:48:49 INFO using platform config platform="{BoardName:unoq FQBN:arduino:zephyr:unoq PlatformID:arduino:zephyr CompileJobs:2 Linux:{BoardLeds:[/sys/class/leds/blue:user /sys/class/leds/green:user /sys/class/leds/red:user /sys/class/leds/blue:bt /sys/class/leds/green:wlan /sys/class/leds/red:panic]} Micro:{ResetPin:{Chip:gpiochip1 Number:38}}}"
{
  "apps": [
    {
      "id": "ZXhhbXBsZXM6Y29sb3IteW91ci1sZWRz",
      "name": "Color your LEDs",
      "description": "Control the color of your LEDs from a web interface.",
      "icon": "🎨",
      "status": "stopped",
      "example": true,
      "default": false
    },
```

### Change description

move to debug

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
