### PR TITLE
Change arduino-app-cloud service name to arduino-cloud-connector

### DIFF
--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -66,7 +66,7 @@ func NewFromEnv() (Configuration, error) {
 	// Required host units bind-mounted as /run/<unit> into app containers.
 	requiredRuntimesEnv, ok := os.LookupEnv("ARDUINO_APP_CLI__REQUIRED_RUNTIMES")
 	if !ok {
-		requiredRuntimesEnv = "arduino-router,arduino-app-cloud"
+		requiredRuntimesEnv = "arduino-router,arduino-cloud-connector"
 	}
 	var requiredRuntimes []string
 	for u := range strings.SplitSeq(requiredRuntimesEnv, ",") {


### PR DESCRIPTION
### Motivation
The cloud daemon has been renamed from arduino-app-cloud to arduino-cloud-connector

### Change description
Change the default service name

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
