### PR TITLE
fix: ai icon from brick list is not shown

### DIFF
--- a/internal/orchestrator/bricks/bricks_test.go
+++ b/internal/orchestrator/bricks/bricks_test.go
@@ -379,7 +379,7 @@ bricks:
 - id: arduino:object_detection
   name: Object Detection
   description: Detect objects in images using a pre-trained model
-  require_model: true
+  model_name: yolox-object-detection
   mount_devices_into_container: true
   ports: ["8000"]
   category: video
@@ -562,7 +562,6 @@ func TestAppBrickInstanceModelsDetails(t *testing.T) {
 bricks:
 - id: arduino:object_detection
   name: Object Detection
-  require_model: true
   model_name: yolox-object-detection
   category: video
   variables:
@@ -576,7 +575,6 @@ bricks:
   name: Weather Forecast
   category:  "miscellaneous"
   model_name: ""
-  require_model: false
 `
 	tmpDir := t.TempDir()
 	brickYamlPath := filepath.Join(tmpDir, "bricks-list.yaml")
@@ -720,13 +718,11 @@ func TestAppBrickInstancesList(t *testing.T) {
 - id: arduino:weather_forecast
   name: Weather Forecast
   category: miscellaneous
-  require_model: false
   variables: []
 - id: arduino:object_detection
   name: Object Detection
   category: video
   model_name: yolox-object-detection
-  require_model: true
   variables:
   - name: CUSTOM_MODEL_PATH
     default_value: /home/arduino/.arduino-bricks/models
@@ -738,7 +734,6 @@ func TestAppBrickInstancesList(t *testing.T) {
   name: Audio Classification
   category: audio
   model_name: glass-breaking
-  require_model: true
   variables:
   - name: CUSTOM_MODEL_PATH
     default_value: /home/arduino/.arduino-bricks/models
@@ -747,7 +742,6 @@ func TestAppBrickInstancesList(t *testing.T) {
 - id: arduino:streamlit_ui
   name: WebUI - Streamlit
   category: ui
-  require_model: false
   ports:
   - "7000"
   - "8000"
@@ -763,7 +757,6 @@ func TestAppBrickInstancesList(t *testing.T) {
     default_value: /i/am/visible
     hidden: false
 - id: arduino:brick-with-boards
-  require_model: true
   supported_boards:
   - ventunoq
   model_name: face-detection

--- a/internal/orchestrator/bricks/testdata/bricks-list.yaml
+++ b/internal/orchestrator/bricks/testdata/bricks-list.yaml
@@ -2,7 +2,6 @@ bricks:
 - id: arduino:arduino_cloud
   name: Arduino Cloud
   description: Connects to Arduino Cloud
-  require_model: false
   mount_devices_into_container: false
   ports: []
   category: null
@@ -15,14 +14,12 @@ bricks:
   name: Database - SQL
   description: Simplified database storage layer for Arduino sensor data using SQLite
     local database.
-  require_model: false
   mount_devices_into_container: false
   ports: []
   category: storage
 - id: arduino:brick-with-require-model
   name: A brick with required model
   description: "Brick with required model"
-  require_model: true
   model_name: mobilenet-image-classification
 - id: arduino:brick-with-custom-model
   name: A brick with a custom model

--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -220,7 +220,7 @@ func (b Brick) GetModelNameByBoard(platform platform.Platform) string {
 	return defaultModelName
 }
 
-func (b Brick) isModelRequired(platform platform.Platform) bool {
+func (b Brick) isAiBrick(platform platform.Platform) bool {
 	for _, mb := range b.ModelByBoard {
 		if mb.Platform == platform.BoardName && mb.Model != "" {
 			return true
@@ -295,7 +295,7 @@ func Load(platform platform.Platform, path *paths.Path) (*BricksIndex, error) {
 		yamlIndex.Bricks[i].ReadmeFile = path.Join("docs", namespace, brickName, "README.md")
 		yamlIndex.Bricks[i].ExamplesPath = path.Join("examples", namespace, brickName)
 		yamlIndex.Bricks[i].DocsAPIPath = path.Join("api-docs", namespace, "app_bricks", brickName, "API.md")
-		yamlIndex.Bricks[i].RequireModel = yamlIndex.Bricks[i].isModelRequired(platform)
+		yamlIndex.Bricks[i].RequireModel = yamlIndex.Bricks[i].isAiBrick(platform)
 
 		// Load main compose file and, if present, platform-specific compose files
 		var (

--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -221,15 +221,13 @@ func (b Brick) GetModelNameByBoard(platform platform.Platform) string {
 }
 
 func (b Brick) isModelRequired(platform platform.Platform) bool {
-	if b.ModelName != "" {
-		return true
-	}
 	for _, mb := range b.ModelByBoard {
 		if mb.Platform == platform.BoardName && mb.Model != "" {
 			return true
 		}
 	}
-	return false
+
+	return b.ModelName != ""
 }
 
 type BrickInstance struct {

--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -118,7 +118,6 @@ type Brick struct {
 	RequiresDisplay string   `yaml:"requires_display,omitempty"`
 	// Deprecated : the field `require_container` is deprecated, you can remove it from the brick config. It will be ignored if present.
 	RequireContainer            bool                      `yaml:"require_container"` // Deprecated
-	RequireModel                bool                      `yaml:"require_model"`
 	Variables                   []BrickVariable           `yaml:"variables,omitempty"`
 	Ports                       []string                  `yaml:"ports,omitempty"`
 	ModelName                   string                    `yaml:"model_name,omitempty"`
@@ -135,6 +134,7 @@ type Brick struct {
 	ReadmeFile   *paths.Path `yaml:"-"` // README.md file path, optional
 	ExamplesPath *paths.Path `yaml:"-"` // code examples folder path, optional
 	DocsAPIPath  *paths.Path `yaml:"-"` // API docs file path, optional
+	RequireModel bool        `yaml:"-"`
 
 	containerPorts []string `yaml:"-"` // Ports extracted from the compose file, optional
 }
@@ -220,6 +220,18 @@ func (b Brick) GetModelNameByBoard(platform platform.Platform) string {
 	return defaultModelName
 }
 
+func (b Brick) isModelRequired(platform platform.Platform) bool {
+	if b.ModelName != "" {
+		return true
+	}
+	for _, mb := range b.ModelByBoard {
+		if mb.Platform == platform.BoardName && mb.Model != "" {
+			return true
+		}
+	}
+	return false
+}
+
 type BrickInstance struct {
 	Model string
 }
@@ -285,6 +297,7 @@ func Load(platform platform.Platform, path *paths.Path) (*BricksIndex, error) {
 		yamlIndex.Bricks[i].ReadmeFile = path.Join("docs", namespace, brickName, "README.md")
 		yamlIndex.Bricks[i].ExamplesPath = path.Join("examples", namespace, brickName)
 		yamlIndex.Bricks[i].DocsAPIPath = path.Join("api-docs", namespace, "app_bricks", brickName, "API.md")
+		yamlIndex.Bricks[i].RequireModel = yamlIndex.Bricks[i].isModelRequired(platform)
 
 		// Load main compose file and, if present, platform-specific compose files
 		var (

--- a/internal/orchestrator/bricksindex/bricks_index_test.go
+++ b/internal/orchestrator/bricksindex/bricks_index_test.go
@@ -104,14 +104,17 @@ bricks:
 	require.True(t, found)
 	require.False(t, bNoRequireModel.RequireModel)
 
-	bRequireModelForPlatform, found := index.FindBrickByID("arduino:with-model-by-boards")
+	indexVentuno, err := Load(platform.Platform{BoardName: "ventunoq"}, assetDir)
+	require.NoError(t, err)
+	brickVentuno, found := indexVentuno.FindBrickByID("arduino:with-model-by-boards")
 	require.True(t, found)
-	require.True(t, bRequireModelForPlatform.RequireModel)
+	require.True(t, brickVentuno.RequireModel)
+
 	indexUnoQ, err := Load(platform.Platform{BoardName: "unoq"}, assetDir)
 	require.NoError(t, err)
-	bRequireModelForPlatform, found = indexUnoQ.FindBrickByID("arduino:with-model-by-boards")
+	brickUno, found := indexUnoQ.FindBrickByID("arduino:with-model-by-boards")
 	require.True(t, found)
-	require.False(t, bRequireModelForPlatform.RequireModel)
+	require.False(t, brickUno.RequireModel)
 
 	withHidden, found := index.FindBrickByID("arduino:with-hidden-variables")
 	require.True(t, found)
@@ -208,7 +211,6 @@ func TestBricksIndexYAMLFormats(t *testing.T) {
   name: Complex Brick
   description: A complex test brick
   category: storage
-  require_model: true
   mount_devices_into_container: true
   model_name: a-complex-model
   required_devices:
@@ -230,6 +232,7 @@ func TestBricksIndexYAMLFormats(t *testing.T) {
 					Description:               "A complex test brick",
 					Category:                  "storage",
 					RequiresDisplay:           "",
+					RequireModel:              true,
 					RequiredDevices:           []peripherals.DeviceClass{peripherals.CameraClass},
 					MountDevicesIntoContainer: true,
 					Variables: []BrickVariable{
@@ -312,10 +315,11 @@ func TestBricksIndexYAMLFormats(t *testing.T) {
 `,
 			expectedBricks: []Brick{
 				{
-					ID:          "arduino:brick_with_model_by_boards",
-					Name:        "Brick With Model By Boards",
-					Description: "A brick with model_by_boards",
-					ModelName:   "default-model",
+					ID:           "arduino:brick_with_model_by_boards",
+					Name:         "Brick With Model By Boards",
+					Description:  "A brick with model_by_boards",
+					ModelName:    "default-model",
+					RequireModel: true,
 					ModelByBoard: []ModelsBoard{
 						{Platform: "ventunoq", Model: "ventunoq-model"},
 						{Platform: "portenta", Model: "portenta-model"},

--- a/internal/orchestrator/bricksindex/bricks_index_test.go
+++ b/internal/orchestrator/bricksindex/bricks_index_test.go
@@ -40,11 +40,13 @@ bricks:
     description: description for the first variable
   - name: SECOND_VARIABLE
     description: description for the second variable
-- id: arduino:model_required
-  require_model: true
-- id: arduino:model_required_false
-  require_model: false
-- id: arduino:missing-model-require
+- id: arduino:with-model-name
+  model_name: mobilenet-image-classification
+- id: arduino:with-model-by-boards
+  model_by_boards:
+  - platform: ventunoq
+    model: mobilenet-image-classification
+- id: arduino:missing-model
 - id: arduino:with-hidden-variables
   variables:
     - name: HIDDEN_VARIABLE
@@ -94,17 +96,18 @@ bricks:
 	require.Equal(t, "description for the second variable", bWithVariables.Variables[1].Description)
 	require.True(t, bWithVariables.Variables[1].IsRequired())
 
-	bRequireModel, found := index.FindBrickByID("arduino:model_required")
+	bRequireModel, found := index.FindBrickByID("arduino:with-model-name")
 	require.True(t, found)
 	require.True(t, bRequireModel.RequireModel)
 
-	bDb, found := index.FindBrickByID("arduino:model_required_false")
-	require.True(t, found)
-	require.False(t, bDb.RequireModel)
-
-	bNoRequireModel, found := index.FindBrickByID("arduino:missing-model-require")
+	bNoRequireModel, found := index.FindBrickByID("arduino:missing-model")
 	require.True(t, found)
 	require.False(t, bNoRequireModel.RequireModel)
+
+	bRequireModelForPlatform, found := index.FindBrickByID("arduino:with-model-by-boards")
+	require.True(t, found)
+	require.True(t, bRequireModelForPlatform.RequireModel)
+	require.False(t, bRequireModelForPlatform.RequireModel)
 
 	withHidden, found := index.FindBrickByID("arduino:with-hidden-variables")
 	require.True(t, found)
@@ -186,7 +189,6 @@ func TestBricksIndexYAMLFormats(t *testing.T) {
 					Category:                  "",
 					RequiresDisplay:           "",
 					RequireContainer:          false,
-					RequireModel:              false,
 					RequiredDevices:           nil,
 					Variables:                 nil,
 					Ports:                     nil,
@@ -224,7 +226,6 @@ func TestBricksIndexYAMLFormats(t *testing.T) {
 					Description:               "A complex test brick",
 					Category:                  "storage",
 					RequiresDisplay:           "",
-					RequireModel:              true,
 					RequiredDevices:           []peripherals.DeviceClass{peripherals.CameraClass},
 					MountDevicesIntoContainer: true,
 					Variables: []BrickVariable{

--- a/internal/orchestrator/bricksindex/bricks_index_test.go
+++ b/internal/orchestrator/bricksindex/bricks_index_test.go
@@ -67,7 +67,7 @@ bricks:
 	err := assetDir.Join("bricks-list.yaml").WriteFile([]byte(yamlContent))
 	require.NoError(t, err)
 
-	index, err := Load(platform.GetPlatform(nil), assetDir)
+	index, err := Load(platform.Platform{BoardName: "ventunoq"}, assetDir)
 	require.NoError(t, err)
 
 	brickBasi, found := index.FindBrickByID("arduino:basic")
@@ -107,6 +107,10 @@ bricks:
 	bRequireModelForPlatform, found := index.FindBrickByID("arduino:with-model-by-boards")
 	require.True(t, found)
 	require.True(t, bRequireModelForPlatform.RequireModel)
+	indexUnoQ, err := Load(platform.Platform{BoardName: "unoq"}, assetDir)
+	require.NoError(t, err)
+	bRequireModelForPlatform, found = indexUnoQ.FindBrickByID("arduino:with-model-by-boards")
+	require.True(t, found)
 	require.False(t, bRequireModelForPlatform.RequireModel)
 
 	withHidden, found := index.FindBrickByID("arduino:with-hidden-variables")

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -597,7 +597,6 @@ bricks:
     \ images and returns the predicted class label, bounding-boxes and confidence\
     \ score.\nBrick is designed to work with pre-trained models provided by framework\
     \ or with custom object detection models trained on Edge Impulse platform. \n"
-  require_model: true
   ports: []
   category: video
   model_name: yolox-object-detection
@@ -680,7 +679,6 @@ bricks:
     \ images and returns the predicted class label, bounding-boxes and confidence\
     \ score.\nBrick is designed to work with pre-trained models provided by framework\
     \ or with custom object detection models trained on Edge Impulse platform. \n"
-  require_model: true
   category: video
   model_name: yolox-object-detection
   variables:

--- a/internal/orchestrator/provision_test.go
+++ b/internal/orchestrator/provision_test.go
@@ -68,13 +68,11 @@ bricks:
   name: Database Storage - SQLStore
   description: Simplified database storage layer for Arduino sensor data using SQLite
     local database.
-  require_model: false
   ports: []
   category: storage
 - id: arduino:video_object_detection
   name: Object Detection
   description: "Brick for object detection using a pre-trained model."
-  require_model: true
   mount_devices_into_container: true
   ports: []
   category: video
@@ -316,7 +314,6 @@ bricks:
   name: Database Storage - Time Series Store
   description: Simplified time series database storage layer for Arduino sensor samples
     built on top of InfluxDB.
-  require_model: false
   ports: []
   category: storage
   variables:
@@ -480,7 +477,6 @@ bricks:
   name: Database Storage - Time Series Store
   description: Simplified time series database storage layer for Arduino sensor samples
     built on top of InfluxDB.
-  require_model: false
   ports: []
   category: storage
   variables:
@@ -627,7 +623,6 @@ bricks:
 - id: arduino:video_object_detection
   name: Object Detection
   description: "Brick for object detection using a pre-trained model."
-  require_model: false
   ports: []
   category: video
   requires_services: ["arduino:foo"]`)

--- a/internal/orchestrator/testdata/archive/bricks-list.yaml
+++ b/internal/orchestrator/testdata/archive/bricks-list.yaml
@@ -3,7 +3,6 @@ bricks:
   name: Database - SQL
   description: Simplified database storage layer for Arduino sensor data using SQLite
     local database.
-  require_model: false
   mount_devices_into_container: false
   ports: []
   category: storage
@@ -21,7 +20,6 @@ bricks:
     models trained on the Edge Impulse platform.
 
     '
-  require_model: true
   mount_devices_into_container: true
   ports: []
   category: video
@@ -48,7 +46,6 @@ bricks:
 - id: arduino:arduino_cloud
   name: Arduino Cloud
   description: Connects to Arduino Cloud
-  require_model: false
   mount_devices_into_container: false
   ports: []
   category: null
@@ -63,7 +60,6 @@ bricks:
   name: WebUI - HTML
   description: A user interface based on HTML and JavaScript that can rely on additional
     APIs and a WebSocket exposed by a web server.
-  require_model: false
   mount_devices_into_container: false
   ports:
   - 7000
@@ -73,7 +69,6 @@ bricks:
   name: Cloud LLM
   description: Cloud LLM Brick enables seamless integration with cloud-based Large
     Language Models (LLMs) for advanced AI capabilities in your Arduino projects.
-  require_model: false
   mount_devices_into_container: false
   ports: []
   category: null
@@ -93,11 +88,10 @@ bricks:
     own custom anomaly detections models trained on the Edge Impulse platform.
 
     '
-  require_model: true
+  model_name: fan-anomaly-detection
   mount_devices_into_container: false
   ports: []
   category: null
-  model_name: fan-anomaly-detection
   variables:
   - name: EI_VIBRATION_ANOMALY_DETECTION_MODEL
     default_value: /models/ootb/ei/fan-anomaly-detection.eim
@@ -126,7 +120,6 @@ bricks:
     models trained on the Edge Impulse platform.
 
     '
-  require_model: true
   mount_devices_into_container: true
   ports: []
   category: null
@@ -153,7 +146,6 @@ bricks:
 - id: arduino:streamlit_ui
   name: WebUI - Streamlit
   description: A simplified user interface based on Streamlit and Python.
-  require_model: false
   mount_devices_into_container: false
   ports:
   - 7000
@@ -168,11 +160,10 @@ bricks:
     custom audio classification models trained on Edge Impulse platform.
 
     '
-  require_model: true
+  model_name: keyword-spotting-hey-arduino
   mount_devices_into_container: false
   ports: []
   category: audio
-  model_name: keyword-spotting-hey-arduino
   required_devices:
   - microphone
   variables:
@@ -199,7 +190,6 @@ bricks:
     custom motion classification models trained on the Edge Impulse platform.
 
     '
-  require_model: true
   mount_devices_into_container: false
   ports: []
   category: null
@@ -221,7 +211,6 @@ bricks:
   name: Database - Time Series
   description: Simplified time series database storage layer for Arduino sensor samples
     built on top of InfluxDB.
-  require_model: false
   mount_devices_into_container: false
   ports: []
   category: storage
@@ -246,7 +235,6 @@ bricks:
   name: Weather Forecast
   description: Online weather forecast module for Arduino using open-meteo.com geolocation
     and weather APIs. Requires an internet connection.
-  require_model: false
   mount_devices_into_container: false
   ports: []
   category: miscellaneous
@@ -256,7 +244,6 @@ bricks:
     \ images to identify unusual patterns and returns detected anomalies with bounding\
     \ boxes. \nSupports pre-trained models provided by the framework or custom anomaly\
     \ detection models trained on the Edge Impulse platform. \n"
-  require_model: true
   mount_devices_into_container: false
   ports: []
   category: image
@@ -280,7 +267,6 @@ bricks:
     \ images and returns the predicted class label, bounding-boxes and confidence\
     \ score.\nBrick is designed to work with pre-trained models provided by framework\
     \ or with custom object detection models trained on Edge Impulse platform. \n"
-  require_model: true
   mount_devices_into_container: false
   ports: []
   category: video
@@ -302,7 +288,6 @@ bricks:
   name: Wave Generator
   description: Continuous wave generator for audio synthesis. Generates sine, square,
     sawtooth, and triangle waveforms with smooth frequency and amplitude transitions.
-  require_model: false
   mount_devices_into_container: false
   ports: []
   category: audio
@@ -315,7 +300,6 @@ bricks:
     It classifies text as positive, negative, or neutral.
 
     '
-  require_model: false
   mount_devices_into_container: false
   ports: []
   category: text
@@ -325,7 +309,6 @@ bricks:
     \ images and returns the predicted class label and confidence score.\nBrick is\
     \ designed to work with pre-trained models provided by framework or with custom\
     \ image classification models trained on Edge Impulse platform. \n"
-  require_model: true
   mount_devices_into_container: false
   ports: []
   category: video
@@ -346,7 +329,6 @@ bricks:
 - id: arduino:camera_code_detection
   name: Camera Code Detection
   description: Scans a camera for barcodes and QR codes
-  require_model: false
   mount_devices_into_container: false
   ports: []
   category: video
@@ -361,7 +343,6 @@ bricks:
     custom audio classification models trained on Edge Impulse platform.
 
     '
-  require_model: true
   mount_devices_into_container: false
   ports: []
   category: audio


### PR DESCRIPTION
### Motivation
The following Bricks don't display the "AI" icon:
- Gesture Recognition
- Large Language Model (LLM)
- Object Detection
- Video Object Detection

Expected
 All Bricks with AI models should have the AI icon.

### Change description
The brick is an AiBrick is resolved at runtime by app-cli by looking at the `model_name` and the `model_by_board` filed in the brick list. The `require_model` filed in the yaml is removed.


ai brick: if the "model_name" is not empty or the "model_by_board" is not empty.
Precedence to the `model_name`



### Additional Notes
-- https://github.com/arduino/app-bricks-py/pull/348 

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
