### PR TITLE
refactor: remove unused platform parameter from model and brick handlers

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -62,8 +62,8 @@ func NewHTTPRouter(
 	mux.Handle("PUT /v1/system/update/apply", handlers.HandleUpdateApply(updater))
 	mux.Handle("GET /v1/system/resources", handlers.HandleSystemResources(cfg))
 
-	mux.Handle("GET /v1/models", handlers.HandleModelsList(dockerClient, modelsIndex, cfg, platform))
-	mux.Handle("GET /v1/models/{modelID}", handlers.HandlerModelByID(dockerClient, modelsIndex, cfg, platform))
+	mux.Handle("GET /v1/models", handlers.HandleModelsList(dockerClient, modelsIndex, cfg))
+	mux.Handle("GET /v1/models/{modelID}", handlers.HandlerModelByID(dockerClient, modelsIndex, cfg))
 	mux.Handle("PUT /v1/models/ei/projects/{projectID}", handlers.HandleInstallEIModel(cfg, bricksIndex, modelsIndex, dockerClient, platform))
 	mux.Handle("PUT /v1/models/{modelID}", handlers.HandleInstallModel(dockerClient, modelsIndex, cfg, platform))
 	mux.Handle("DELETE /v1/models/{modelID}", handlers.HandlerDeleteModelByID(dockerClient, cfg, modelsIndex, bricksIndex, idProvider, platform))
@@ -85,8 +85,8 @@ func NewHTTPRouter(
 	mux.Handle("DELETE /v1/apps/{appID}/sketch/libraries/{libRef}", handlers.HandleSketchRemoveLibrary(idProvider))
 	mux.Handle("GET /v1/apps/{appID}/sketch/libraries", handlers.HandleSketchListLibraries(idProvider))
 
-	mux.Handle("GET /v1/apps/{appID}/bricks", handlers.HandleAppBrickInstancesList(brickService, idProvider, platform))
-	mux.Handle("GET /v1/apps/{appID}/bricks/{brickID}", handlers.HandleAppBrickInstanceDetails(brickService, idProvider, platform))
+	mux.Handle("GET /v1/apps/{appID}/bricks", handlers.HandleAppBrickInstancesList(brickService, idProvider))
+	mux.Handle("GET /v1/apps/{appID}/bricks/{brickID}", handlers.HandleAppBrickInstanceDetails(brickService, idProvider))
 	mux.Handle("PUT /v1/apps/{appID}/bricks/{brickID}", handlers.HandleBrickCreate(brickService, idProvider))
 	mux.Handle("PATCH /v1/apps/{appID}/bricks/{brickID}", handlers.HandleBrickUpdates(brickService, idProvider))
 	mux.Handle("DELETE /v1/apps/{appID}/bricks/{brickID}", handlers.HandleBrickDelete(brickService, idProvider))

--- a/internal/api/handlers/ai_models.go
+++ b/internal/api/handlers/ai_models.go
@@ -31,7 +31,7 @@ type InstallEIModelRequest struct {
 	ImpulseID *int `json:"impulse_id" description:"Edge Impulse impulse ID" example:"1" required:"true"`
 }
 
-func HandleModelsList(dockerClient command.Cli, modelsIndex *modelsindex.ModelsIndex, cfg config.Configuration, plat platform.Platform) http.HandlerFunc {
+func HandleModelsList(dockerClient command.Cli, modelsIndex *modelsindex.ModelsIndex, cfg config.Configuration) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query()
 
@@ -41,19 +41,19 @@ func HandleModelsList(dockerClient command.Cli, modelsIndex *modelsindex.ModelsI
 		}
 		res := orchestrator.AIModelsList(r.Context(), dockerClient.Client(), orchestrator.AIModelsListRequest{
 			FilterByBrickID: brickFilter,
-		}, modelsIndex, cfg, plat)
+		}, modelsIndex, cfg)
 		render.EncodeResponse(w, http.StatusOK, res)
 	}
 }
 
-func HandlerModelByID(dockerClient command.Cli, modelsIndex *modelsindex.ModelsIndex, cfg config.Configuration, plat platform.Platform) http.HandlerFunc {
+func HandlerModelByID(dockerClient command.Cli, modelsIndex *modelsindex.ModelsIndex, cfg config.Configuration) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("modelID")
 		if id == "" {
 			render.EncodeResponse(w, http.StatusBadRequest, models.ErrorResponse{Details: "id must be set"})
 			return
 		}
-		res, found, err := orchestrator.AIModelDetails(r.Context(), dockerClient.Client(), modelsIndex, id, cfg, plat)
+		res, found, err := orchestrator.AIModelDetails(r.Context(), dockerClient.Client(), modelsIndex, id, cfg)
 		if err != nil {
 			render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{Details: err.Error()})
 			return

--- a/internal/api/handlers/bricks.go
+++ b/internal/api/handlers/bricks.go
@@ -37,7 +37,6 @@ func HandleBrickList(brickService *bricks.Service) http.HandlerFunc {
 func HandleAppBrickInstancesList(
 	brickService *bricks.Service,
 	idProvider *app.IDProvider,
-	platform platform.Platform,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))
@@ -54,7 +53,7 @@ func HandleAppBrickInstancesList(
 			return
 		}
 
-		res, err := brickService.AppBrickInstancesList(&app, platform)
+		res, err := brickService.AppBrickInstancesList(&app)
 		if err != nil {
 			slog.Error("Unable to parse the app.yaml", slog.String("error", err.Error()))
 			details := fmt.Sprintf("unable to find brick list for app %q", appId)
@@ -68,7 +67,6 @@ func HandleAppBrickInstancesList(
 func HandleAppBrickInstanceDetails(
 	brickService *bricks.Service,
 	idProvider *app.IDProvider,
-	platform platform.Platform,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))
@@ -91,7 +89,7 @@ func HandleAppBrickInstanceDetails(
 			return
 		}
 
-		res, err := brickService.AppBrickInstanceDetails(&app, brickID, platform)
+		res, err := brickService.AppBrickInstanceDetails(&app, brickID)
 		if err != nil {
 			slog.Error("Unable to parse the app.yaml", slog.String("error", err.Error()))
 			render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{Details: "unable to obtain brick details"})

--- a/internal/orchestrator/bricks/bricks.go
+++ b/internal/orchestrator/bricks/bricks.go
@@ -63,7 +63,7 @@ func (s *Service) List() (BrickListResult, error) {
 	return res, nil
 }
 
-func (s *Service) AppBrickInstancesList(a *app.ArduinoApp, platform platform.Platform) (AppBrickInstancesResult, error) {
+func (s *Service) AppBrickInstancesList(a *app.ArduinoApp) (AppBrickInstancesResult, error) {
 	res := AppBrickInstancesResult{BrickInstances: make([]BrickInstance, len(a.Descriptor.Bricks))}
 	for i, brickInstance := range a.Descriptor.Bricks {
 		brick, found := s.bricksIndex.WithAppBricks(a.LocalBricks).FindBrickByID(brickInstance.ID)
@@ -101,7 +101,7 @@ func (s *Service) AppBrickInstancesList(a *app.ArduinoApp, platform platform.Pla
 	return res, nil
 }
 
-func (s *Service) AppBrickInstanceDetails(a *app.ArduinoApp, brickID string, platform platform.Platform) (BrickInstance, error) {
+func (s *Service) AppBrickInstanceDetails(a *app.ArduinoApp, brickID string) (BrickInstance, error) {
 	bricksindex := s.bricksIndex.WithAppBricks(a.LocalBricks)
 	brick, found := bricksindex.FindBrickByID(brickID)
 	if !found {

--- a/internal/orchestrator/bricks/bricks_test.go
+++ b/internal/orchestrator/bricks/bricks_test.go
@@ -697,7 +697,7 @@ bricks:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := svc.AppBrickInstanceDetails(tt.app, tt.brickID, platform.Platform{})
+			result, err := svc.AppBrickInstanceDetails(tt.app, tt.brickID)
 
 			if tt.expectedError != "" {
 				require.Error(t, err)
@@ -1004,7 +1004,7 @@ func TestAppBrickInstancesList(t *testing.T) {
 				bricksIndex: bIndex,
 				modelsIndex: modelsIdx,
 			}
-			result, err := svc.AppBrickInstancesList(tt.app, tt.platform)
+			result, err := svc.AppBrickInstancesList(tt.app)
 
 			if tt.expectedError != "" {
 				require.Error(t, err)

--- a/internal/orchestrator/models.go
+++ b/internal/orchestrator/models.go
@@ -51,7 +51,7 @@ type AIModelsListRequest struct {
 	FilterByBrickID []string
 }
 
-func AIModelsList(ctx context.Context, cli client.APIClient, req AIModelsListRequest, modelsIndex *modelsindex.ModelsIndex, cfg config.Configuration, plat platform.Platform) AIModelsListResult {
+func AIModelsList(ctx context.Context, cli client.APIClient, req AIModelsListRequest, modelsIndex *modelsindex.ModelsIndex, cfg config.Configuration) AIModelsListResult {
 	collection := modelsIndex.GetModels(ctx)
 	if len(req.FilterByBrickID) != 0 {
 		collection = slices.DeleteFunc(collection, func(model modelsindex.AIModel) bool {
@@ -82,7 +82,7 @@ func AIModelsList(ctx context.Context, cli client.APIClient, req AIModelsListReq
 	return AIModelsListResult{Models: items}
 }
 
-func AIModelDetails(ctx context.Context, _ client.APIClient, modelsIndex *modelsindex.ModelsIndex, id string, _ config.Configuration, _ platform.Platform) (AIModelItem, bool, error) {
+func AIModelDetails(ctx context.Context, _ client.APIClient, modelsIndex *modelsindex.ModelsIndex, id string, _ config.Configuration) (AIModelItem, bool, error) {
 
 	model, err := modelsIndex.GetModelByID(ctx, id)
 	if err != nil {


### PR DESCRIPTION
### Motivation
Remove unused platform.Platform parameters from 4 call sites

platform.Platform was threaded through handlers and orchestrator functions that never actually consumed it. This removes the dead parameter passing without any behavioral change.


### Change description

- AIModelsList / HandlerModelByID — removed platform (orchestrator function explicitly used _ blank identifier)
- AppBrickInstancesList / AppBrickInstanceDetails — removed platform (service methods never read it)
- Updated handler constructors in api.go and one test file to match


### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
