### PR TITLE
fix: prevent slog logs before setting level

### DIFF
--- a/cmd/arduino-app-cli/app/destroy.go
+++ b/cmd/arduino-app-cli/app/destroy.go
@@ -36,7 +36,7 @@ func newDestroyCmd(cfg config.Configuration) *cobra.Command {
 		},
 		ValidArgsFunction: completion.ApplicationNamesWithFilterFunc(cfg, func(apps orchestrator.AppInfo) bool {
 			return apps.Status != orchestrator.StatusUninitialized
-		}, servicelocator.GetPlatform()),
+		}),
 	}
 }
 

--- a/cmd/arduino-app-cli/app/export.go
+++ b/cmd/arduino-app-cli/app/export.go
@@ -53,7 +53,7 @@ Use '-' as output_path to write the zip to stdout.`,
 			}
 			return completion.ApplicationNamesWithFilterFunc(cfg, func(apps orchestrator.AppInfo) bool {
 				return !apps.Example
-			}, servicelocator.GetPlatform())(cmd, args, toComplete)
+			})(cmd, args, toComplete)
 		},
 	}
 

--- a/cmd/arduino-app-cli/app/start.go
+++ b/cmd/arduino-app-cli/app/start.go
@@ -40,7 +40,7 @@ func newStartCmd(cfg config.Configuration) *cobra.Command {
 		ValidArgsFunction: completion.ApplicationNamesWithFilterFunc(cfg, func(apps orchestrator.AppInfo) bool {
 			return apps.Status != orchestrator.StatusStarting &&
 				apps.Status != orchestrator.StatusRunning
-		}, servicelocator.GetPlatform()),
+		}),
 	}
 
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")

--- a/cmd/arduino-app-cli/app/stop.go
+++ b/cmd/arduino-app-cli/app/stop.go
@@ -37,7 +37,7 @@ func newStopCmd(cfg config.Configuration) *cobra.Command {
 		ValidArgsFunction: completion.ApplicationNamesWithFilterFunc(cfg, func(apps orchestrator.AppInfo) bool {
 			return apps.Status == orchestrator.StatusStarting ||
 				apps.Status == orchestrator.StatusRunning
-		}, servicelocator.GetPlatform()),
+		}),
 	}
 }
 

--- a/cmd/arduino-app-cli/completion/completion.go
+++ b/cmd/arduino-app-cli/completion/completion.go
@@ -16,7 +16,6 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricks"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/platform"
 )
 
 func NewCompletionCommand() *cobra.Command {
@@ -61,10 +60,10 @@ func NewCompletionCommand() *cobra.Command {
 }
 
 func ApplicationNames(cfg config.Configuration) cobra.CompletionFunc {
-	return ApplicationNamesWithFilterFunc(cfg, func(_ orchestrator.AppInfo) bool { return true }, servicelocator.GetPlatform())
+	return ApplicationNamesWithFilterFunc(cfg, func(_ orchestrator.AppInfo) bool { return true })
 }
 
-func ApplicationNamesWithFilterFunc(cfg config.Configuration, filter func(apps orchestrator.AppInfo) bool, platform platform.Platform) cobra.CompletionFunc {
+func ApplicationNamesWithFilterFunc(cfg config.Configuration, filter func(apps orchestrator.AppInfo) bool) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		apps, err := orchestrator.ListApps(cmd.Context(),
 			servicelocator.GetDockerClient(),
@@ -75,7 +74,8 @@ func ApplicationNamesWithFilterFunc(cfg config.Configuration, filter func(apps o
 			},
 			servicelocator.GetAppIDProvider(),
 			servicelocator.GetBricksIndex(),
-			cfg, platform,
+			cfg,
+			servicelocator.GetPlatform(),
 		)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError


### PR DESCRIPTION
### Motivation

In Cobra, everything needs to be closure to avoid executing code before global configuration are applied, like slog level.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
