### PR TITLE
fix: compose file parsing in system init

### DIFF
--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -312,10 +312,12 @@ func extractImagesFromCompose(composeFile *paths.Path) ([]string, error) {
 	prj, err := loader.LoadWithContext(
 		context.Background(),
 		types.ConfigDetails{
+			WorkingDir:  composeFile.Parent().String(),
 			ConfigFiles: []types.ConfigFile{{Content: content}},
 			Environment: types.NewMapping(os.Environ()),
 		},
 		func(o *loader.Options) { o.SetProjectName("default", false) },
+		loader.WithSkipValidation, // avoid os.Getwd() in schema validation, which fails when CWD is missing (e.g. during .deb postinst)
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Motivation

Fix for the error while doing the upgrade (which calls system init).
```
failed to download container images used in examples: validating : error in parsing "compose-spec.json": getwd: no such file or directory
```

### Change description

This code was not executed before the PR linked below, so the bug was there but not visible.
The fix is to avoid doing a validation of the compose file while calling `loader.LoadWithContext`. This happens when there is no current working dir set (for example during .deb postinst).

See also the corresponding `loader.LoadWithContext` inside `logs.go`.

### Additional Notes

This bug was triggered by this change:
- https://github.com/arduino/arduino-app-cli/pull/494

