### PR TITLE
Move down chown in postinst

### DIFF
--- a/debian/arduino-app-cli/DEBIAN/postinst
+++ b/debian/arduino-app-cli/DEBIAN/postinst
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-chmod -R 775 /var/lib/arduino-app-cli
-
 systemctl enable arduino-app-cli
 systemctl enable arduino-avahi-serial.service
 
@@ -10,6 +8,8 @@ export ARDUINO_APP_CLI__ALLOW_ROOT=true && arduino-app-cli completion bash > /et
 
 chown -R arduino:arduino /var/lib/arduino-app-cli \
 || chown -R :arduino /var/lib/arduino-app-cli
+
+chmod -R 775 /var/lib/arduino-app-cli
 
 if [ "$1" = "configure" ]; then
     rm -rf /home/arduino/.local/share/arduino-app-cli

--- a/debian/arduino-app-cli/DEBIAN/postinst
+++ b/debian/arduino-app-cli/DEBIAN/postinst
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-chown -R arduino:arduino /var/lib/arduino-app-cli \
-|| chown -R :arduino /var/lib/arduino-app-cli
-
 chmod -R 775 /var/lib/arduino-app-cli
 
 systemctl enable arduino-app-cli
@@ -10,6 +7,9 @@ systemctl enable arduino-avahi-serial.service
 
 mkdir -p /etc/bash_completion.d/
 export ARDUINO_APP_CLI__ALLOW_ROOT=true && arduino-app-cli completion bash > /etc/bash_completion.d/arduino-app-cli.bash || true
+
+chown -R arduino:arduino /var/lib/arduino-app-cli \
+|| chown -R :arduino /var/lib/arduino-app-cli
 
 if [ "$1" = "configure" ]; then
     rm -rf /home/arduino/.local/share/arduino-app-cli


### PR DESCRIPTION
The postinst script will ensure all the folders in `/var/lib/arduino-app-cli` are owned by arduino.
This must be done after calling the arduino-app-cli for "completion bash".