### PR TITLE
fix: force daemon restart if needrestart defer it

### DIFF
--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -7,7 +7,6 @@ package apt
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -306,10 +305,7 @@ func restartServices(ctx context.Context) error {
 	if out, err := needRestartCmd.RunAndCaptureCombinedOutput(ctx); err != nil {
 		return fmt.Errorf("error running needrestart command: %w: %s", err, out)
 	} else {
-		lines := f.Map(bytes.Split(out, []byte("\n")), func(line []byte) string {
-			return string(line)
-		})
-		slog.Debug("needrestart output", slog.String("output", strings.Join(lines, "\n")))
+		slog.Debug("needrestart output", slog.String("output", string(out)))
 	}
 	return nil
 }

--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -15,8 +15,10 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/arduino/go-paths-helper"
 	"go.bug.st/f"
@@ -60,6 +62,8 @@ func (s *Service) ListUpgradablePackages(ctx context.Context, matcher func(updat
 	return pkgs, nil
 }
 
+const selfPackageName = "arduino-app-cli"
+
 // UpgradePackages upgrades the specified packages using the `apt-get upgrade` command.
 // It publishes events to subscribers during the upgrade process.
 // It returns an error if the upgrade is already in progress or if the upgrade command fails.
@@ -67,18 +71,26 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	// At the end of the upgrade, always try to restart the services (that need it).
-	// This makes sure key services are restarted even if an error happens in the upgrade steps (for examples container images download).
+	selfUpgrade := slices.ContainsFunc(packages, func(p update.PackageInfo) bool {
+		return p.Name == selfPackageName
+	})
+
 	defer func() {
 		eventCB(update.NewDataEvent(update.RestartEvent, "Upgrade completed. Restarting ..."))
 
-		err := restartServices(ctx)
-		if err != nil {
+		if err := restartServices(ctx); err != nil {
 			eventCB(update.NewErrorEvent(fmt.Errorf("error restarting services after upgrade: %w", err)))
-			return
 		}
 
-		os.Exit(0) // Restart the orchestrator to make sure all services are restarted after the upgrade.
+		if selfUpgrade {
+			// on ubuntu needrestart refuses to restart its caller's cgroup pid, so we signal
+			// ourselves to let systemd respawn us on the new binary.
+			if p, err := os.FindProcess(os.Getpid()); err == nil {
+				if err := p.Signal(syscall.SIGTERM); err != nil {
+					slog.Error("failed to send SIGTERM to self after upgrade", slog.String("error", err.Error()))
+				}
+			}
+		}
 	}()
 
 	names := f.Map(packages, func(pkg update.PackageInfo) string {

--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -7,11 +7,13 @@ package apt
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"iter"
 	"log/slog"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -75,6 +77,8 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 			eventCB(update.NewErrorEvent(fmt.Errorf("error restarting services after upgrade: %w", err)))
 			return
 		}
+
+		os.Exit(0) // Restart the orchestrator to make sure all services are restarted after the upgrade.
 	}()
 
 	names := f.Map(packages, func(pkg update.PackageInfo) string {
@@ -289,6 +293,11 @@ func restartServices(ctx context.Context) error {
 	}
 	if out, err := needRestartCmd.RunAndCaptureCombinedOutput(ctx); err != nil {
 		return fmt.Errorf("error running needrestart command: %w: %s", err, out)
+	} else {
+		lines := f.Map(bytes.Split(out, []byte("\n")), func(line []byte) string {
+			return string(line)
+		})
+		slog.Debug("needrestart output", slog.String("output", strings.Join(lines, "\n")))
 	}
 	return nil
 }


### PR DESCRIPTION
### Motivation

The Ubuntu version of needrestart has this pacth https://git.launchpad.net/ubuntu/+source/needrestart/tree/debian/patches/lp2067482/0002-defer-restarting-the-service-that-called-needrestart.patch, which defers the restart of the caller of needrestart.

### Change description

Explicitly kill `arduino-app-cli` daemon to force the daemon restart.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
