### PR TITLE
fix(models): parse the new downloding event

### DIFF
--- a/internal/dockerhelper/dockerhelper.go
+++ b/internal/dockerhelper/dockerhelper.go
@@ -10,6 +10,7 @@ package dockerhelper
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -132,7 +133,7 @@ func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
 		if status.Error != nil {
 			runErr = fmt.Errorf("container exit error: %s", status.Error.Message)
 		} else if status.StatusCode != 0 {
-			runErr = fmt.Errorf("container exited with status %d", status.StatusCode)
+			runErr = &ExitError{Code: status.StatusCode}
 		}
 	}
 
@@ -140,6 +141,23 @@ func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
 	_ = g.Wait()
 
 	return cmp.Or(ctx.Err(), runErr)
+}
+
+// ExitError is returned by Run when the container exits with a non-zero status.
+// Callers can use errors.AsType to inspect the exit code, or IsExitError for
+// a simple boolean check.
+type ExitError struct {
+	Code int64
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("container exited with status %d", e.Code)
+}
+
+// IsExitError reports whether err (or any error wrapped by it) is an *ExitError.
+func IsExitError(err error) bool {
+	_, ok := errors.AsType[*ExitError](err)
+	return ok
 }
 
 func ensureImage(ctx context.Context, cli client.APIClient, img string) error {

--- a/internal/orchestrator/modelsindex/models_index.go
+++ b/internal/orchestrator/modelsindex/models_index.go
@@ -268,25 +268,28 @@ func (m *ModelsIndex) modelInstalled(ctx context.Context, model AIModel, cli cli
 		Env:    envVars,
 		Stdout: &buf,
 	})
-	if err != nil {
+	if err != nil && !dockerhelper.IsExitError(err) {
 		return false, fmt.Errorf("model check failed for %q: %w", model.ID, err)
 	}
 
+	slog.Debug("model check output", "model", model.ID, "output", buf.String())
 	var out struct {
 		Event       string `json:"event"`
 		Description string `json:"description"`
+		Downloading bool   `json:"downloading"`
 	}
 	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
 		return false, fmt.Errorf("model check returned invalid JSON for %q: %w", model.ID, err)
 	}
-	if out.Event == "error" {
-		slog.Debug("model check returned error", "model", model.ID, "description", out.Description)
+
+	switch out.Event {
+	case "error":
 		return false, nil
+	case "info":
+		return !out.Downloading, nil
+	default:
+		return false, fmt.Errorf("model check returned unexpected event %q for %q", out.Event, model.ID)
 	}
-	if out.Event == "info" {
-		return true, nil
-	}
-	return false, fmt.Errorf("model check returned unexpected event %q for %q", out.Event, model.ID)
 }
 
 func loadInternalModels(dir *paths.Path, handlers *HandlersIndex) ([]AIModel, error) {

--- a/internal/orchestrator/modelsindex/modelsindex_test.go
+++ b/internal/orchestrator/modelsindex/modelsindex_test.go
@@ -157,27 +157,61 @@ func TestModelsIndex(t *testing.T) {
 		assert.Equal(t, InstalledStatus, model.Status)
 	})
 
-	t.Run("it loads a not preloaded model with handler", func(t *testing.T) {
-		cli := newFakeDockerClient(func(image string, cmd []string) (string, int) {
-			// it always return that the model is installed
-			return "{\"event\":\"info\"}\n", 0
-		})
-		modelsIndex, err := Load(platform.GetPlatform(nil), paths.New("testdata"), paths.New("testdata/models"), nil, cli, config.Configuration{})
-		require.NoError(t, err)
+	t.Run("it read the status of the model using the check handler", func(t *testing.T) {
+		t.Run("installed: info event with downloading=false", func(t *testing.T) {
+			cli := newFakeDockerClient(func(image string, cmd []string) (string, int) {
+				return "{\"event\":\"info\",\"downloading\":false}\n", 0
+			})
+			modelsIndex, err := Load(platform.GetPlatform(nil), paths.New("testdata"), paths.New("testdata/models"), nil, cli, config.Configuration{})
+			require.NoError(t, err)
 
-		model, err := modelsIndex.GetModelByID(t.Context(), "a-model-not-preloaded-with-handler")
-		require.NoError(t, err)
-		require.NotNil(t, model)
-		assert.Equal(t, &AIModel{
-			ID: "a-model-not-preloaded-with-handler",
-			Deployment: &ModelDeployment{
-				Handler:   "my-handler",
-				PreLoaded: false,
-			},
-			IsBuiltIn: false,
-			Status:    InstalledStatus,
-		}, model)
-		assert.Equal(t, InstalledStatus, model.Status)
+			model, err := modelsIndex.GetModelByID(t.Context(), "a-model-not-preloaded-with-handler")
+			require.NoError(t, err)
+			require.NotNil(t, model)
+			assert.Equal(t, &AIModel{
+				ID: "a-model-not-preloaded-with-handler",
+				Deployment: &ModelDeployment{
+					Handler:   "my-handler",
+					PreLoaded: false,
+				},
+				IsBuiltIn: false,
+				Status:    InstalledStatus,
+			}, model)
+		})
+
+		t.Run("not installed: info event with downloading=true", func(t *testing.T) {
+			cli := newFakeDockerClient(func(image string, cmd []string) (string, int) {
+				return "{\"event\":\"info\",\"downloading\":true}\n", 0
+			})
+			modelsIndex, err := Load(platform.GetPlatform(nil), paths.New("testdata"), paths.New("testdata/models"), nil, cli, config.Configuration{})
+			require.NoError(t, err)
+
+			model, err := modelsIndex.GetModelByID(t.Context(), "a-model-not-preloaded-with-handler")
+			require.NoError(t, err)
+			require.NotNil(t, model)
+			assert.Equal(t, &AIModel{
+				ID: "a-model-not-preloaded-with-handler",
+				Deployment: &ModelDeployment{
+					Handler:   "my-handler",
+					PreLoaded: false,
+				},
+				IsBuiltIn: false,
+				Status:    NotInstalledStatus,
+			}, model)
+		})
+
+		t.Run("not installed: error event", func(t *testing.T) {
+			cli := newFakeDockerClient(func(image string, cmd []string) (string, int) {
+				return "{\"event\":\"error\",\"description\":\"model not found\"}\n", 1
+			})
+			modelsIndex, err := Load(platform.GetPlatform(nil), paths.New("testdata"), paths.New("testdata/models"), nil, cli, config.Configuration{})
+			require.NoError(t, err)
+
+			model, err := modelsIndex.GetModelByID(t.Context(), "a-model-not-preloaded-with-handler")
+			require.NoError(t, err)
+			require.NotNil(t, model)
+			assert.Equal(t, NotInstalledStatus, model.Status)
+		})
 	})
 
 	t.Run("it get custom model by id", func(t *testing.T) {


### PR DESCRIPTION
### Motivation

The runner updated its check action protocol: it now emits an info event with a downloading field instead of just returning info to mean "installed". Without this fix, a model being downloaded would be incorrectly reported as installed.

### Change description

Introduces ExitError type in dockerhelper so callers can distinguish a non-zero container exit code from other run errors. The check action container exits non-zero when a model is not installed, which is expected behavior — not a failure.
Updates modelInstalled to tolerate ExitError (i.e., non-zero exit) and properly parse the new "info" event shape from the check action, which now includes a downloading boolean field.
Adds a switch on out.Event for clarity:
-  "error"  =>  `not installed`
- "info" with downloading: false =>  `installed` 
- "info" with downloading: true => `not installed` (still in progress), 
- anything else → propagated error.

### Additional Notes
How to test

- download a model ` curl -X PUT 127.0.0.1:8800/v1/models/llamacpp:Qwen3.5-0.8B-Q4_0`
- create a `.download` file inside `/var/lib/arduino-app-cli/models/llamacpp/unsloth/Qwen3.5-0.8B-GGUF` with a json like
```
  {
"status": "downloading",
 "handler": "hf-handler", 
"models_repository": "llamacpp", 
"model_directory": "unsloth/Qwen3.5-0.8B-GGUF", 
"model_url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/blob/main/Qwen3.5-0.8B-Q4_0.gguf"
}
```
- check if the model is installed ` curl -X GET 127.0.0.1:8800/v1/models/llamacpp:Qwen3.5-0.8B-Q4_0 | jq`
- check from the list fo models  ` curl -X GET 127.0.0.1:8800/v1/models | jq | grep -A 15 "llamacpp:Qwen3.5-0.8B-Q4_0"` 

Expected Result: ` "status": "not-installed"


### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
