### PR TITLE
Proof-of-concept: Arduino App Releases (release build/install/prepare/clone)

### DIFF
--- a/cmd/arduino-app-cli/app/export.go
+++ b/cmd/arduino-app-cli/app/export.go
@@ -27,6 +27,7 @@ import (
 func newExportCmd(cfg config.Configuration) *cobra.Command {
 	var includeData bool
 	var override bool
+	var scrubSecrets bool
 
 	cmd := &cobra.Command{
 		Use:   "export app_path [output_path]",
@@ -45,7 +46,7 @@ Use '-' as output_path to write the zip to stdout.`,
 			if len(args) > 1 {
 				outputPath = args[1]
 			}
-			return exportHandler(cmd.Context(), servicelocator.GetBricksIndex(), app, outputPath, includeData, override)
+			return exportHandler(cmd.Context(), servicelocator.GetBricksIndex(), app, outputPath, includeData, override, scrubSecrets)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
@@ -59,13 +60,14 @@ Use '-' as output_path to write the zip to stdout.`,
 
 	cmd.Flags().BoolVar(&includeData, "include-data", false, "Include data directory in the archive")
 	cmd.Flags().BoolVar(&override, "overwrite", false, "Overwrite output file if it exists")
+	cmd.Flags().BoolVar(&scrubSecrets, "scrub-secrets", false, "Replace secret values with ${NAME} placeholders (to be provided in data/secrets.env) instead of emptying them")
 
 	return cmd
 }
 
-func exportHandler(ctx context.Context, bricksIndex *bricksindex.BricksIndex, appToExport app.ArduinoApp, outputDest string, includeData bool, override bool) error {
+func exportHandler(ctx context.Context, bricksIndex *bricksindex.BricksIndex, appToExport app.ArduinoApp, outputDest string, includeData bool, override bool, scrubSecrets bool) error {
 
-	zipBytes, originalName, err := orchestrator.ExportAppZip(ctx, bricksIndex, appToExport, includeData)
+	zipBytes, originalName, err := orchestrator.ExportAppZip(ctx, bricksIndex, appToExport, includeData, scrubSecrets)
 	if err != nil {
 		feedback.Fatal(err.Error(), feedback.ErrGeneric)
 	}

--- a/cmd/arduino-app-cli/apprelease/build.go
+++ b/cmd/arduino-app-cli/apprelease/build.go
@@ -1,0 +1,188 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package apprelease
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/arduino/go-paths-helper"
+	"github.com/spf13/cobra"
+
+	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/completion"
+	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/internal/servicelocator"
+	"github.com/arduino/arduino-app-cli/cmd/feedback"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+)
+
+func newBuildCmd(cfg config.Configuration, cliVersion string) *cobra.Command {
+	var overwrite bool
+	var noModels bool
+	var keepSecrets bool
+	var releaseNumber string
+	var filename string
+
+	cmd := &cobra.Command{
+		Use:   "build app_path",
+		Short: "Build a reproducible Arduino App Release from a pre-built app",
+		Long: `Build a reproducible Arduino App Release (.tar.gz) from an app that has already
+been built and started at least once.
+
+The app must be pre-built: the command does not compile the sketch nor provision the Python
+environment. Start the app once before packaging it.
+
+By default the release is written to the current directory with a generated filename derived
+from the app name (shortened to 10 characters) and the release number, e.g.
+"my-weather_20260709120000.tar.gz". Use --filename to choose a different name or path; a
+".tar.gz" extension is appended automatically if omitted.
+
+Required AI models that are stored on disk (e.g. custom or Edge Impulse models) are bundled
+into the release so it is self-contained. Use --no-models to exclude them.
+
+Brick secret variables (API keys, passwords) are by default scrubbed from the release and
+replaced with ${NAME} placeholders; the user must provide them on the destination in the
+app's data/secrets.env file. Use --keep-secrets to embed the secret values instead (which
+makes the archive sensitive).`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return cmd.Help()
+			}
+			appToRelease, err := loadApp(args[0])
+			if err != nil {
+				feedback.Fatal(err.Error(), feedback.ErrBadArgument)
+			}
+			return buildHandler(cmd.Context(), cfg, cliVersion, releaseNumber, appToRelease, filename, overwrite, !noModels, keepSecrets)
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			return completion.ApplicationNamesWithFilterFunc(cfg, func(apps orchestrator.AppInfo) bool {
+				return !apps.Example
+			})(cmd, args, toComplete)
+		},
+	}
+
+	cmd.Flags().StringVar(&filename, "filename", "", "Output file name or path (default: <appname>_<release-number>.tar.gz in the current directory); a .tar.gz extension is added if missing")
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Overwrite the output file if it exists")
+	cmd.Flags().BoolVar(&noModels, "no-models", false, "Do not bundle required AI models into the release")
+	cmd.Flags().BoolVar(&keepSecrets, "keep-secrets", false, "Embed secret variable values in the release instead of scrubbing them (sensitive)")
+	cmd.Flags().StringVar(&releaseNumber, "release-number", "", "Release number to record in the release (default: current timestamp YYYYMMDDhhmmss)")
+
+	return cmd
+}
+
+func buildHandler(ctx context.Context, cfg config.Configuration, cliVersion string, releaseNumber string, appToRelease app.ArduinoApp, filename string, overwrite bool, includeModels bool, keepSecrets bool) error {
+	// Resolve the release number here so it matches the one recorded in the release and
+	// can be embedded into the generated default filename.
+	if releaseNumber == "" {
+		releaseNumber = time.Now().Format("20060102150405")
+	}
+
+	var outputPath *paths.Path
+	if filename == "" {
+		outputPath = paths.New(releaseDefaultFileName(appToRelease.Name, releaseNumber))
+	} else {
+		outputPath = paths.New(filename)
+		// A trailing separator or an existing directory means "write the default name here".
+		dirIntent := outputPath.IsDir() ||
+			strings.HasSuffix(filename, "/") || strings.HasSuffix(filename, string(os.PathSeparator))
+		if dirIntent {
+			outputPath = outputPath.Join(releaseDefaultFileName(appToRelease.Name, releaseNumber))
+		} else if !strings.HasSuffix(strings.ToLower(outputPath.String()), ".tar.gz") {
+			outputPath = paths.New(outputPath.String() + ".tar.gz")
+		}
+	}
+	// Create the parent directory up front so a non-existent target dir fails here with a clear
+	// message instead of deep inside BuildRelease after all the packaging work.
+	if parent := outputPath.Parent(); parent != nil {
+		if err := parent.MkdirAll(); err != nil {
+			feedback.Fatal(fmt.Sprintf("Cannot create output directory %q: %s", parent, err), feedback.ErrGeneric)
+		}
+	}
+	if outputPath.Exist() && !overwrite {
+		feedback.Fatal(fmt.Sprintf("File %q already exists. Use --overwrite to overwrite.", outputPath), feedback.ErrGeneric)
+	}
+
+	out, _, _ := feedback.OutputStreams()
+
+	err := orchestrator.BuildRelease(
+		ctx,
+		servicelocator.GetBricksIndex(),
+		servicelocator.GetModelsIndex(),
+		appToRelease,
+		cfg,
+		servicelocator.GetPlatform(),
+		cliVersion,
+		releaseNumber,
+		outputPath,
+		includeModels,
+		keepSecrets,
+		func(message orchestrator.StreamMessage) {
+			if message.GetType() == orchestrator.InfoType {
+				fmt.Fprintln(out, "[INFO]", message.GetData())
+			}
+		},
+	)
+	if err != nil {
+		feedback.Fatal(fmt.Sprintf("Failed to build release: %s", err), feedback.ErrGeneric)
+	}
+
+	feedback.PrintResult(buildReleaseResult{
+		Result:  "ok",
+		Message: "Release built",
+		Path:    outputPath.String(),
+	})
+	return nil
+}
+
+// releaseDefaultFileName builds a meaningful default file name for a release: the app name
+// (sanitized to a filesystem-safe slug and shortened to 10 characters), an underscore, and the
+// release number. Sanitization keeps only [a-z0-9-] so path separators and other special
+// characters can never turn the default into a nested/invalid path, and truncation operates on
+// the already-ASCII slug so it can never split a multibyte rune.
+func releaseDefaultFileName(appName, releaseNumber string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(appName) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == ' ' || r == '-' || r == '_' || r == '/' || r == '\\' || r == '.':
+			b.WriteByte('-')
+		default:
+			// drop anything else (punctuation, non-ASCII, control chars)
+		}
+	}
+	name := b.String()
+	if len(name) > 10 {
+		name = name[:10]
+	}
+	name = strings.Trim(name, "-")
+	if name == "" {
+		name = "app"
+	}
+	return fmt.Sprintf("%s_%s.tar.gz", name, releaseNumber)
+}
+
+type buildReleaseResult struct {
+	Result  string `json:"result"`
+	Message string `json:"message"`
+	Path    string `json:"path"`
+}
+
+func (r buildReleaseResult) String() string {
+	return fmt.Sprintf("✓ %s at %q", r.Message, r.Path)
+}
+
+func (r buildReleaseResult) Data() any {
+	return r
+}

--- a/cmd/arduino-app-cli/apprelease/build_test.go
+++ b/cmd/arduino-app-cli/apprelease/build_test.go
@@ -1,0 +1,42 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package apprelease
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReleaseDefaultFileName(t *testing.T) {
+	const num = "20260709120000"
+
+	cases := []struct {
+		name string
+		app  string
+		want string
+	}{
+		{"spaces lowercased", "My Weather Station", "my-weather_" + num + ".tar.gz"},
+		{"path separators stripped", "sensors/v2", "sensors-v2_" + num + ".tar.gz"},
+		{"backslash and dots stripped", `a.b\c`, "a-b-c_" + num + ".tar.gz"},
+		{"punctuation dropped and truncated", "Robot#1 (beta)!", "robot1-bet_" + num + ".tar.gz"},
+		{"truncated to 10 chars", "abcdefghijklmnop", "abcdefghij_" + num + ".tar.gz"},
+		{"non-ascii dropped, no split rune", "日本語app", "app_" + num + ".tar.gz"},
+		{"empty falls back to app", "///", "app_" + num + ".tar.gz"},
+		{"trailing dashes trimmed", "hello---", "hello_" + num + ".tar.gz"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := releaseDefaultFileName(tc.app, num)
+			require.Equal(t, tc.want, got)
+			// Never a nested path, always the expected extension.
+			require.NotContains(t, got, "/")
+			require.NotContains(t, got, `\`)
+			require.True(t, strings.HasSuffix(got, ".tar.gz"))
+		})
+	}
+}

--- a/cmd/arduino-app-cli/apprelease/clone.go
+++ b/cmd/arduino-app-cli/apprelease/clone.go
@@ -1,0 +1,93 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package apprelease
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/completion"
+	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/internal/servicelocator"
+	"github.com/arduino/arduino-app-cli/cmd/feedback"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+)
+
+func newCloneCmd(cfg config.Configuration) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clone release_app new_app_name",
+		Short: "Create a new editable app from an installed release",
+		Long: `Create a new app from an app that was installed from a release.
+
+The clone is turned back into a live, editable app: the prebuilt sketch binary, the
+provisioned Python environment, the release number and the release manifest are removed, so
+the next 'app start' will recompile the sketch and re-provision the environment as usual.`,
+		Args: cobra.MaximumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 2 {
+				return cmd.Help()
+			}
+			return cloneHandler(cmd.Context(), cfg, args[0], args[1])
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			return completion.ApplicationNamesWithFilterFunc(cfg, func(apps orchestrator.AppInfo) bool {
+				return !apps.Example
+			})(cmd, args, toComplete)
+		},
+	}
+
+	return cmd
+}
+
+func cloneHandler(ctx context.Context, cfg config.Configuration, source string, newName string) error {
+	srcApp, err := loadApp(source)
+	if err != nil {
+		feedback.Fatal(err.Error(), feedback.ErrBadArgument)
+	}
+	if !srcApp.IsFrozenRelease() {
+		feedback.Fatal(fmt.Sprintf("%q is not a release-installed app; use `arduino-app-cli app new --from-app` to clone a regular app", srcApp.Name), feedback.ErrBadArgument)
+	}
+
+	id, err := servicelocator.GetAppIDProvider().ParseID(source)
+	if err != nil {
+		feedback.Fatal(err.Error(), feedback.ErrBadArgument)
+	}
+
+	resp, err := orchestrator.CloneApp(ctx, orchestrator.CloneAppRequest{
+		FromID:             id,
+		Name:               &newName,
+		StripFrozenRelease: true,
+	}, servicelocator.GetAppIDProvider(), cfg)
+	if err != nil {
+		feedback.Fatal(err.Error(), feedback.ErrGeneric)
+	}
+
+	feedback.PrintResult(cloneResult{
+		Result:  "ok",
+		Message: "App created from release",
+		Path:    resp.ID.ToPath().String(),
+	})
+	return nil
+}
+
+type cloneResult struct {
+	Result  string `json:"result"`
+	Message string `json:"message"`
+	Path    string `json:"path"`
+}
+
+func (r cloneResult) String() string {
+	return fmt.Sprintf("✓ %s at %q", r.Message, r.Path)
+}
+
+func (r cloneResult) Data() any {
+	return r
+}

--- a/cmd/arduino-app-cli/apprelease/install.go
+++ b/cmd/arduino-app-cli/apprelease/install.go
@@ -1,0 +1,169 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package apprelease
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/arduino/go-paths-helper"
+	"github.com/spf13/cobra"
+
+	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/internal/servicelocator"
+	"github.com/arduino/arduino-app-cli/cmd/feedback"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+)
+
+func newInstallCmd(cfg config.Configuration) *cobra.Command {
+	var force bool
+	var noPrepare bool
+
+	cmd := &cobra.Command{
+		Use:   "install release_file.tar.gz",
+		Short: "Install an Arduino App Release into the apps directory",
+		Long: `Install an Arduino App Release (.tar.gz) into the apps directory.
+
+The app is extracted ready to run: the prebuilt sketch, the Python venv, the bundled AI
+models and a localized version-pinned compose file are placed on disk, and the app is
+flagged as a release in app.yaml. From then on it behaves like a regular app — launch it
+with the usual 'arduino-app-cli app start <app>' (it is not recompiled nor re-provisioned).
+
+By default, install also runs the 'prepare' step: it pre-pulls the container images the app
+needs (per its compose file) so that the first 'app start' finds them locally. The app is
+not started. Use --no-prepare to skip this and run 'arduino-app-cli release prepare <app>'
+separately later (a plain 'app start' would also pull any missing images).
+
+Use '-' as release_file to read the release from stdin.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+
+			tarPath, cleanup, err := parseReleasePath(args[0])
+			if err != nil {
+				feedback.Fatal(err.Error(), feedback.ErrBadArgument)
+				return nil
+			}
+			defer cleanup()
+
+			installHandler(cmd.Context(), cfg, tarPath, force, !noPrepare)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Install even if the release targets a different board")
+	cmd.Flags().BoolVar(&noPrepare, "no-prepare", false, "Skip pre-pulling the app's container images (run 'release prepare' later)")
+
+	return cmd
+}
+
+func parseReleasePath(arg string) (*paths.Path, func(), error) {
+	if arg == "-" {
+		tmpFile, err := paths.MkTempFile(nil, "app_release_*.tar.gz")
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create temporary file: %w", err)
+		}
+		defer tmpFile.Close()
+
+		if _, err = io.Copy(tmpFile, os.Stdin); err != nil { // nolint:forbidigo
+			tmpFile.Close()
+			_ = os.Remove(tmpFile.Name())
+			return nil, nil, fmt.Errorf("failed to read from stdin: %w", err)
+		}
+
+		return paths.New(tmpFile.Name()), func() {
+			tmpFile.Close()
+			_ = os.Remove(tmpFile.Name())
+		}, nil
+	}
+
+	path := paths.New(arg)
+	if !path.Exist() {
+		return nil, nil, fmt.Errorf("file not found: %s", arg)
+	}
+	return path, func() {}, nil
+}
+
+func installHandler(ctx context.Context, cfg config.Configuration, tarPath *paths.Path, force bool, prepare bool) {
+	idProvider := servicelocator.GetAppIDProvider()
+	appID, manifest, err := orchestrator.InstallRelease(ctx, cfg, tarPath, idProvider, servicelocator.GetBricksIndex(), servicelocator.GetModelsIndex(), servicelocator.GetPlatform(), force)
+	if err != nil {
+		switch {
+		case errors.Is(err, orchestrator.ErrIncompatibleRelease):
+			feedback.Fatal(err.Error(), feedback.ErrBadArgument)
+		case errors.Is(err, orchestrator.ErrAppAlreadyExists):
+			feedback.Fatal(err.Error(), feedback.ErrGeneric)
+		case errors.Is(err, orchestrator.ErrBadRequest):
+			feedback.Fatal(err.Error(), feedback.ErrBadArgument)
+		default:
+			feedback.Fatal(fmt.Sprintf("Install failed: %s", err), feedback.ErrGeneric)
+		}
+	}
+
+	// The install itself is complete and committed on disk. Pre-pulling the container images
+	// is a convenience: a failure here must NOT fail the install (the images will be pulled on
+	// the first 'app start', or the user can run 'release prepare' later).
+	if prepare {
+		installedApp, loadErr := app.Load(appID.ToPath())
+		if loadErr != nil {
+			feedback.Warnf("Release installed, but could not load it to prepare images: %s", loadErr)
+		} else {
+			out, _, _ := feedback.OutputStreams()
+			prepErr := orchestrator.PrepareRelease(ctx, installedApp, servicelocator.GetDockerClient(), func(message orchestrator.StreamMessage) {
+				if message.GetType() == orchestrator.InfoType {
+					fmt.Fprintln(out, "[INFO]", message.GetData())
+				}
+			})
+			if prepErr != nil {
+				feedback.Warnf("Release installed, but preparing container images failed: %s\n"+
+					"Run 'arduino-app-cli release prepare %q' later, or it will be pulled on first start.", prepErr, installedApp.Name)
+			}
+		}
+	}
+
+	result := installReleaseResult{AppID: appID.String()}
+	if manifest != nil {
+		result.AppName = manifest.AppName
+	}
+	feedback.PrintResult(result)
+}
+
+type installReleaseResult struct {
+	AppID   string `json:"app_id"`
+	AppName string `json:"app_name,omitempty"`
+}
+
+func (r installReleaseResult) String() string {
+	id := r.AppID
+	if decoded, err := base64.RawURLEncoding.DecodeString(r.AppID); err == nil {
+		id = string(decoded)
+	}
+	// The manifest may be unreadable; fall back to the app id so we never print a blank name
+	// or suggest `app start ""`.
+	name := r.AppName
+	startTarget := r.AppName
+	if name == "" {
+		name = id
+	}
+	if startTarget == "" {
+		startTarget = id
+	}
+	return fmt.Sprintf("✓ Release installed.\n  App: %s\n  App ID: %s\n  Start it like any app: arduino-app-cli app start %q", name, id, startTarget)
+}
+
+func (r installReleaseResult) Data() any {
+	if decoded, err := base64.RawURLEncoding.DecodeString(r.AppID); err == nil {
+		return installReleaseResult{AppID: string(decoded), AppName: r.AppName}
+	}
+	return r
+}

--- a/cmd/arduino-app-cli/apprelease/prepare.go
+++ b/cmd/arduino-app-cli/apprelease/prepare.go
@@ -1,0 +1,83 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package apprelease
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/completion"
+	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/internal/servicelocator"
+	"github.com/arduino/arduino-app-cli/cmd/feedback"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+)
+
+func newPrepareCmd(cfg config.Configuration) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "prepare app_path",
+		Short: "Pre-pull the container images an installed app needs",
+		Long: `Pre-pull the Docker images referenced by an installed app's compose file so that a
+subsequent 'app start' finds them locally and does not need network access.
+
+The app is not started, and no AI models are downloaded (model artifacts are already on
+disk from install; only containers are ever pulled). Images already present locally are
+skipped. This is the same step that 'release install' runs by default unless --no-prepare
+is passed.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			appToPrepare, err := loadApp(args[0])
+			if err != nil {
+				feedback.Fatal(err.Error(), feedback.ErrBadArgument)
+			}
+
+			out, _, _ := feedback.OutputStreams()
+			err = orchestrator.PrepareRelease(cmd.Context(), appToPrepare, servicelocator.GetDockerClient(), func(message orchestrator.StreamMessage) {
+				if message.GetType() == orchestrator.InfoType {
+					fmt.Fprintln(out, "[INFO]", message.GetData())
+				}
+			})
+			if err != nil {
+				feedback.Fatal(fmt.Sprintf("Failed to prepare images: %s", err), feedback.ErrGeneric)
+			}
+
+			feedback.PrintResult(prepareReleaseResult{
+				Result:  "ok",
+				Message: "Container images prepared",
+				AppName: appToPrepare.Name,
+			})
+			return nil
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+			return completion.ApplicationNamesWithFilterFunc(cfg, func(apps orchestrator.AppInfo) bool {
+				return !apps.Example
+			})(cmd, args, toComplete)
+		},
+	}
+
+	return cmd
+}
+
+type prepareReleaseResult struct {
+	Result  string `json:"result"`
+	Message string `json:"message"`
+	AppName string `json:"app_name"`
+}
+
+func (r prepareReleaseResult) String() string {
+	return fmt.Sprintf("✓ %s for %q", r.Message, r.AppName)
+}
+
+func (r prepareReleaseResult) Data() any {
+	return r
+}

--- a/cmd/arduino-app-cli/apprelease/release.go
+++ b/cmd/arduino-app-cli/apprelease/release.go
@@ -1,0 +1,52 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package apprelease
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/internal/servicelocator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+)
+
+// NewReleaseCmd builds the `release` command group, which manages reproducible Arduino App
+// Releases: self-contained .tar.gz bundles that include the prebuilt sketch, the user code,
+// the provisioned Python venv, the required AI models and a version-pinned compose file. A
+// release can be installed on another board without recompiling the sketch or downloading
+// Python dependencies (only containers are pulled).
+func NewReleaseCmd(cfg config.Configuration, cliVersion string) *cobra.Command {
+	releaseCmd := &cobra.Command{
+		Use:   "release",
+		Short: "Build, install, prepare and clone reproducible Arduino App Releases",
+		Long: `Manage reproducible Arduino App Releases.
+
+An Arduino App Release is a self-contained archive of an already-built app: it bundles the
+compiled sketch binary, the user code, the provisioned Python virtual environment, the
+required AI models and a version-pinned Docker Compose file. Once installed, a release
+behaves like a regular app and is launched with the usual 'app start' command; it is not
+recompiled nor re-provisioned, and only containers are pulled.`,
+	}
+
+	releaseCmd.AddCommand(newBuildCmd(cfg, cliVersion))
+	releaseCmd.AddCommand(newInstallCmd(cfg))
+	releaseCmd.AddCommand(newPrepareCmd(cfg))
+	releaseCmd.AddCommand(newCloneCmd(cfg))
+
+	return releaseCmd
+}
+
+// loadApp resolves an app id-or-path to an ArduinoApp, mirroring the helper used by the
+// `app` command group.
+func loadApp(idOrPath string) (app.ArduinoApp, error) {
+	id, err := servicelocator.GetAppIDProvider().ParseID(idOrPath)
+	if err != nil {
+		return app.ArduinoApp{}, fmt.Errorf("invalid app path: %s", idOrPath)
+	}
+	return app.Load(id.ToPath())
+}

--- a/cmd/arduino-app-cli/main.go
+++ b/cmd/arduino-app-cli/main.go
@@ -16,6 +16,7 @@ import (
 	"go.bug.st/cleanup"
 
 	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/app"
+	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/apprelease"
 	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/brick"
 	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/completion"
 	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/config"
@@ -74,6 +75,7 @@ func run(configuration cfg.Configuration) error {
 		version.NewVersionCmd(Version),
 		monitor.NewMonitorCmd(),
 		model.NewModelCmd(configuration),
+		apprelease.NewReleaseCmd(configuration, Version),
 	)
 
 	ctx := context.Background()

--- a/docs/release_feature_specification.md
+++ b/docs/release_feature_specification.md
@@ -1,0 +1,621 @@
+# Arduino App Releases — Detailed Design & Behavior
+
+This document explains, in depth, how the **Release** feature works end to end: what
+`release build` produces, the structure of the release manifest, the exact `install` and
+`app start` (execute) workflows, and the full story of how **models**, **containers**, and
+**secrets** are handled.
+
+It is a design/reference companion to the user-facing section in
+`docs/user-documentation.md`. Code references use `file:line` and point at the
+`internal/orchestrator/` package unless noted.
+
+---
+
+## 1. Concept and terminology
+
+An **Arduino App** on a board (Arduino UNO Q / VENTUNOQ, Linux/arm64) is a bundle of:
+Python code, an optional MCU sketch, "bricks" (reusable components), and references to AI
+models. It runs as a set of containers orchestrated by `docker compose`, plus a sketch
+flashed to the microcontroller.
+
+There are **two** ways to package an app:
+
+| | `app export` / `app import` (pre-existing) | `release build` / `install` / `clone` (this feature) |
+|---|---|---|
+| Contents | **source only** (excludes `.cache`) | source **+ build artifacts** (prebuilt sketch, provisioned venv, frozen compose, bundled models) |
+| On the destination | stays **editable**; first `app start` **recompiles** the sketch and **re-runs pip** | **immutable / locked**; `app start` flashes the prebuilt binary and reuses the venv — **no compile, no pip** |
+| Network at install | n/a | **never** downloads models; only **containers** are pulled — by default at install (the "prepare" step), otherwise at `start` |
+| Format | `.zip` | `.tar.gz` (preserves symlinks + file modes, required for the venv) |
+
+> **Naming note:** the concept was originally "package" and was renamed to **"release"**
+> (the word "package" confused Python developers). Unrelated apt/`debian-package`
+> concepts in the codebase were intentionally **not** renamed.
+
+A release is a **frozen** app: everything that would otherwise be rebuilt on first start is
+already inside the archive, so it runs on another identical board reproducibly.
+
+---
+
+## 2. `release build` — step by step
+
+Entry point: `BuildRelease` (`release.go:127`). Invoked by the CLI
+`arduino-app-cli release build <app> <out.tar.gz>` and the HTTP endpoint
+`GET /v1/apps/{id}/release`.
+
+Flags: `--release-number` (default `YYYYMMDDhhmmss`), `--overwrite`, `--no-models`,
+`--keep-secrets`.
+
+The steps, in order:
+
+1. **Release number** (`release.go:149`). Identifies this build. Defaults to a UTC timestamp
+   `20060102150405`.
+
+2. **Validate the app is pre-built** — `validatePrebuilt` (`release.go:359`). A release must
+   never compile or provision; it only *copies* what already exists. It therefore requires:
+   - `.cache/app-compose.yaml` to exist → otherwise *"app has not been started yet"*.
+   - if the app has a sketch, a **non-empty** `.cache/sketch` build dir (`SketchBuildPath()`).
+   - a **provisioned Python venv**, detected by walking `.cache` for a `pyvenv.cfg` file
+     (`hasProvisionedVenv`, `release.go:389` — the venv dir name is owned by the python
+     runner image, so it is discovered, not hard-coded).
+
+   If any is missing the command fails with a *"Start the app once before packaging"* error.
+
+3. **Handle secrets** (`release.go:161`). Unless `--keep-secrets` is set, `scrubAppSecrets`
+   (`release.go:239`) walks every brick variable flagged `secret: true` in the brick
+   definition that currently has a **non-empty** value, replaces the value in `app.yaml` with
+   a `${NAME}` placeholder, and returns both the list of `required_secrets` (name + owning
+   brick) and a `name → plaintext-value` map. See [§9 Secrets](#9-secrets).
+
+4. **Resolve models** — `resolveAppModels` (`release.go:277`). Walks the models referenced by
+   the app's bricks and decides, per model, whether it is *preloaded* (rides in a container
+   image → not bundled) or must be **bundled** from its on-disk artifacts. Produces the
+   manifest `models` entries and the list of files to add to the archive. See
+   [§7 Models](#7-models-the-full-story).
+
+5. **Freeze the compose** — `buildFrozenCompose` (`release.go:423`). Runs
+   `docker compose config` to flatten all includes and pin concrete image versions, tokenizes
+   host-specific values to portable placeholders, and scrubs secret material. See
+   [§6 Compose freezing](#6-compose-freezing--tokenization). Result is stored as
+   `.cache/release-compose.yaml`.
+
+6. **Build the manifest** (`release.go:199`) — see [§4 Manifest](#4-the-manifest-file). The
+   image list is derived from the frozen compose via `extractComposeImages`
+   (`release.go:547`).
+
+7. **Write the archive** — `writeAppTarGz` (`release.go:582`). Walks the app folder into a
+   gzip tarball rooted at a filesystem-safe folder name (`releaseRootFolderName`,
+   `release.go:574`), **preserving symlinks (via `Lstat`/`Readlink`) and file modes**
+   (required for the venv). The scrubbed `app.yaml`, the manifest, and the frozen compose are
+   injected as synthetic entries (so the scrubbed versions win over what is on disk), and the
+   bundled model artifacts are appended. Excluded from the archive:
+   - `data/` (reserved, host-local — holds `secrets.env`),
+   - the non-portable generated `.cache/app-compose.yaml` and `.cache/app-compose-overrides.yaml`.
+
+---
+
+## 3. Release archive layout
+
+```
+my-app.tar.gz
+└── my-app/
+    ├── arduino-app-release.yaml   # the manifest (ReleaseManifest)
+    ├── app.yaml                   # descriptor; secret values scrubbed by default
+    ├── README.md
+    ├── python/  sketch/  bricks/  # user code
+    ├── .cache/
+    │   ├── release-compose.yaml   # frozen, version-pinned, RELOCATABLE compose (placeholders)
+    │   ├── sketch/                # prebuilt MCU binary (flashed as-is)
+    │   └── <venv>/                # provisioned Python venv (pip is NOT re-run)
+    └── models/                    # bundled AI model artifacts (only if any are bundled)
+```
+
+`data/`, `.cache/app-compose.yaml`, and `.cache/app-compose-overrides.yaml` are **not** in
+the archive.
+
+---
+
+## 4. The manifest file
+
+File name: `arduino-app-release.yaml` (constant `ReleaseManifestFileName`, `release.go:46`),
+placed at the root of the release next to `app.yaml`. Struct: `ReleaseManifest`
+(`release.go:61`). It records **provenance and compatibility** so `install` can validate the
+release and restore its models/secrets.
+
+```yaml
+format_version: "1"                      # ReleaseFormatVersion; bump on breaking layout changes
+app_name: "My App"
+release: "20260702120000"                # the release number from create
+created_at: 2026-07-02T12:00:00Z         # UTC
+source_cli_version: "0.11.0rc6"          # CLI that built the release
+runner_version: "0.11.0rc6"              # asset/runner version on the source board
+python_image: "ghcr.io/arduino/.../python-runner:..."   # pinned python base image
+board_name: "ventunoq"                   # <-- compatibility key (see §5, §8)
+fqbn: "arduino:zephyr:..."               # source board FQBN
+arch: "arm64"                            # GOARCH of the source
+images:                                  # every container image referenced by the frozen compose
+  - "ghcr.io/arduino/app-bricks/...:0.11.0rc6"
+  - "artifacts.codelinaro.org/.../genai-llm-vlm-service:1.2.0"
+models:                                  # one entry per model the app requires (see §7)
+  - id: "genie:qwen3_4b_instruct_2507"
+    name: "Qwen 3-4B Instruct"
+    runner: "..."
+    preloaded: false                     # false => its files are bundled under models/
+    bundled: true
+    paths:                               # bundled artifact paths, relative to the custom-models dir
+      - "genai"
+required_secrets:                        # secret variables whose VALUES are NOT in the release (see §9)
+  - name: "OPENAI_API_KEY"
+    brick: "arduino:llm"
+```
+
+Field-by-field responsibility:
+
+| Field | Meaning | Used by install to… |
+|---|---|---|
+| `format_version` | release layout version | reject unknown/incompatible layouts |
+| `app_name` | display name | name the installed app |
+| `release` | release number | stamp `frozen_release.number` in `app.yaml` |
+| `created_at`, `source_cli_version`, `runner_version`, `python_image` | provenance / diagnostics | (informational) |
+| `board_name`, `fqbn`, `arch` | source hardware identity | **board compatibility check** (`board_name`; see §5/§8) |
+| `images` | pinned container images | (informational; the compose is authoritative) |
+| `models` | which models the app needs & how each is provided | **restore bundled model files** |
+| `required_secrets` | secret variable names (value NOT in release) | write the `data/secrets.env` template + drive run-time resolution |
+
+---
+
+## 5. `install` workflow
+
+Entry point: `InstallRelease` (`release.go:751`). CLI:
+`arduino-app-cli release install <file.tar.gz>` (accepts `-` for stdin) with `--force`.
+HTTP: `POST /v1/apps/release/install` (multipart) with `?force=`.
+
+Steps:
+
+1. **Read metadata** — `readReleaseMetadata` (`release.go:1132`) scans the archive for its
+   root prefix and parses the manifest; it also validates that the archive really is a
+   release (rejects non-releases).
+
+2. **Board compatibility check** (`release.go:767`):
+   ```go
+   if !force && manifest.BoardName != "" && plat.BoardName != "" && manifest.BoardName != plat.BoardName {
+       return ..., fmt.Errorf("%w: release was built for board %q but this board is %q (use --force to override)",
+           ErrIncompatibleRelease, manifest.BoardName, plat.BoardName)
+   }
+   ```
+   A mismatch fails fast with a message naming both boards and pointing at `--force`. See
+   [§8](#8-board-compatibility--force) for why only `board_name` is compared and how the
+   error is surfaced (CLI fatal / HTTP **409 Conflict**).
+
+3. **Pick the destination name.** Uses the archive root folder name; on a name collision,
+   appends a `-YYYYMMDD-HHMMSS` suffix. The folder name is validated.
+
+4. **Extract to a temp dir** — `extractTarGz` (`release.go`, see [§10 Security](#10-security-hardening)).
+   Extraction is hardened against tar-slip, malicious symlinks, and zip-bomb-style oversized
+   files.
+
+5. **Restore bundled models** — `restoreBundledModels` (`release.go:845`). Copies the
+   archived `models/…` tree into the destination's **custom-models dir** (outside the app
+   folder), preserving layout so the compose placeholder resolves. **Copy only — never
+   downloads.** Existing artifacts are kept unless `--force`. The staging `models/` folder is
+   then removed so it is not moved into the apps directory.
+
+6. **Localize the compose** — `localizeInstalledRelease` (`release.go:921`). Reads
+   `.cache/release-compose.yaml`, resolves the **stable** host paths for *this* machine
+   (`${APP_HOME}` → the final app path, `${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}` → this
+   board's custom-models dir), and writes the standard `.cache/app-compose.yaml`. `${HOST_IP}`
+   is **left as a placeholder** — it is filled fresh at every `app start`. The frozen compose
+   file is then removed (superseded). Finally it **stamps** `frozen_release.number` into
+   `app.yaml` so the normal start path recognizes it as a release.
+
+7. **Write the secrets template** — `writeSecretsTemplate` (`release.go:981`). If the manifest
+   declares `required_secrets` and no `data/secrets.env` exists yet, writes a template listing
+   the required keys with empty values.
+
+8. **Validate & finalize.** `app.Load` validates the extracted app; then the temp dir is
+   **atomically renamed** to the final path (so a failed install never leaves a half-written
+   app). An app ID is derived and returned along with the manifest.
+
+9. **Prepare (default)** — unless `--no-prepare` (CLI) / `?prepare=false` (HTTP) is set,
+   install then runs the [prepare step](#10-containers):
+   `PrepareRelease` (`release_prepare.go`) pre-pulls the container images the app needs so the
+   first `app start` finds them locally. The install is already committed on disk at this
+   point, so a prepare failure is **non-fatal** — it is surfaced as a warning and the user can
+   re-run `release prepare` later (or a plain `app start` will pull whatever is still missing).
+
+After install the app is a **regular app** in `app list` — there is no separate "release
+start". It is launched, stopped, and inspected with the ordinary `app start/stop/logs`
+commands; the release-specific behavior is triggered by the `frozen_release` marker in
+`app.yaml`.
+
+---
+
+## 6. Compose freezing & tokenization
+
+This is the mechanism that makes the compose **relocatable** across boards while keeping the
+volatile network address dynamic. Three host-specific values are handled:
+
+| Placeholder | Meaning | Resolved when |
+|---|---|---|
+| `${APP_HOME}` | the app's folder on disk | at **install** (stable per machine) |
+| `${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}` | the custom-models dir | at **install** (stable per machine) |
+| `${HOST_IP}` | the board's LAN IP | at **every `app start`** (volatile) |
+
+### At create — `buildFrozenCompose` (`release.go:423`)
+
+1. Run `docker compose -f app-compose.yaml [-f overrides] config`, but with the three
+   host-specific env vars set to **unique sentinel tokens** (`release.go:413`):
+   ```go
+   frozenEnvs["HOST_IP"]                              = sentinelHostIP    // "__ARDUINO_RELEASE_PLACEHOLDER_HOST_IP__"
+   frozenEnvs["APP_HOME"]                             = sentinelAppHome   // "/__ARDUINO_..._APP_HOME__"
+   frozenEnvs["ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR"] = sentinelModelsDir // "/__ARDUINO_..._CUSTOM_MODEL_DIR__"
+   ```
+   Compose interpolation therefore expands those vars to the sentinels, not to real host
+   values.
+
+2. `tokenizeHostSpecificValues` (`release.go:474`) reverse-maps each sentinel to its portable
+   `${...}` placeholder.
+
+   **Why sentinels?** A naïve `strings.ReplaceAll` of the *real* host IP `192.168.1.5` would
+   also corrupt `192.168.1.50` (substring over-match). Routing `${HOST_IP}` *references*
+   through unique tokens eliminates that. As a **safety net** the function *also* replaces any
+   literally baked `customModelsDir` / `appHome` strings (long, unique absolute paths that
+   cannot over-match a substring), guarded against empty/`/` values.
+
+   **Baked host IP.** The provisioner writes the app's `main` service `environment:` with the
+   *resolved* env map (`provision.go:392`), so the generated `.cache/app-compose.yaml` carries
+   `HOST_IP: <literal-ip>` — **not** a `${HOST_IP}` reference. The sentinel indirection never
+   sees that literal, so `tokenizeHostSpecificValues` also replaces the **known** host IP
+   (passed in from `envs["HOST_IP"]`) using a **word-boundary-anchored regex**
+   (`\b<ip>\b` via `ReplaceAllLiteralString`), which tokenizes `192.168.1.5` while leaving
+   `192.168.1.50` intact — the exact over-match the sentinel was introduced to avoid. Without
+   this, the real board IP leaks into `release-compose.yaml` inside the tar (fixed).
+
+   > This safety net is load-bearing for local LLMs: the genie/llamacpp runner service
+   > composes mount the models dir as a **hardcoded absolute path**
+   > (`/var/lib/arduino-app-cli/models/genai`) rather than via the env var, so only the
+   > literal-path replace turns them into `${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}/genai`.
+   > This works board-to-board because the custom-models dir is the same fixed path on every
+   > board (and is a prefix of the mount). See [§7](#7-models-the-full-story).
+
+3. Scrub secret material from the flattened compose (see [§9](#9-secrets)).
+
+### At install — `localizeInstalledRelease` (`release.go:921`)
+
+```go
+localized = strings.ReplaceAll(localized, "${APP_HOME}",                          finalAppPath.String())
+localized = strings.ReplaceAll(localized, "${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}", cfg.CustomModelsDir().String())
+// ${HOST_IP} intentionally left for run time
+```
+
+### At run — shared with normal apps
+
+`getAppEnvironmentVariables` (`orchestrator.go:253`) sets `APP_HOME` and, crucially,
+`HOST_IP` **fresh** via `helpers.GetHostIP()` (`orchestrator.go:293`). `StartApp` then runs
+`docker compose up` with those env vars (`orchestrator.go:230`), so Docker Compose
+interpolates the `${HOST_IP}` still present in `app-compose.yaml`. The IP thus always
+reflects the *current* board and can change between reboots without re-installing.
+
+---
+
+## 7. Models — the full story
+
+Governing rule: **`install` never downloads a model; the only thing ever pulled from the
+network is containers, and only at `start`.** How each model is provided depends on its
+deployment type, decided in `resolveAppModels` (`release.go:277`) using
+`ModelsIndex.GetModelLocalArtifacts` (`modelsindex/models_index.go:289`).
+
+| Model type | Detection | Release behavior |
+|---|---|---|
+| **Preloaded** | `deployment.pre-loaded: true` (e.g. the EI vision/audio models) | Lives **inside** the version-pinned container image → **not bundled**. Manifest: `preloaded: true`. |
+| **Custom / Edge Impulse** (self-contained folder) | `model.ModelFolderPath` exists | The whole folder is **bundled** under `models/…`. |
+| **Handler-downloaded** (AI Hub / Edge Impulse / Hugging Face) | `deployment.handler` set, not preloaded | Located via the handler's bind volume `${CUSTOM_MODEL_DIR}/${models_repository}` and **bundled** from disk. |
+
+If a required, non-preloaded model cannot be located, `create` **fails** (the release would
+be incomplete) — unless `--no-models`, which records the model in the manifest but leaves
+installing it to the destination.
+
+At install, `restoreBundledModels` (`release.go:845`) copies the bundled files back into the
+destination's custom-models dir (never downloads); the frozen compose references that dir via
+`${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}`, so it resolves wherever the destination keeps its
+models.
+
+### Local LLMs (Qwen3, Gemma via `genie` / `llamacpp`)
+
+On-device LLMs are **the third row above** — they are **not preloaded** and are
+handler-backed, so **their multi-GB weights are bundled into the `.tar.gz`**. Three pieces
+cooperate:
+
+- an `arduino:llm` / `arduino:vlm` brick in the app,
+- a model entry like `genie:qwen3_4b_instruct_2507` (`ai-hub-handler`) or
+  `llamacpp:gemma-4-E2B_q4_0-it` (`hf-handler`), with no `pre-loaded`,
+- a **runner service** merged into the compose: `arduino:genie` (port 9001) or
+  `arduino:llamacpp` (port 9999). The runner container loads the weights from a mounted
+  directory and serves inference over localhost; the brick talks to it.
+
+Weights live on disk under the runner's repository folder:
+`<CustomModelsDir>/genai/…` (genie) or `<CustomModelsDir>/llamacpp/…` (llamacpp), which on a
+board is `/var/lib/arduino-app-cli/models/…`.
+
+Lifecycle for a local LLM:
+- **create**: `GetModelLocalArtifacts` resolves the weights under the repo folder and bundles
+  them into `models/genai|llamacpp/…`; `create` fails fast if they are not already on the
+  source board. The runner's hardcoded mount path is tokenized by the safety-net replace (see
+  [§6](#6-compose-freezing--tokenization)).
+- **install**: weights are copied into the destination's repo folder (no download);
+  `${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}` is localized.
+- **start**: only the **runner container image** is pulled (`--pull missing`); the weights are
+  already on disk. The runner mounts them and serves the model.
+
+**Caveats specific to local LLMs (real, worth knowing):**
+
+1. **Huge archives.** Qwen3-4B ≈ 3 GB, Qwen2.5-VL-7B ≈ 6.5 GB, Gemma-4-E4B ≈ 5.3 GB — all
+   carried inside the tarball.
+2. **Over-bundling.** The "refine to a single model file" step in `GetModelLocalArtifacts`
+   keys on the `model_name` deployment variable
+   (`modelsindex/models_index.go:320`), but genie's weights actually sit in a directory named
+   by `model_directory` (a different string), and llamacpp declares **no `model_name` at
+   all**. So the refine misses and the code bundles the **entire repository folder** — i.e.
+   *every* genie/llamacpp model present on the source board, not just the one the app uses.
+   Not incorrect (the needed model is always included), but bloats the release.
+3. **Relocation relies on the custom-models dir being a prefix** of the runner's hardcoded
+   mount. True board-to-board (both `/var/lib/arduino-app-cli/models`), so it works for the
+   intended use case; fragile if a host overrides `ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR`.
+4. **Board homogeneity.** The runner mounts Qualcomm firmware/NPU devices (`/dev/dma_heap/*`,
+   `/usr/share/qcom`, `/sys/firmware/...`) left literal (correct — identical across boards of
+   the same type). genie/VLM releases are **ventunoq-only**; llamacpp supports unoq+ventunoq.
+
+> **Cloud LLMs** (e.g. the `chatbot-cloud-llm` example) are the opposite case: no local model
+> artifact at all — the app calls a remote API. Nothing is bundled; the only sensitive thing
+> is the API key, handled by the [secrets](#9-secrets) path.
+
+---
+
+## 8. Board compatibility & `--force`
+
+Because a release carries a **prebuilt sketch binary** (FQBN/arch-specific) and
+**arch-specific container images**, it is only valid on a matching board. `create` records
+the source board identity (`board_name`, `fqbn`, `arch`) in the manifest; `InstallRelease`
+enforces it (`release.go:767`):
+
+- If the release's `board_name` differs from the current board's, install **fails** with
+  *"release was built for board X but this board is Y (use --force to override)"*
+  (`ErrIncompatibleRelease`).
+- `--force` (CLI flag) / `?force=true` (HTTP) skips the check and proceeds. `--force` also
+  makes `restoreBundledModels` overwrite existing model artifacts.
+- The check is **skipped** if either side's board name is empty (unknown platform → don't
+  block).
+
+Error surfacing:
+- **CLI** (`cmd/arduino-app-cli/apprelease/install.go`): `ErrIncompatibleRelease` →
+  `feedback.Fatal(..., ErrBadArgument)` (clean message, no stack).
+- **HTTP** (`internal/api/handlers/release_install.go`): `ErrIncompatibleRelease` → **HTTP 409
+  Conflict** with the same message.
+
+**Design note:** only `board_name` is compared, though `fqbn` and `arch` are also recorded.
+For these boards `board_name` (`unoq`/`ventunoq`) maps 1:1 to arch and FQBN, so a name match
+implies an arch match. Tightening to also compare `arch` would be a one-line addition in the
+same `!force` block if ever needed.
+
+---
+
+## 9. Secrets
+
+**Invariant: a release, unlike a model, must never carry credentials.** Brick variables that
+the brick definition flags `secret: true` (API keys, passwords, …) are handled specially so
+the shareable archive contains no secret material.
+
+### At create (default)
+
+1. `scrubAppSecrets` (`release.go:239`) replaces each non-empty secret variable's value in
+   `app.yaml` with a `${NAME}` placeholder and records it under `required_secrets` (name +
+   owning brick). Empty secret variables are left as-is (nothing to hide). Returns the
+   `name → value` map.
+2. The frozen compose is scrubbed in **two passes**:
+   - `scrubComposeSecretKeys` (`release.go:492`) rewrites the env entries **by key** (both the
+     map form `NAME: value` and the list form `- NAME=value`) to `NAME: ${NAME}`.
+   - `scrubComposeSecretValues` (`release.go:518`) then strips any **literal secret value**
+     still present (e.g. a password embedded inside a `postgres://user:pass@host` connection
+     string), longest-value-first so a short secret can't corrupt a longer one. As
+     defense-in-depth it **returns an error and aborts the build** if any secret value still
+     appears afterwards — the release is never written with a leaked secret.
+
+### At install
+
+`writeSecretsTemplate` (`release.go:981`) drops a `data/secrets.env` template (only if the
+release declares secrets and the file doesn't already exist), listing the required keys with
+empty values and a per-key comment naming the owning brick.
+
+### At run (`app start`) — shared by releases and scrubbed exports
+
+`applyReleaseSecrets` (`release.go:1051`):
+- Determines the **authoritative set of required secret names** via `declaredSecretNames`
+  (`release.go:1007`): the union of the release manifest's `required_secrets` and the keys in
+  `data/secrets.env`. This is deliberately *not* "any `${NAME}`-shaped env value", which would
+  misclassify a legitimate non-secret `${FOO}` as a required secret. A placeholder-scan
+  fallback is used **only** when neither a manifest nor a secrets template exists (e.g. a
+  hand-crafted app).
+- Loads `data/secrets.env` (`parseEnvFile`, `release.go:1095`) and injects values into the
+  env, but **only for declared secrets this app actually references and hasn't resolved yet**
+  (value still a `${NAME}` placeholder).
+- Returns the list of **still-missing** secrets. `StartApp` (`orchestrator.go:176`) then
+  **fails fast** — the app does not start with blank credentials — with
+  *"missing required secret(s) …: set them in data/secrets.env"*.
+
+This is a **no-op** for apps with no secret placeholders.
+
+### Escape hatches & related
+
+- `release build --keep-secrets` embeds the values in the release instead (no placeholders,
+  no `required_secrets`). The resulting archive is self-contained but **sensitive**.
+- `app export --scrub-secrets` applies the identical placeholder scrubbing to a plain source
+  export and drops a `data/secrets.env` template into the zip; the re-imported app resolves
+  them at `app start` exactly as a release does. (`ExportAppZip` gained a `scrubSecrets`
+  param.)
+- **Caveat:** secrets still sit in plaintext in `data/secrets.env` on the destination — that
+  is unavoidable without an external secret manager. The guarantee is only that the **release
+  archive** carries no secrets.
+
+---
+
+## 10. Containers
+
+- **Version pinning.** `buildFrozenCompose` runs `docker compose config`, which resolves and
+  flattens all compose includes and pins concrete image references. The pinned images are
+  also listed in the manifest's `images` (via `extractComposeImages`, `release.go:547`) for
+  visibility, though the frozen compose is the authoritative source.
+- **Pre-pulled at install by the "prepare" step (default).** After extraction, `install` runs
+  `PrepareRelease` (`release_prepare.go`) unless `--no-prepare` / `?prepare=false` is given.
+  Prepare reads the installed app's localized compose (`AppComposeFilePath()`), lists the image
+  references (`extractComposeImages`), skips those already present locally
+  (`listImagesAlreadyPulled`) and pulls the rest (`pullImage`, with retry) — exactly the
+  `--pull missing` set `start` would need, but **without launching the app**. It is also
+  available standalone as `release prepare <installed-app>` (CLI) / `POST /v1/apps/{id}/prepare`
+  (HTTP) so a user who skipped it at install can run it later. It never downloads AI models —
+  only containers — since model weights are already on disk from install.
+- **Also pulled at start.** `StartApp` runs
+  `docker compose up -d --remove-orphans --pull missing` (`orchestrator.go:210`). Only images
+  **not already present** are pulled — so after a successful prepare this pulls nothing, and if
+  prepare was skipped or partially failed, start still pulls whatever is missing. Model weights
+  are never pulled here — they are already on disk from install.
+- **Runner containers.** AI runners (python-runner, genie `genai-llm-vlm-service`,
+  `llamacpp-npu-runner`, the models-downloader handler image, etc.) are ordinary services in
+  the frozen compose and are pulled the same way.
+
+---
+
+## 11. Execute — `app start` on a frozen release
+
+There is **no `release start`**. An installed release runs through the normal `StartApp`
+(`orchestrator.go:93`), which branches on `appToStart.IsFrozenRelease()` (true when
+`Descriptor.FrozenRelease != nil`, set by `localizeInstalledRelease`).
+
+`frozenRelease := appToStart.IsFrozenRelease()` (`orchestrator.go:143`) then changes exactly
+three things versus a normal app:
+
+1. **Sketch** (`orchestrator.go:145`): if the app has a sketch, `uploadPrebuiltSketch`
+   (`release.go:1348`) flashes the already-compiled binary from `.cache/sketch` **as-is** (an
+   upload-only step via the arduino-cli RPC server) — it does **not** run
+   `compileUploadSketch`.
+2. **Provisioning** (`orchestrator.go:190`): the frozen branch **skips** `provisioner.App`
+   entirely — the venv is already on disk and the compose is already localized and
+   version-pinned. A normal app would provision (pip) here.
+3. Everything else is **identical** to a normal app:
+   - `getAppEnvironmentVariables` builds the env (including a fresh `HOST_IP`);
+   - `applyReleaseSecrets` resolves `${NAME}` secrets and fails fast on a missing one;
+   - `docker compose up -d --remove-orphans --pull missing` brings the app up.
+
+Because install wrote the standard `.cache/app-compose.yaml`, `app stop`, `app logs`, and
+status all behave exactly as for any app.
+
+> **Linchpin assumption (unverified on hardware):** skipping provisioning relies on the
+> external python-runner image's entrypoint **not** reinstalling deps when the venv already
+> exists in `.cache`. If it always reinstalls, bundling the venv is pointless. Confirm on a
+> board / with the image maintainers.
+
+---
+
+## 12. `clone` — turning a release back into an editable app
+
+`release clone <installed-app> <new-name>` → `CloneApp` with `StripFrozenRelease = true`
+(`orchestrator.go:762`). The clone:
+
+- copies the app tree **excluding `.cache` and `data`** (so it has no prebuilt artifacts),
+- also excludes the release manifest (`ReleaseManifestFileName`) so it is no longer
+  recognized as a release,
+- clears `frozen_release` from the cloned `app.yaml` (`descriptor.FrozenRelease = nil`,
+  `orchestrator.go:849`).
+
+The result is a normal, editable app: its next `app start` **recompiles** the sketch and
+**re-provisions** the venv, exactly like a freshly imported source app. (HTTP:
+`POST /v1/apps/{id}/clone` with `strip_release` in the JSON body.)
+
+---
+
+## 13. Security hardening (extraction)
+
+`extractTarGz` (`release.go`) defends against hostile archives:
+
+- **Tar-slip:** every entry's resolved target must stay within the destination
+  (`strings.HasPrefix(target, destClean)`), else *"illegal file path in release"*.
+- **Malicious symlinks:** a **two-pass** approach. First `collectArchiveNames` gathers all
+  entry names; then, for each symlink:
+  - **relative** targets must resolve **inside** the destination;
+  - **absolute** targets are rejected **only if** another archive entry is nested under the
+    symlink's path (the real tar-slip-via-symlink vector). A bare absolute *leaf* symlink is
+    allowed, because the **Python venv legitimately needs** one
+    (`bin/python -> /usr/local/bin/python` baked into the base image). This was a real bug
+    found during on-board testing and fixed here.
+- **Oversized files:** each regular file is copied through an
+  `io.LimitReader(tr, maxReleaseFileSize+1)` and rejected if it exceeds `maxReleaseFileSize`
+  (zip-bomb / runaway-size guard).
+
+Plus the create-side guard: `scrubComposeSecretValues` aborts the build if any secret value
+survives scrubbing (see [§9](#9-secrets)).
+
+---
+
+## 14. CLI & HTTP surface
+
+**CLI** (`cmd/arduino-app-cli/apprelease/`):
+- `release build <app> <out.tar.gz>` — `--release-number`, `--overwrite`, `--no-models`,
+  `--keep-secrets`.
+- `release install <file.tar.gz>` — `-` reads from stdin; `--force`; `--no-prepare` (skip the
+  default image pre-pull).
+- `release prepare <installed-app>` — pre-pull the app's container images (no start, no model
+  download); the same step `install` runs by default.
+- `release clone <installed-app> <new-name>`.
+- No `release start` (use `app start`).
+
+**HTTP daemon API** (`internal/api/api.go`):
+- `GET  /v1/apps/{id}/release` → builds + streams the `.tar.gz`
+  (`?models=`, `?release_number=`, `?keep_secrets=`); uses `render.EncodeTarGzResponse`.
+- `POST /v1/apps/release/install` → multipart upload install (`?force=`, `?prepare=`
+  [default true; blocks until images are pulled, pull failure is non-fatal]).
+- `POST /v1/apps/{id}/prepare` → pre-pull the installed app's container images (`204` on success).
+- `GET  /v1/apps/{id}/export?scrub_secrets=` → export with placeholder scrubbing.
+- `POST /v1/apps/{id}/clone` with `strip_release` in the body.
+
+OpenAPI: `internal/api/docs/openapi.yaml` (`buildAppRelease` / `installAppRelease` /
+`prepareAppRelease`). The e2e client is generated — after any OpenAPI change run
+`go generate ./internal/e2e/` (or `task generate`).
+
+---
+
+## 15. Known caveats & unverified items
+
+Compiled + unit-tested; **not yet verified on hardware** beyond a `create`/`install` smoke
+test. Open items:
+
+1. **venv-skip linchpin** — depends on the python-runner image not reinstalling deps when the
+   venv exists (see [§11](#11-execute--app-start-on-a-frozen-release)).
+2. **Local-LLM over-bundling** — a Qwen3/Gemma release carries the whole `genai/`/`llamacpp/`
+   repo folder, not just the one model (see [§7](#7-models-the-full-story)). Fix: have
+   `GetModelLocalArtifacts` also match on `model_directory`.
+3. **Compose secret scrub** is regex-on-key + literal-value strip against `docker compose
+   config` output — grep a generated `release-compose.yaml` for known secret values to
+   confirm nothing leaks.
+4. **Handler-model artifact resolution** is derived from `models-handlers.yaml` /
+   `models-list.yaml` conventions — verify it resolves to the right files for a real
+   handler-downloaded model.
+5. **Secrets remain plaintext** in `data/secrets.env` on the destination (expected; the
+   guarantee is only about the archive).
+
+---
+
+### Key files
+
+- `internal/orchestrator/release.go` (+ `release_test.go`) — build/install/clone core,
+  tar/scrub/secrets/localize/models helpers, `ReleaseManifest`/`ReleaseModel`/`ReleaseSecret`.
+- `internal/orchestrator/release_prepare.go` (+ `release_prepare_test.go`) — `PrepareRelease`
+  (pre-pull the app's container images) and the `imagesToPull` helper.
+- `internal/orchestrator/orchestrator.go` — `StartApp` frozen branch; `CloneApp` /
+  `StripFrozenRelease`; `getAppEnvironmentVariables` (`HOST_IP`/`APP_HOME`).
+- `internal/orchestrator/modelsindex/models_index.go` — `GetModelLocalArtifacts`.
+- `internal/orchestrator/archive.go` — `ExportAppZip(..., scrubSecrets)`.
+- `internal/orchestrator/app/parser.go` / `app.go` — `FrozenReleaseInfo`, `IsFrozenRelease()`,
+  release path helpers.
+- `cmd/arduino-app-cli/apprelease/` — CLI commands.
+- `internal/api/handlers/` — `app_release_build.go`, `release_install.go`,
+  `app_release_prepare.go`, `app_clone.go`, `app_export.go`; routes in `internal/api/api.go`;
+  spec in `internal/api/docs/openapi.yaml`.
+- `docs/user-documentation.md` — user-facing "Arduino App Releases" section.

--- a/docs/user-documentation.md
+++ b/docs/user-documentation.md
@@ -66,3 +66,210 @@ Examples of the `assets` and the builtin `examples` stored under the `ARDUINO_AP
 │   │   └── README.md
 │   └── ...
 ```
+
+## Arduino App Releases
+
+An **Arduino App Release** is a self-contained, reproducible `.tar.gz` archive of an app that has already been built, designed to be moved to another board and launched without recompiling the sketch or downloading Python dependencies. Only the required containers are pulled at start.
+
+This is different from `app export`/`app import`, which bundle only the *source* of an app (and deliberately exclude the `.cache` folder). A release instead **also includes the build artifacts** — the compiled sketch binary, the provisioned Python virtual environment and a version-pinned compose file — plus a manifest and any required AI models.
+
+Each release carries a **release number** (set with `--release-number`, or a `YYYYMMDDhhmmss` timestamp by default). Once **installed**, a release becomes a *regular app*: it is flagged as a release in its `app.yaml` (with the release number) and launched with the ordinary `app start` command — there is no separate "run release" command. Because it is flagged, the run command flashes the prebuilt sketch and uses the frozen compose instead of recompiling or re-provisioning.
+
+### What's inside a release
+
+A release is a gzip-compressed tar archive containing a single root folder named after the app (lowercased, spaces replaced with `-`). Its layout:
+
+```
+my-app.tar.gz
+└── my-app/                           # release root (sanitized app name)
+    ├── arduino-app-release.yaml      # release manifest (provenance, compatibility, models)
+    ├── app.yaml                      # app descriptor (secret values scrubbed by default)
+    ├── README.md                     # optional, if present in the app
+    ├── python/                       # user Python code
+    │   ├── main.py
+    │   └── requirements.txt          # optional
+    ├── sketch/                       # user sketch sources (if the app has a sketch)
+    │   ├── sketch.ino
+    │   └── sketch.yaml
+    ├── bricks/                       # optional app-local (custom) bricks
+    ├── .cache/                       # build artifacts (normally volatile, shipped here)
+    │   ├── release-compose.yaml      # flattened, version-pinned, relocatable compose
+    │   ├── sketch/                   # prebuilt sketch binary (flashed as-is, no recompile)
+    │   └── <venv>/                   # provisioned Python virtualenv (pip is not re-run)
+    └── models/                       # bundled AI model artifacts (only if the app needs them)
+        └── <repository>/<files>      # mirrors the layout under the custom-models dir
+```
+
+What each part is for:
+
+- **`app.yaml`, `README.md`, `python/`, `sketch/`, `bricks/`** — the app as authored, except that secret brick variables in `app.yaml` are scrubbed to `${NAME}` placeholders by default (see [Secrets](#secrets)).
+- **`.cache/sketch/`** — the already-compiled microcontroller binary. On start it is flashed directly; the sketch is never recompiled.
+- **`.cache/<venv>/`** — the provisioned Python virtual environment. Because it runs inside the container at a fixed mount point, it is portable; Python dependencies are not re-installed on the destination.
+- **`.cache/release-compose.yaml`** — a single self-contained compose file produced by flattening the app's generated compose and pinning concrete container image versions. Host-specific values are tokenized so the file is relocatable: `${APP_HOME}` (app folder), `${HOST_IP}`, and `${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}` (models dir). On install it is **localized** to the destination and written as the standard `.cache/app-compose.yaml` (the app path and models dir are resolved; `${HOST_IP}` is left for the run command to fill, exactly as for a normal app).
+- **`models/`** — bundled AI model files, present only when the app references non-preloaded models (see [AI models](#ai-models)).
+- **`arduino-app-release.yaml`** — the manifest (see below).
+
+#### The manifest (`arduino-app-release.yaml`)
+
+The manifest records provenance and compatibility, and is what marks an installed app as release-managed. Example:
+
+```yaml
+format_version: "1.0"
+app_name: Smart Garden Pro
+release: "20260627100000"        # --release-number, or a timestamp by default
+created_at: 2026-06-27T10:00:00Z
+source_cli_version: 1.2.3
+runner_version: 0.11.0rc6
+python_image: ghcr.io/arduino/app-bricks/python-apps-base:0.11.0rc6
+board_name: unoq                 # board the release was built for
+fqbn: arduino:zephyr:unoq
+arch: arm64
+images:                          # all container images referenced by the frozen compose
+  - ghcr.io/arduino/app-bricks/python-apps-base:0.11.0rc6
+  - ghcr.io/arduino/app-bricks/object-detection:1.4.0
+models:                          # AI models required by the app and how they are provided
+  - id: "ei:efficientnet-b4"
+    name: General purpose object classification - EfficientNet-B4
+    runner: brick
+    preloaded: false             # false => its files are bundled below
+    bundled: true
+    paths:                       # artifact paths, relative to the custom-models dir
+      - edge-impulse/efficientnet-b4-qnn.eim
+required_secrets:                # secret variables to provide on the destination (values NOT in release)
+  - name: DB_PASSWORD
+    brick: arduino:dbstorage
+```
+
+Field reference:
+
+| Field | Meaning | Used at runtime? |
+| ----- | ------- | ---------------- |
+| `format_version` | Version of the release format itself. | informational |
+| `app_name` | Human-readable app name. | cosmetic (shown by `install`) |
+| `release` | The release release number (from `--release-number`, or a `YYYYMMDDhhmmss` timestamp). Stamped into the installed app's `app.yaml`. | ✅ |
+| `created_at` | Build timestamp (UTC). | informational |
+| `source_cli_version` | Version of `arduino-app-cli` that built the release. | informational |
+| `runner_version` | The app-bricks **runner generation** that produced the bricks/models and the Python base image (e.g. `0.11.0rc6`). | informational |
+| `python_image` | The base image of the **main Python container** — the one the bundled venv runs inside and is ABI-tied to. | informational |
+| `board_name` / `fqbn` / `arch` | The board the release was built for. | ✅ compatibility check |
+| `images` | The **complete** list of every container image referenced by the frozen compose (the Python base image **plus** all brick and service images). | informational |
+| `models` | The AI models the app requires and how each is provided (`preloaded`, `bundled`, and bundled `paths`). | ✅ model restore |
+| `required_secrets` | Secret variables (name + owning brick) whose values are **not** in the release and must be supplied on the destination. | ✅ secrets template + run-time check |
+
+**On the apparent overlap between `images`, `python_image` and `runner_version`:** the **frozen compose is the single source of truth** for which containers are pulled and run — at start the runtime only reads the compose (`docker compose up --pull missing`). The manifest's `images`, `python_image` and `runner_version` are **provenance metadata and are not read at runtime**; they exist so a person or tool can answer questions without parsing the compose:
+
+- `images` — *"everything this release needs to pull"* (an unlabeled flat list).
+- `python_image` — *"which single image is THE Python runtime"*. It also appears inside `images`, but is called out separately because the bundled venv only works with that exact image, so it is the most important one to identify. 
+- `runner_version` — *"which app-bricks generation built this"*. It usually matches the tag in `python_image`, but can differ when a custom Python base image is used (`DOCKER_PYTHON_BASE_IMAGE`), which is why both are recorded.
+
+Only `release`, `board_name`/`fqbn`/`arch` and `models` affect what `install`/`start` actually do; the rest is for inspection and auditing.
+
+On install, `board_name`/`fqbn`/`arch` are checked against the destination board (override with `--force`).
+
+#### What's excluded
+
+- The **`data/`** folder (user/runtime data — may contain personal data).
+- The host-specific generated compose files **`.cache/app-compose.yaml`** and **`.cache/app-compose-overrides.yaml`** (they bake absolute host paths and are superseded by `release-compose.yaml`).
+
+> **Security note:** by default a release contains **no secrets** — secret brick variables are scrubbed (see [Secrets](#secrets)). If you build with `--keep-secrets`, the values are embedded in `app.yaml` and the frozen compose; treat such an archive as sensitive.
+
+### Where things land on install — and how it runs afterwards
+
+`release install` extracts the release into the apps directory and restores bundled models into the custom-models dir. During install it also **localizes** the app: it produces `.cache/app-compose.yaml` from the frozen compose and stamps the release metadata into `app.yaml`.
+
+```
+$ARDUINO_APP_CLI__APPS_DIR/
+└── my-app/
+    ├── app.yaml                      # now carries: frozen_release: { number: "<number>" }
+    ├── arduino-app-release.yaml      # the manifest, preserved next to app.yaml
+    ├── python/  sketch/  ...
+    └── .cache/
+        ├── app-compose.yaml          # localized, version-pinned compose (HOST_IP left dynamic)
+        ├── sketch/                   # prebuilt binary
+        └── <venv>/
+
+$ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR/
+└── <repository>/<files>             # restored from the release's models/ folder
+```
+
+From here the app is **a regular app**: it shows up in `app list` and is launched, stopped and inspected with the ordinary commands:
+
+```sh
+arduino-app-cli app start my-app     # flashes the prebuilt binary, brings up the frozen compose
+arduino-app-cli app stop my-app
+```
+
+Because `app.yaml` is flagged as a release, `app start` takes the release path instead of the normal build path:
+
+- **Sketch:** the prebuilt binary from `.cache/sketch/` is flashed to the microcontroller as-is (an upload-only step) — it is **not** recompiled.
+- **Python:** the on-disk venv and the localized `.cache/app-compose.yaml` are used directly — the environment is **not** re-provisioned and dependencies are **not** re-installed.
+- **Containers:** only missing images are pulled (`--pull missing`).
+
+Everything else (`app stop`, `app logs`, status) behaves exactly as for a normal app. (To get a normal, editable app back, use `release clone`, described below.)
+
+### AI models
+
+Required AI models are made part of the release at **create** time, so that installing it never downloads a model — the only thing ever pulled from the network is containers (at `start`).
+
+- **Preloaded models** (baked into a brick/base image) ride along with the version-pinned container — nothing extra to bundle.
+- **Every other required model** (custom / Edge Impulse models and handler-downloaded models such as those from AI Hub, Edge Impulse or Hugging Face) is **bundled into the `.tar.gz`** from its on-disk files under the custom-models dir (`ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR`). `install` restores them into the destination's custom-models dir — it only copies from the archive, it never downloads.
+
+`release build` fails if a required, non-preloaded model is not installed / its files cannot be located (the release would otherwise be incomplete) — install it first, or pass `--no-models` to deliberately exclude models and install them on the destination yourself.
+
+On install, a bundled model artifact that already exists on the destination is kept as-is (use `--force` to overwrite). The frozen compose references the models dir via a `${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}` placeholder, so it resolves correctly wherever the destination keeps its models.
+
+### Secrets
+
+A release, unlike a model, must **never** carry credentials. Brick variables that the brick definition flags as `secret: true` (API keys, passwords, …) are handled specially so the shareable archive contains no secret material.
+
+**At create (default):** every secret variable that has a value is **scrubbed** — its value is replaced with a `${NAME}` env-variable placeholder in both `app.yaml` and the frozen compose, and the secret is recorded (name + owning brick) under `required_secrets` in the manifest. The value itself is **not** written anywhere in the release. (Empty secret variables are left as-is — there is nothing to hide.)
+
+**At install:** a template is written to the app's **`data/secrets.env`** (only if it doesn't already exist), listing the required keys with empty values, e.g.:
+
+```
+# Secrets required by this Arduino App Release.
+# Fill in the values below, then start the app.
+# required by brick arduino:dbstorage
+DB_PASSWORD=
+```
+
+`data/` is the reserved per-app data folder — it is excluded from releases and exports, so the values you put there stay on the machine and are never re-released.
+
+**At run (`app start`):** the values in `data/secrets.env` are loaded and injected into the environment so the `${NAME}` placeholders in the compose resolve. If any required secret is missing or empty, `app start` **fails fast** with a clear message naming the missing keys — the app does not start with blank credentials.
+
+**Escape hatch:** `release build --keep-secrets` embeds the secret values in the release instead of scrubbing them (no `${NAME}` placeholders, no `required_secrets`). The resulting archive is self-contained but **sensitive** — only use it for trusted, private transfers.
+
+> The secret values still live in plaintext in `data/secrets.env` on the destination (that is unavoidable without an external secret manager); the guarantee is only that the **release** carries no secrets.
+
+**Same mechanism for `app export`:** `app export --scrub-secrets` applies the identical placeholder scrubbing to a plain source export (instead of the default behavior, which empties secret values). The exported zip then carries a `data/secrets.env` template, and the re-imported app — once its secrets are filled in — resolves them at `app start` exactly as a release does. (Without `--scrub-secrets`, `app export` keeps emptying secret values as before.)
+
+### Commands
+
+| Command | Description |
+| ------- | ----------- |
+| `arduino-app-cli release build <app_path> <output.tar.gz>` | Build a release from a **pre-built** app. The app must have been started at least once (the command never compiles the sketch nor provisions the venv). Required on-disk AI models are bundled; secrets are scrubbed. Flags: `--release-number <n>` (default: `YYYYMMDDhhmmss`), `--overwrite`, `--no-models`, `--keep-secrets`. |
+| `arduino-app-cli release install <release.tar.gz>` | Install a release into the apps directory; bundled models are restored into the custom-models dir and the app is flagged as a release in `app.yaml`. By default it then **prepares** the app (pre-pulls its container images) so the first `app start` needs no network. Afterwards run it with `app start`. Use `-` to read from stdin, `--force` to install a release built for a different board / overwrite existing models, and `--no-prepare` to skip the image pre-pull (run `release prepare` later). |
+| `arduino-app-cli release prepare <release_app>` | Pre-pull the container images the installed app needs (per its compose file) so a later `app start` finds them locally. The app is **not** started and no AI models are downloaded (only containers). This is the same step `install` runs by default; use it after `--no-prepare`, or to re-pull. |
+| `arduino-app-cli release clone <release_app> <new_app_name>` | Create a new **editable** app from an installed release: removes the prebuilt artifacts, the manifest and the release flag, so the next `app start` recompiles and re-provisions normally. |
+
+> There is no `release start` command. An installed release is launched with the regular `app start` (and stopped with `app stop`).
+
+### Typical workflow
+
+```sh
+# On the source board (app already started at least once):
+arduino-app-cli app start my-app
+arduino-app-cli release build my-app my-app.tar.gz --release-number 1.2.0
+
+# On the destination board:
+arduino-app-cli release install my-app.tar.gz   # extracts + pre-pulls container images
+arduino-app-cli app start my-app            # runs as a release: no recompile, no pip
+
+# ...or split the image pull from the install:
+arduino-app-cli release install my-app.tar.gz --no-prepare
+arduino-app-cli release prepare my-app          # pre-pull images later (no start)
+
+# To turn it back into an editable app:
+arduino-app-cli release clone my-app my-app-dev
+arduino-app-cli app start my-app-dev        # recompiles + re-provisions as usual
+```

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -80,6 +80,10 @@ func NewHTTPRouter(
 	mux.Handle("DELETE /v1/apps/{appID}", handlers.HandleAppDelete(dockerClient, idProvider, platform))
 	mux.Handle("GET /v1/apps/{appID}/export", handlers.HandleAppExport(cfg, idProvider, bricksIndex))
 	mux.Handle("POST /v1/apps/import", handlers.HandleAppImport(cfg, idProvider))
+
+	mux.Handle("GET /v1/apps/{appID}/release", handlers.HandleAppReleaseBuild(bricksIndex, modelsIndex, idProvider, cfg, platform, version))
+	mux.Handle("POST /v1/apps/release/install", handlers.HandleReleaseInstall(dockerClient, cfg, idProvider, bricksIndex, modelsIndex, platform))
+	mux.Handle("POST /v1/apps/{appID}/prepare", handlers.HandleAppReleasePrepare(dockerClient, idProvider))
 	mux.Handle("GET /v1/apps/{appID}/exposed-ports", handlers.HandleAppPorts(bricksIndex, idProvider))
 	mux.Handle("PUT /v1/apps/{appID}/sketch/libraries/{libRef}", handlers.HandleSketchAddLibrary(idProvider))
 	mux.Handle("DELETE /v1/apps/{appID}/sketch/libraries/{libRef}", handlers.HandleSketchRemoveLibrary(idProvider))

--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -621,6 +621,14 @@ paths:
           description: If true, the exported archive will include the 'data' directory.
             Default is false.
           type: boolean
+      - description: If true, replace secret variable values with ${NAME} placeholders (and
+          add a data/secrets.env template) instead of emptying them. Default is false.
+        in: query
+        name: scrub_secrets
+        schema:
+          description: If true, replace secret variable values with ${NAME} placeholders (and
+            add a data/secrets.env template) instead of emptying them. Default is false.
+          type: boolean
       responses:
         "200":
           content:
@@ -636,6 +644,62 @@ paths:
         "500":
           $ref: '#/components/responses/InternalServerError'
       summary: Exports an app as ZIP
+      tags:
+      - Application
+  /v1/apps/{id}/release:
+    get:
+      description: Builds a reproducible Arduino App Release (.tar.gz) from a pre-built
+        app and streams it back. The app must have been started at least once; the sketch
+        is not recompiled nor the Python environment provisioned. Required on-disk AI
+        models are bundled unless 'models' is false.
+      operationId: buildAppRelease
+      parameters:
+      - description: application identifier.
+        in: path
+        name: id
+        required: true
+        schema:
+          description: application identifier.
+          type: string
+      - description: If false, do not bundle required AI models. Default is true.
+        in: query
+        name: models
+        schema:
+          description: If false, do not bundle required AI models. Default is true.
+          type: boolean
+      - description: Release number to record in the release manifest. Defaults to the
+          current timestamp (YYYYMMDDhhmmss).
+        in: query
+        name: release_number
+        schema:
+          description: Release number to record in the release manifest. Defaults to the
+            current timestamp (YYYYMMDDhhmmss).
+          type: string
+      - description: If true, embed secret variable values in the release instead of scrubbing
+          them (sensitive). Default is false.
+        in: query
+        name: keep_secrets
+        schema:
+          description: If true, embed secret variable values in the release instead of
+            scrubbing them (sensitive). Default is false.
+          type: boolean
+      responses:
+        "200":
+          content:
+            application/gzip:
+              schema:
+                format: binary
+                type: string
+          description: The .tar.gz Arduino App Release.
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "412":
+          $ref: '#/components/responses/PreconditionFailed'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: Build and download an Arduino App Release
       tags:
       - Application
   /v1/apps/{id}/logs:
@@ -843,6 +907,90 @@ paths:
         "500":
           $ref: '#/components/responses/InternalServerError'
       summary: Imports an app from ZIP
+      tags:
+      - Application
+  /v1/apps/release/install:
+    post:
+      description: Installs an Arduino App Release (.tar.gz) into the apps directory,
+        ready to be started. Validates board compatibility against the current board
+        unless 'force' is set. Unless 'prepare' is false, it also pre-pulls the app's
+        container images before responding (this blocks until the pull completes); a pull
+        failure does not fail the install.
+      operationId: installAppRelease
+      parameters:
+      - description: If true, install even if the release targets a different board, and
+          overwrite bundled models that already exist on the destination.
+        in: query
+        name: force
+        schema:
+          description: If true, install even if the release targets a different board, and
+            overwrite bundled models that already exist on the destination.
+          type: boolean
+      - description: If false, skip pre-pulling the app's container images. Default is true.
+        in: query
+        name: prepare
+        schema:
+          description: If false, skip pre-pulling the app's container images. Default is true.
+          type: boolean
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                file:
+                  description: The .tar.gz Arduino App Release to install.
+                  format: binary
+                  type: string
+              type: object
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                properties:
+                  app_name:
+                    description: The name of the installed application.
+                    type: string
+                  id:
+                    description: The Base64 encoded identifier of the installed application.
+                    type: string
+                type: object
+          description: Release installed successfully.
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "409":
+          $ref: '#/components/responses/Conflict'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: Install an Arduino App Release
+      tags:
+      - Application
+  /v1/apps/{id}/prepare:
+    post:
+      description: Pre-pulls the container images the installed app needs (per its compose
+        file) so that a subsequent start finds them locally. The app is not started and no
+        AI models are downloaded; images already present locally are skipped.
+      operationId: prepareAppRelease
+      parameters:
+      - description: application identifier.
+        in: path
+        name: id
+        required: true
+        schema:
+          description: application identifier.
+          type: string
+      responses:
+        "204":
+          description: The container images are present locally.
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "412":
+          $ref: '#/components/responses/PreconditionFailed'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+      summary: Pre-pull an installed app's container images
       tags:
       - Application
   /v1/bricks:
@@ -1750,6 +1898,11 @@ components:
           example: My Awesome App
           nullable: true
           type: string
+        strip_release:
+          description: Clone a release-installed app as a regular editable app (drops the
+            release manifest and the frozen_release metadata in app.yaml, so the clone is recompiled
+            and re-provisioned on the next start).
+          type: boolean
       type: object
     CodeExample:
       properties:

--- a/internal/api/handlers/app_clone.go
+++ b/internal/api/handlers/app_clone.go
@@ -24,6 +24,10 @@ import (
 type CloneRequest struct {
 	Name *string `json:"name" description:"application name" example:"My Awesome App"`
 	Icon *string `json:"icon" description:"application icon"`
+	// StripFrozenRelease turns a release-installed app back into a live, editable app: the
+	// release manifest and the frozen_release metadata in app.yaml are dropped so the clone is
+	// recompiled and re-provisioned on the next start.
+	StripFrozenRelease bool `json:"strip_release,omitempty" description:"clone a release-installed app as a regular editable app"`
 }
 
 func HandleAppClone(
@@ -56,9 +60,10 @@ func HandleAppClone(
 		}
 
 		res, err := orchestrator.CloneApp(r.Context(), orchestrator.CloneAppRequest{
-			FromID: id,
-			Name:   req.Name,
-			Icon:   req.Icon,
+			FromID:             id,
+			Name:               req.Name,
+			Icon:               req.Icon,
+			StripFrozenRelease: req.StripFrozenRelease,
 		}, idProvider, cfg)
 		if err != nil {
 			if errors.Is(err, orchestrator.ErrAppAlreadyExists) {

--- a/internal/api/handlers/app_export.go
+++ b/internal/api/handlers/app_export.go
@@ -55,7 +55,19 @@ func HandleAppExport(
 			}
 		}
 
-		zipBytes, fileName, err := orchestrator.ExportAppZip(r.Context(), bricksIndex, appToExport, includeData)
+		scrubSecrets := false
+		if val := r.URL.Query().Get("scrub_secrets"); val != "" {
+			var err error
+			scrubSecrets, err = strconv.ParseBool(val)
+			if err != nil {
+				render.EncodeResponse(w, http.StatusBadRequest, models.ErrorResponse{
+					Details: "The parameter 'scrub_secrets' must be a boolean.",
+				})
+				return
+			}
+		}
+
+		zipBytes, fileName, err := orchestrator.ExportAppZip(r.Context(), bricksIndex, appToExport, includeData, scrubSecrets)
 		if err != nil {
 			slog.Error("failed to export app", "app_id", id.String(), "error", err)
 			render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{

--- a/internal/api/handlers/app_release_build.go
+++ b/internal/api/handlers/app_release_build.go
@@ -1,0 +1,119 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/arduino/go-paths-helper"
+
+	"github.com/arduino/arduino-app-cli/internal/api/models"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
+	"github.com/arduino/arduino-app-cli/internal/platform"
+	"github.com/arduino/arduino-app-cli/internal/render"
+)
+
+// HandleAppReleaseBuild builds a reproducible Arduino App Release from a pre-built app and
+// streams it back as a .tar.gz download.
+func HandleAppReleaseBuild(
+	bricksIndex *bricksindex.BricksIndex,
+	modelsIndex *modelsindex.ModelsIndex,
+	idProvider *app.IDProvider,
+	cfg config.Configuration,
+	plat platform.Platform,
+	version string,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, err := idProvider.IDFromBase64(r.PathValue("appID"))
+		if err != nil {
+			render.EncodeResponse(w, http.StatusPreconditionFailed, models.ErrorResponse{Details: fmt.Sprintf("invalid id: %s", err.Error())})
+			return
+		}
+
+		appToRelease, err := app.Load(id.ToPath())
+		if err != nil {
+			slog.Error("Unable to load the app", "error", err.Error(), "path", id.String())
+			if errors.Is(err, os.ErrNotExist) {
+				render.EncodeResponse(w, http.StatusNotFound, models.ErrorResponse{Details: err.Error()})
+			} else {
+				render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{Details: err.Error()})
+			}
+			return
+		}
+
+		tempFile, err := paths.MkTempFile(nil, "app-release-*.tar.gz")
+		if err != nil {
+			slog.Error("unable to create temp file", "err", err)
+			render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{Details: "internal server error"})
+			return
+		}
+		tempFile.Close()
+		tempFilePath := paths.New(tempFile.Name())
+		defer func() { _ = tempFilePath.Remove() }()
+
+		includeModels := true
+		if val := r.URL.Query().Get("models"); val != "" {
+			parsed, err := strconv.ParseBool(val)
+			if err != nil {
+				render.EncodeResponse(w, http.StatusBadRequest, models.ErrorResponse{Details: "The parameter 'models' must be a boolean."})
+				return
+			}
+			includeModels = parsed
+		}
+
+		releaseNumber := r.URL.Query().Get("release_number")
+
+		keepSecrets := false
+		if val := r.URL.Query().Get("keep_secrets"); val != "" {
+			parsed, err := strconv.ParseBool(val)
+			if err != nil {
+				render.EncodeResponse(w, http.StatusBadRequest, models.ErrorResponse{Details: "The parameter 'keep_secrets' must be a boolean."})
+				return
+			}
+			keepSecrets = parsed
+		}
+
+		if err := orchestrator.BuildRelease(r.Context(), bricksIndex, modelsIndex, appToRelease, cfg, plat, version, releaseNumber, tempFilePath, includeModels, keepSecrets, nil); err != nil {
+			slog.Error("failed to build release", "app_id", id.String(), "error", err)
+			if errors.Is(err, orchestrator.ErrBadRequest) {
+				render.EncodeResponse(w, http.StatusBadRequest, models.ErrorResponse{Details: err.Error()})
+			} else {
+				render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{Details: "failed to build release"})
+			}
+			return
+		}
+
+		f, err := os.Open(tempFilePath.String())
+		if err != nil {
+			slog.Error("failed to open generated release", "error", err)
+			render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{Details: "failed to read generated release"})
+			return
+		}
+		defer f.Close()
+
+		// Stream the archive back rather than buffering the whole file (releases can bundle
+		// hundreds of MB of AI models, which would risk OOM on the device serving the API).
+		render.EncodeTarGzStream(w, http.StatusOK, f, releaseDownloadName(appToRelease.Name))
+	}
+}
+
+func releaseDownloadName(appName string) string {
+	name := strings.ToLower(strings.ReplaceAll(appName, " ", "-"))
+	if name == "" {
+		name = "app-release"
+	}
+	return name + ".tar.gz"
+}

--- a/internal/api/handlers/app_release_prepare.go
+++ b/internal/api/handlers/app_release_prepare.go
@@ -1,0 +1,59 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/docker/cli/cli/command"
+
+	"github.com/arduino/arduino-app-cli/internal/api/models"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/render"
+)
+
+// HandleAppReleasePrepare pre-pulls the container images an installed app needs so that a
+// subsequent start finds them locally. It does not start the app and never downloads models.
+func HandleAppReleasePrepare(
+	dockerClient command.Cli,
+	idProvider *app.IDProvider,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, err := idProvider.IDFromBase64(r.PathValue("appID"))
+		if err != nil {
+			render.EncodeResponse(w, http.StatusPreconditionFailed, models.ErrorResponse{Details: fmt.Sprintf("invalid id: %s", err.Error())})
+			return
+		}
+
+		appToPrepare, err := app.Load(id.ToPath())
+		if err != nil {
+			slog.Error("unable to load the app", "error", err.Error(), "path", id.String())
+			if errors.Is(err, os.ErrNotExist) {
+				render.EncodeResponse(w, http.StatusNotFound, models.ErrorResponse{Details: err.Error()})
+			} else {
+				render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{Details: err.Error()})
+			}
+			return
+		}
+
+		if err := orchestrator.PrepareRelease(r.Context(), appToPrepare, dockerClient, func(orchestrator.StreamMessage) {}); err != nil {
+			slog.Error("failed to prepare container images", "app_id", id.String(), "error", err)
+			if errors.Is(err, orchestrator.ErrBadRequest) {
+				render.EncodeResponse(w, http.StatusBadRequest, models.ErrorResponse{Details: err.Error()})
+			} else {
+				render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{Details: "failed to prepare container images"})
+			}
+			return
+		}
+
+		render.EncodeResponse(w, http.StatusNoContent, nil)
+	}
+}

--- a/internal/api/handlers/release_install.go
+++ b/internal/api/handlers/release_install.go
@@ -1,0 +1,123 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package handlers
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/arduino/go-paths-helper"
+	"github.com/docker/cli/cli/command"
+
+	"github.com/arduino/arduino-app-cli/internal/api/models"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
+	"github.com/arduino/arduino-app-cli/internal/platform"
+	"github.com/arduino/arduino-app-cli/internal/render"
+)
+
+type ReleaseInstallResponse struct {
+	ID      string `json:"id"`
+	AppName string `json:"app_name,omitempty"`
+}
+
+// HandleReleaseInstall installs an uploaded Arduino App Release (.tar.gz) into the apps
+// directory, ready to be launched with the app start endpoint. Unless 'prepare' is false,
+// it also pre-pulls the app's container images (this blocks until the pull completes).
+func HandleReleaseInstall(
+	dockerClient command.Cli,
+	cfg config.Configuration,
+	idProvider *app.IDProvider,
+	bricksIndex *bricksindex.BricksIndex,
+	modelsIndex *modelsindex.ModelsIndex,
+	plat platform.Platform,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		force := false
+		if val := r.URL.Query().Get("force"); val != "" {
+			parsed, err := strconv.ParseBool(val)
+			if err != nil {
+				render.EncodeResponse(w, http.StatusBadRequest, models.ErrorResponse{Details: "The parameter 'force' must be a boolean."})
+				return
+			}
+			force = parsed
+		}
+
+		prepare := true
+		if val := r.URL.Query().Get("prepare"); val != "" {
+			parsed, err := strconv.ParseBool(val)
+			if err != nil {
+				render.EncodeResponse(w, http.StatusBadRequest, models.ErrorResponse{Details: "The parameter 'prepare' must be a boolean."})
+				return
+			}
+			prepare = parsed
+		}
+
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			slog.Error("missing file parameter", "err", err)
+			render.EncodeResponse(w, http.StatusBadRequest, models.ErrorResponse{Details: "missing required file parameter"})
+			return
+		}
+		defer file.Close()
+
+		tempFile, err := paths.MkTempFile(nil, "app-release-install-*.tar.gz")
+		if err != nil {
+			slog.Error("unable to create temp file", "err", err)
+			render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{Details: "internal server error"})
+			return
+		}
+
+		tempFilePath := paths.NewFromFile(tempFile)
+		defer func() { _ = tempFilePath.Remove() }()
+
+		if _, err := io.Copy(tempFile, file); err != nil {
+			tempFile.Close()
+			slog.Error("unable to save upload to temp file", "err", err)
+			render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{Details: "failed to save uploaded file"})
+			return
+		}
+		tempFile.Close()
+
+		appID, manifest, err := orchestrator.InstallRelease(r.Context(), cfg, tempFilePath, idProvider, bricksIndex, modelsIndex, plat, force)
+		if err != nil {
+			slog.Error("release install failed", "file", header.Filename, "err", err)
+			switch {
+			case errors.Is(err, orchestrator.ErrIncompatibleRelease):
+				render.EncodeResponse(w, http.StatusConflict, models.ErrorResponse{Details: err.Error()})
+			case errors.Is(err, orchestrator.ErrAppAlreadyExists):
+				render.EncodeResponse(w, http.StatusConflict, models.ErrorResponse{Details: err.Error()})
+			case errors.Is(err, orchestrator.ErrBadRequest):
+				render.EncodeResponse(w, http.StatusBadRequest, models.ErrorResponse{Details: err.Error()})
+			default:
+				render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{Details: "failed to process the release: " + err.Error()})
+			}
+			return
+		}
+
+		// Install is committed on disk. Pre-pulling images is best-effort: a failure here must
+		// not fail the install (images will be pulled on first start, or via the prepare endpoint).
+		if prepare {
+			if installedApp, loadErr := app.Load(appID.ToPath()); loadErr != nil {
+				slog.Warn("release installed but could not load it to prepare images", "app_id", appID.String(), "err", loadErr)
+			} else if prepErr := orchestrator.PrepareRelease(r.Context(), installedApp, dockerClient, func(orchestrator.StreamMessage) {}); prepErr != nil {
+				slog.Warn("release installed but preparing container images failed", "app_id", appID.String(), "err", prepErr)
+			}
+		}
+
+		resp := ReleaseInstallResponse{ID: appID.String()}
+		if manifest != nil {
+			resp.AppName = manifest.AppName
+		}
+		render.EncodeResponse(w, http.StatusCreated, resp)
+	}
+}

--- a/internal/e2e/client/client.gen.go
+++ b/internal/e2e/client/client.gen.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/oapi-codegen/runtime"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
 // Defines values for ModelStatus.
@@ -310,6 +311,9 @@ type CloneRequest struct {
 
 	// Name application name
 	Name *string `json:"name,omitempty"`
+
+	// StripRelease Clone a release-installed app as a regular editable app (drops the release manifest and the frozen_release metadata in app.yaml, so the clone is recompiled and re-provisioned on the next start).
+	StripRelease *bool `json:"strip_release,omitempty"`
 }
 
 // CodeExample defines model for CodeExample.
@@ -535,6 +539,21 @@ type ImportAppParams struct {
 	File *string `form:"file,omitempty" json:"file,omitempty"`
 }
 
+// InstallAppReleaseMultipartBody defines parameters for InstallAppRelease.
+type InstallAppReleaseMultipartBody struct {
+	// File The .tar.gz Arduino App Release to install.
+	File *openapi_types.File `json:"file,omitempty"`
+}
+
+// InstallAppReleaseParams defines parameters for InstallAppRelease.
+type InstallAppReleaseParams struct {
+	// Force If true, install even if the release targets a different board, and overwrite bundled models that already exist on the destination.
+	Force *bool `form:"force,omitempty" json:"force,omitempty"`
+
+	// Prepare If false, skip pre-pulling the app's container images. Default is true.
+	Prepare *bool `form:"prepare,omitempty" json:"prepare,omitempty"`
+}
+
 // AppSketchRemoveLibraryParams defines parameters for AppSketchRemoveLibrary.
 type AppSketchRemoveLibraryParams struct {
 	// RemoveDeps if set to "true", the library's dependencies will be removed as well if not needed anymore.
@@ -551,6 +570,9 @@ type AppSketchAddLibraryParams struct {
 type ExportAppParams struct {
 	// IncludeData If true, the exported archive will include the 'data' directory. Default is false.
 	IncludeData *bool `form:"include_data,omitempty" json:"include_data,omitempty"`
+
+	// ScrubSecrets If true, replace secret variable values with ${NAME} placeholders (and add a data/secrets.env template) instead of emptying them. Default is false.
+	ScrubSecrets *bool `form:"scrub_secrets,omitempty" json:"scrub_secrets,omitempty"`
 }
 
 // GetAppLogsParams defines parameters for GetAppLogs.
@@ -558,6 +580,18 @@ type GetAppLogsParams struct {
 	Filter   *string `form:"filter,omitempty" json:"filter,omitempty"`
 	Tail     *int    `form:"tail,omitempty" json:"tail,omitempty"`
 	Nofollow *bool   `form:"nofollow,omitempty" json:"nofollow,omitempty"`
+}
+
+// BuildAppReleaseParams defines parameters for BuildAppRelease.
+type BuildAppReleaseParams struct {
+	// Models If false, do not bundle required AI models. Default is true.
+	Models *bool `form:"models,omitempty" json:"models,omitempty"`
+
+	// ReleaseNumber Release number to record in the release manifest. Defaults to the current timestamp (YYYYMMDDhhmmss).
+	ReleaseNumber *string `form:"release_number,omitempty" json:"release_number,omitempty"`
+
+	// KeepSecrets If true, embed secret variable values in the release instead of scrubbing them (sensitive). Default is false.
+	KeepSecrets *bool `form:"keep_secrets,omitempty" json:"keep_secrets,omitempty"`
 }
 
 // StartAppParams defines parameters for StartApp.
@@ -634,6 +668,9 @@ type CreateAppJSONRequestBody = CreateAppRequest
 
 // ImportAppFormdataRequestBody defines body for ImportApp for application/x-www-form-urlencoded ContentType.
 type ImportAppFormdataRequestBody ImportAppFormdataBody
+
+// InstallAppReleaseMultipartRequestBody defines body for InstallAppRelease for multipart/form-data ContentType.
+type InstallAppReleaseMultipartRequestBody InstallAppReleaseMultipartBody
 
 // CreateAppLocalBrickJSONRequestBody defines body for CreateAppLocalBrick for application/json ContentType.
 type CreateAppLocalBrickJSONRequestBody = AppLocalBrickCreateRequest
@@ -748,6 +785,9 @@ type ClientInterface interface {
 
 	ImportAppWithFormdataBody(ctx context.Context, params *ImportAppParams, body ImportAppFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// InstallAppReleaseWithBody request with any body
+	InstallAppReleaseWithBody(ctx context.Context, params *InstallAppReleaseParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetAppBrickInstances request
 	GetAppBrickInstances(ctx context.Context, appID string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -813,6 +853,12 @@ type ClientInterface interface {
 
 	// GetAppLogs request
 	GetAppLogs(ctx context.Context, id string, params *GetAppLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PrepareAppRelease request
+	PrepareAppRelease(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// BuildAppRelease request
+	BuildAppRelease(ctx context.Context, id string, params *BuildAppReleaseParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// StartApp request
 	StartApp(ctx context.Context, id string, params *StartAppParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -938,6 +984,18 @@ func (c *Client) ImportAppWithBody(ctx context.Context, params *ImportAppParams,
 
 func (c *Client) ImportAppWithFormdataBody(ctx context.Context, params *ImportAppParams, body ImportAppFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewImportAppRequestWithFormdataBody(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) InstallAppReleaseWithBody(ctx context.Context, params *InstallAppReleaseParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewInstallAppReleaseRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1226,6 +1284,30 @@ func (c *Client) ExportApp(ctx context.Context, id string, params *ExportAppPara
 
 func (c *Client) GetAppLogs(ctx context.Context, id string, params *GetAppLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetAppLogsRequest(c.Server, id, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PrepareAppRelease(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPrepareAppReleaseRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) BuildAppRelease(ctx context.Context, id string, params *BuildAppReleaseParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewBuildAppReleaseRequest(c.Server, id, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1690,6 +1772,74 @@ func NewImportAppRequestWithBody(server string, params *ImportAppParams, content
 		if params.File != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "file", *params.File, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: "base64"}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewInstallAppReleaseRequestWithBody generates requests for InstallAppRelease with any type of body
+func NewInstallAppReleaseRequestWithBody(server string, params *InstallAppReleaseParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/apps/release/install")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Force != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "force", *params.Force, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Prepare != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "prepare", *params.Prepare, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -2487,6 +2637,18 @@ func NewExportAppRequest(server string, id string, params *ExportAppParams) (*ht
 
 		}
 
+		if params.ScrubSecrets != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "scrub_secrets", *params.ScrubSecrets, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
 		if encoded := queryValues.Encode(); encoded != "" {
 			rawQueryFragments = append(rawQueryFragments, encoded)
 		}
@@ -2563,6 +2725,125 @@ func NewGetAppLogsRequest(server string, id string, params *GetAppLogsParams) (*
 		if params.Nofollow != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "nofollow", *params.Nofollow, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPrepareAppReleaseRequest generates requests for PrepareAppRelease
+func NewPrepareAppReleaseRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/apps/%s/prepare", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewBuildAppReleaseRequest generates requests for BuildAppRelease
+func NewBuildAppReleaseRequest(server string, id string, params *BuildAppReleaseParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/apps/%s/release", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Models != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "models", *params.Models, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.ReleaseNumber != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "release_number", *params.ReleaseNumber, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.KeepSecrets != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "keep_secrets", *params.KeepSecrets, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -3482,6 +3763,9 @@ type ClientWithResponsesInterface interface {
 
 	ImportAppWithFormdataBodyWithResponse(ctx context.Context, params *ImportAppParams, body ImportAppFormdataRequestBody, reqEditors ...RequestEditorFn) (*ImportAppResp, error)
 
+	// InstallAppReleaseWithBodyWithResponse request with any body
+	InstallAppReleaseWithBodyWithResponse(ctx context.Context, params *InstallAppReleaseParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InstallAppReleaseResp, error)
+
 	// GetAppBrickInstancesWithResponse request
 	GetAppBrickInstancesWithResponse(ctx context.Context, appID string, reqEditors ...RequestEditorFn) (*GetAppBrickInstancesResp, error)
 
@@ -3547,6 +3831,12 @@ type ClientWithResponsesInterface interface {
 
 	// GetAppLogsWithResponse request
 	GetAppLogsWithResponse(ctx context.Context, id string, params *GetAppLogsParams, reqEditors ...RequestEditorFn) (*GetAppLogsResp, error)
+
+	// PrepareAppReleaseWithResponse request
+	PrepareAppReleaseWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*PrepareAppReleaseResp, error)
+
+	// BuildAppReleaseWithResponse request
+	BuildAppReleaseWithResponse(ctx context.Context, id string, params *BuildAppReleaseParams, reqEditors ...RequestEditorFn) (*BuildAppReleaseResp, error)
 
 	// StartAppWithResponse request
 	StartAppWithResponse(ctx context.Context, id string, params *StartAppParams, reqEditors ...RequestEditorFn) (*StartAppResp, error)
@@ -3734,6 +4024,45 @@ func (r ImportAppResp) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r ImportAppResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type InstallAppReleaseResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *struct {
+		// AppName The name of the installed application.
+		AppName *string `json:"app_name,omitempty"`
+
+		// Id The Base64 encoded identifier of the installed application.
+		Id *string `json:"id,omitempty"`
+	}
+	JSON400 *BadRequest
+	JSON409 *Conflict
+	JSON500 *InternalServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r InstallAppReleaseResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r InstallAppReleaseResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r InstallAppReleaseResp) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -4321,6 +4650,72 @@ func (r GetAppLogsResp) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r GetAppLogsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type PrepareAppReleaseResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON404      *NotFound
+	JSON412      *PreconditionFailed
+	JSON500      *InternalServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r PrepareAppReleaseResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PrepareAppReleaseResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r PrepareAppReleaseResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type BuildAppReleaseResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *BadRequest
+	JSON404      *NotFound
+	JSON412      *PreconditionFailed
+	JSON500      *InternalServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r BuildAppReleaseResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r BuildAppReleaseResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r BuildAppReleaseResp) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -4982,6 +5377,15 @@ func (c *ClientWithResponses) ImportAppWithFormdataBodyWithResponse(ctx context.
 	return ParseImportAppResp(rsp)
 }
 
+// InstallAppReleaseWithBodyWithResponse request with arbitrary body returning *InstallAppReleaseResp
+func (c *ClientWithResponses) InstallAppReleaseWithBodyWithResponse(ctx context.Context, params *InstallAppReleaseParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InstallAppReleaseResp, error) {
+	rsp, err := c.InstallAppReleaseWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseInstallAppReleaseResp(rsp)
+}
+
 // GetAppBrickInstancesWithResponse request returning *GetAppBrickInstancesResp
 func (c *ClientWithResponses) GetAppBrickInstancesWithResponse(ctx context.Context, appID string, reqEditors ...RequestEditorFn) (*GetAppBrickInstancesResp, error) {
 	rsp, err := c.GetAppBrickInstances(ctx, appID, reqEditors...)
@@ -5190,6 +5594,24 @@ func (c *ClientWithResponses) GetAppLogsWithResponse(ctx context.Context, id str
 		return nil, err
 	}
 	return ParseGetAppLogsResp(rsp)
+}
+
+// PrepareAppReleaseWithResponse request returning *PrepareAppReleaseResp
+func (c *ClientWithResponses) PrepareAppReleaseWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*PrepareAppReleaseResp, error) {
+	rsp, err := c.PrepareAppRelease(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePrepareAppReleaseResp(rsp)
+}
+
+// BuildAppReleaseWithResponse request returning *BuildAppReleaseResp
+func (c *ClientWithResponses) BuildAppReleaseWithResponse(ctx context.Context, id string, params *BuildAppReleaseParams, reqEditors ...RequestEditorFn) (*BuildAppReleaseResp, error) {
+	rsp, err := c.BuildAppRelease(ctx, id, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseBuildAppReleaseResp(rsp)
 }
 
 // StartAppWithResponse request returning *StartAppResp
@@ -5502,6 +5924,59 @@ func ParseImportAppResp(rsp *http.Response) (*ImportAppResp, error) {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
 		var dest struct {
 			// Id The Base64 encoded identifier of the imported application.
+			Id *string `json:"id,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseInstallAppReleaseResp parses an HTTP response from a InstallAppReleaseWithResponse call
+func ParseInstallAppReleaseResp(rsp *http.Response) (*InstallAppReleaseResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &InstallAppReleaseResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest struct {
+			// AppName The name of the installed application.
+			AppName *string `json:"app_name,omitempty"`
+
+			// Id The Base64 encoded identifier of the installed application.
 			Id *string `json:"id,omitempty"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -6312,6 +6787,100 @@ func ParseGetAppLogsResp(rsp *http.Response) (*GetAppLogsResp, error) {
 			return nil, err
 		}
 		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
+		var dest PreconditionFailed
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON412 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePrepareAppReleaseResp parses an HTTP response from a PrepareAppReleaseWithResponse call
+func ParsePrepareAppReleaseResp(rsp *http.Response) (*PrepareAppReleaseResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PrepareAppReleaseResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
+		var dest PreconditionFailed
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON412 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseBuildAppReleaseResp parses an HTTP response from a BuildAppReleaseWithResponse call
+func ParseBuildAppReleaseResp(rsp *http.Response) (*BuildAppReleaseResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &BuildAppReleaseResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
 		var dest PreconditionFailed

--- a/internal/orchestrator/app/app.go
+++ b/internal/orchestrator/app/app.go
@@ -175,6 +175,44 @@ func (a *ArduinoApp) AppComposeOverrideFilePath() *paths.Path {
 	return a.ProvisioningStateDir().Join("app-compose-overrides.yaml")
 }
 
+// ReleaseComposeFilePath returns the path to the flattened, version-pinned compose file
+// produced by `release build` (staged inside the release archive). Unlike
+// AppComposeFilePath, this file is self-contained (no external includes) and uses
+// ${APP_HOME}/${HOST_IP} placeholders instead of host-absolute paths, so it can be moved
+// between machines; on install it is localized into AppComposeFilePath.
+func (a *ArduinoApp) ReleaseComposeFilePath() *paths.Path {
+	return a.ProvisioningStateDir().Join("release-compose.yaml")
+}
+
+// ReleaseManifestPath returns the path to the release manifest file. Its presence (together
+// with the app.yaml frozen_release marker) indicates an app installed from a release.
+func (a *ArduinoApp) ReleaseManifestPath() *paths.Path {
+	return a.FullPath.Join("arduino-app-release.yaml")
+}
+
+// IsFrozenRelease reports whether the app was installed from an Arduino App Release. When
+// true, the run command launches it as a frozen release (flashing the prebuilt sketch and
+// using the frozen compose) instead of recompiling/re-provisioning. The signal is the
+// frozen_release metadata in app.yaml, written at install time.
+func (a *ArduinoApp) IsFrozenRelease() bool {
+	return a.Descriptor.FrozenRelease != nil
+}
+
+// ReleaseNumber returns the release number when the app is a frozen release, or "".
+func (a *ArduinoApp) ReleaseNumber() string {
+	if a.Descriptor.FrozenRelease == nil {
+		return ""
+	}
+	return a.Descriptor.FrozenRelease.Number
+}
+
+// SecretsEnvFilePath returns the path to the per-app secrets file. It lives inside the
+// reserved data/ folder so it is never included when the app is released or exported. The
+// user fills it in on the destination to provide the secret values the app needs.
+func (a *ArduinoApp) SecretsEnvFilePath() *paths.Path {
+	return a.FullPath.Join("data", "secrets.env")
+}
+
 func (a *ArduinoApp) getAppDescriptionFromReadme() (string, error) {
 	readmePath := a.FullPath.Join("README.md")
 	if !readmePath.Exist() {

--- a/internal/orchestrator/app/parser.go
+++ b/internal/orchestrator/app/parser.go
@@ -23,23 +23,33 @@ type Brick struct {
 	Devices   []string          `yaml:"devices,omitempty"`
 }
 
+// FrozenReleaseInfo marks an app as installed from an Arduino App Release and records its
+// release number. Its presence tells the run command to launch the app as a frozen release
+// (prebuilt sketch + frozen compose) rather than recompiling/re-provisioning it.
+type FrozenReleaseInfo struct {
+	Number string `yaml:"number"`
+}
+
 type AppDescriptor struct {
 	Name        string  `yaml:"name"`
 	Description string  `yaml:"description"`
 	Ports       []int   `yaml:"ports"`
 	Bricks      []Brick `yaml:"bricks"`
 	Icon        string  `yaml:"icon,omitempty"`
+	// FrozenRelease is set when the app was installed from an Arduino App Release.
+	FrozenRelease *FrozenReleaseInfo `yaml:"frozen_release,omitempty"`
 	// Deprecated: Use the RequiredDevices section defined per Brick instead.
 	RequiredDevices []string `yaml:"required_devices,omitempty"`
 }
 
 func (d AppDescriptor) MarshalYAML() (any, error) {
 	type raw struct {
-		Name        string             `yaml:"name"`
-		Description string             `yaml:"description"`
-		Ports       []int              `yaml:"ports"`
-		Bricks      []map[string]Brick `yaml:"bricks"`
-		Icon        string             `yaml:"icon,omitempty"`
+		Name          string             `yaml:"name"`
+		Description   string             `yaml:"description"`
+		Ports         []int              `yaml:"ports"`
+		Bricks        []map[string]Brick `yaml:"bricks"`
+		Icon          string             `yaml:"icon,omitempty"`
+		FrozenRelease *FrozenReleaseInfo `yaml:"frozen_release,omitempty"`
 		// Deprecated: Use the RequiredDevices section defined per Brick instead.
 		RequiredDevices []string `yaml:"required_devices,omitempty"`
 	}
@@ -54,6 +64,7 @@ func (d AppDescriptor) MarshalYAML() (any, error) {
 		Ports:           d.Ports,
 		Bricks:          bricks,
 		Icon:            d.Icon,
+		FrozenRelease:   d.FrozenRelease,
 		RequiredDevices: d.RequiredDevices,
 	}, nil
 }

--- a/internal/orchestrator/archive.go
+++ b/internal/orchestrator/archive.go
@@ -32,6 +32,7 @@ func ExportAppZip(
 	bricksIndex *bricksindex.BricksIndex,
 	appTarget app.ArduinoApp,
 	includeData bool,
+	scrubSecrets bool,
 ) ([]byte, string, error) {
 
 	bricksIndex = bricksIndex.WithAppBricks(appTarget.LocalBricks)
@@ -41,14 +42,14 @@ func ExportAppZip(
 		appName = "app-export"
 	}
 	filename := fmt.Sprintf("%s.zip", appName)
-	zipBytes, err := zipAppToBuffer(bricksIndex, appTarget.FullPath.String(), appName, includeData)
+	zipBytes, err := zipAppToBuffer(bricksIndex, appTarget.FullPath.String(), appName, includeData, scrubSecrets)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create zip archive: %w", err)
 	}
 	return zipBytes, filename, nil
 }
 
-func zipAppToBuffer(bricksIndex *bricksindex.BricksIndex, sourcePath string, rootFolderName string, includeData bool) ([]byte, error) {
+func zipAppToBuffer(bricksIndex *bricksindex.BricksIndex, sourcePath string, rootFolderName string, includeData bool, scrubSecrets bool) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	zipWriter := zip.NewWriter(buf)
 
@@ -69,11 +70,17 @@ func zipAppToBuffer(bricksIndex *bricksindex.BricksIndex, sourcePath string, roo
 		return nil, err
 	}
 
+	var requiredSecrets []ReleaseSecret
 	for _, entry := range entries {
 		relPath, err := filepath.Rel(sourcePath, entry.String())
 		if err != nil {
 			zipWriter.Close()
 			return nil, err
+		}
+
+		// When scrubbing, never ship an existing secrets file (it would leak values).
+		if scrubSecrets && filepath.ToSlash(relPath) == "data/secrets.env" {
+			continue
 		}
 
 		info, err := entry.Stat() // follows symlinks
@@ -115,7 +122,13 @@ func zipAppToBuffer(bricksIndex *bricksindex.BricksIndex, sourcePath string, roo
 				zipWriter.Close()
 				return nil, err
 			}
-			redactSecrets(bricksIndex, &desc)
+			if scrubSecrets {
+				// Replace secret values with ${NAME} env placeholders (the importer provides
+				// them in data/secrets.env), instead of silently emptying them.
+				requiredSecrets, _ = scrubAppSecrets(&desc, bricksIndex)
+			} else {
+				redactSecrets(bricksIndex, &desc)
+			}
 			if err := yaml.NewEncoder(writer).Encode(desc); err != nil {
 				zipWriter.Close()
 				return nil, err
@@ -132,6 +145,22 @@ func zipAppToBuffer(bricksIndex *bricksindex.BricksIndex, sourcePath string, roo
 				zipWriter.Close()
 				return nil, copyErr
 			}
+		}
+	}
+
+	// Add a data/secrets.env template so the importer knows which secrets to provide.
+	if scrubSecrets && len(requiredSecrets) > 0 {
+		writer, err := zipWriter.CreateHeader(&zip.FileHeader{
+			Name:   filepath.ToSlash(filepath.Join(rootFolderName, "data", "secrets.env")),
+			Method: zip.Deflate,
+		})
+		if err != nil {
+			zipWriter.Close()
+			return nil, err
+		}
+		if _, err := writer.Write(renderSecretsTemplate(requiredSecrets)); err != nil {
+			zipWriter.Close()
+			return nil, err
 		}
 	}
 

--- a/internal/orchestrator/archive_test.go
+++ b/internal/orchestrator/archive_test.go
@@ -130,7 +130,7 @@ func TestExportAppZip(t *testing.T) {
 				Name:     tc.appName,
 				FullPath: paths.New(appPath),
 			}
-			zipData, filename, err := ExportAppZip(t.Context(), bricksIndex, app, tc.includeData)
+			zipData, filename, err := ExportAppZip(t.Context(), bricksIndex, app, tc.includeData, false)
 
 			if tc.wantErr {
 				require.Error(t, err)

--- a/internal/orchestrator/modelsindex/models_index.go
+++ b/internal/orchestrator/modelsindex/models_index.go
@@ -14,8 +14,10 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"path/filepath"
 	"slices"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/docker/cli/cli/command"
@@ -290,6 +292,75 @@ func (m *ModelsIndex) modelInstalled(ctx context.Context, model AIModel, cli cli
 	default:
 		return false, fmt.Errorf("model check returned unexpected event %q for %q", out.Event, model.ID)
 	}
+}
+
+// GetModelLocalArtifacts returns the host filesystem paths (files and/or folders) that
+// make up the given model on disk. It is used to bundle the model into a reproducible
+// package so that nothing model-related needs to be downloaded on the destination.
+//
+// Preloaded models live inside (version-pinned) container images and return nil. Custom
+// models return their self-contained folder. Handler-backed models are located by
+// resolving the handler's bind volumes with the model's deployment variables (e.g.
+// ${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}/${models_repository}), refined to the specific
+// model file when the deployment declares a model_name. Only existing paths located under
+// the custom-models dir are returned (so they can be mapped back on install).
+func (m *ModelsIndex) GetModelLocalArtifacts(model AIModel) []*paths.Path {
+	// Custom (e.g. Edge Impulse) models: a self-contained folder.
+	if model.ModelFolderPath != nil && model.ModelFolderPath.Exist() {
+		return []*paths.Path{model.ModelFolderPath}
+	}
+
+	// Handler-backed internal models: resolve the handler bind volumes.
+	if model.Deployment == nil || model.Deployment.PreLoaded || model.Deployment.Handler == "" || m.Handlers == nil {
+		return nil
+	}
+	handler, ok := m.Handlers.GetHandlerByID(model.Deployment.Handler)
+	if !ok {
+		return nil
+	}
+
+	envVars := model.Deployment.VariablesForPlatform(m.plat.BoardName)
+	maps.Insert(envVars, maps.All(m.Handlers.configEnv))
+
+	// Handler bind volumes resolve via ${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}, so artifacts
+	// live under the custom-models dir — which is also where the release restores them and
+	// against which resolveAppModels re-validates them. Filtering against modelsDir (MODELS_PATH)
+	// instead would reject every handler-backed artifact and break `release build`.
+	if m.customModelsDir == nil {
+		return nil
+	}
+	modelsDir := m.customModelsDir.String()
+	seen := make(map[string]struct{})
+	var artifacts []*paths.Path
+	for _, vol := range handler.Volumes {
+		resolved := ResolveVars(vol, envVars)
+		// Volume format is "source:target[:mode]"; the host source has no colon.
+		hostSide := resolved
+		if i := strings.Index(resolved, ":"); i > 0 {
+			hostSide = resolved[:i]
+		}
+		candidate := paths.New(hostSide)
+		// Refine to the specific model file when the handler exposes one, to avoid bundling
+		// sibling models that share the same repository folder.
+		if name := envVars["model_name"]; name != "" {
+			if file := candidate.Join(name); file.Exist() {
+				candidate = file
+			}
+		}
+		if candidate.NotExist() {
+			continue
+		}
+		// Only bundle paths under the custom-models dir so they can be restored back.
+		if rel, err := filepath.Rel(modelsDir, candidate.String()); err != nil || strings.HasPrefix(rel, "..") {
+			continue
+		}
+		if _, dup := seen[candidate.String()]; dup {
+			continue
+		}
+		seen[candidate.String()] = struct{}{}
+		artifacts = append(artifacts, candidate)
+	}
+	return artifacts
 }
 
 func loadInternalModels(dir *paths.Path, handlers *HandlersIndex) ([]AIModel, error) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -167,35 +167,66 @@ func StartApp(
 
 	cb(StreamMessage{progress: &Progress{Name: "preparing", Progress: 0.0}})
 
+	// A release-installed app ships a prebuilt sketch binary and a frozen, already-localized
+	// compose: it must not be recompiled nor re-provisioned. A regular app is compiled and
+	// provisioned as usual. Everything else (containers, env, docker compose up) is shared.
+	frozenRelease := appToStart.IsFrozenRelease()
+
 	if _, ok := appToStart.GetSketchPath(); ok {
-		cb(StreamMessage{progress: &Progress{Name: "sketch compiling and uploading", Progress: 0.0}})
+		if frozenRelease {
+			cb(StreamMessage{progress: &Progress{Name: "uploading prebuilt sketch", Progress: 0.0}})
+			if err := uploadPrebuiltSketch(ctx, platform, appToStart, sketchCallbackWriter); err != nil {
+				return err
+			}
+			cb(StreamMessage{progress: &Progress{Name: "sketch uploaded", Progress: 10.0}})
+		} else {
+			cb(StreamMessage{progress: &Progress{Name: "sketch compiling and uploading", Progress: 0.0}})
 
-		if ok, err := migrateRemoveRouterBridgeIfNeeded(ctx, platform, appToStart); err != nil {
-			cb(StreamMessage{data: "Failed to apply app migration for platform arduino:zephyr >0.54.1. Error: " + err.Error()})
-		} else if ok {
-			cb(StreamMessage{data: "Applied app migration for platform arduino:zephyr >0.54.1. Arduino_RouterBridge is now part of the platform and shouldn't be explicitly specified"})
+			if ok, err := migrateRemoveRouterBridgeIfNeeded(ctx, platform, appToStart); err != nil {
+				cb(StreamMessage{data: "Failed to apply app migration for platform arduino:zephyr >0.54.1. Error: " + err.Error()})
+			} else if ok {
+				cb(StreamMessage{data: "Applied app migration for platform arduino:zephyr >0.54.1. Arduino_RouterBridge is now part of the platform and shouldn't be explicitly specified"})
+			}
+
+			if err := compileUploadSketch(ctx, verbose, platform, appToStart, sketchCallbackWriter); err != nil {
+				return err
+			}
+
+			cb(StreamMessage{progress: &Progress{Name: "sketch updated", Progress: 10.0}})
 		}
-
-		if err := compileUploadSketch(ctx, verbose, platform, appToStart, sketchCallbackWriter); err != nil {
-			return err
-		}
-
-		cb(StreamMessage{progress: &Progress{Name: "sketch updated", Progress: 10.0}})
 	}
 
 	if appToStart.MainPythonFile != nil {
 		envs := getAppEnvironmentVariables(ctx, appToStart, bricksIndex, modelsIndex, platform, cfg)
 
-		cb(StreamMessage{data: "python provisioning"})
+		// Resolve any scrubbed secrets (${NAME} placeholders) from data/secrets.env and fail
+		// early (with a clear message) if a required secret is missing. This applies to any
+		// app whose secret variables were scrubbed — frozen releases and scrubbed exports
+		// alike; it is a no-op for apps with no secret placeholders.
+		missing, err := applyReleaseSecrets(appToStart, envs)
+		if err != nil {
+			return err
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("missing required secret(s) %s: set them in %s",
+				strings.Join(missing, ", "), appToStart.SecretsEnvFilePath())
+		}
+
 		provisionStartProgress := float32(0.0)
 		if _, ok := appToStart.GetSketchPath(); ok {
 			provisionStartProgress = 10.0
 		}
 
-		cb(StreamMessage{progress: &Progress{Name: "python provisioning", Progress: provisionStartProgress}})
+		if frozenRelease {
+			// Compose is already on disk and version-pinned; nothing to provision.
+			cb(StreamMessage{progress: &Progress{Name: "python provisioning", Progress: provisionStartProgress}})
+		} else {
+			cb(StreamMessage{data: "python provisioning"})
+			cb(StreamMessage{progress: &Progress{Name: "python provisioning", Progress: provisionStartProgress}})
 
-		if err := provisioner.App(ctx, bricksIndex, servicesIndex, &appToStart, cfg, envs, platform); err != nil {
-			return err
+			if err := provisioner.App(ctx, bricksIndex, servicesIndex, &appToStart, cfg, envs, platform); err != nil {
+				return err
+			}
 		}
 
 		cb(StreamMessage{data: "python downloading"})
@@ -765,6 +796,11 @@ type CloneAppRequest struct {
 
 	Name *string
 	Icon *string
+	// StripFrozenRelease turns a release-installed app back into a live, editable app: it omits
+	// the release manifest and clears the frozen_release metadata from app.yaml. Combined with
+	// the normal exclusion of the .cache folder, the clone has no prebuilt artifacts and will
+	// be compiled and provisioned again on the next start.
+	StripFrozenRelease bool
 }
 
 type CloneAppResponse struct {
@@ -811,7 +847,12 @@ func CloneApp(
 		}
 	}()
 
-	list, err := originPath.ReadDir(paths.FilterOutNames(".cache", "data"))
+	excluded := []string{".cache", "data"}
+	if req.StripFrozenRelease {
+		// Drop the release manifest so the clone is no longer recognized as a release.
+		excluded = append(excluded, ReleaseManifestFileName)
+	}
+	list, err := originPath.ReadDir(paths.FilterOutNames(excluded...))
 	if err != nil {
 		return CloneAppResponse{}, fmt.Errorf("failed to read app directory: %w", err)
 	}
@@ -827,7 +868,7 @@ func CloneApp(
 		}
 	}
 
-	if (req.Name != nil && *req.Name != "") || (req.Icon != nil && *req.Icon != "") {
+	if (req.Name != nil && *req.Name != "") || (req.Icon != nil && *req.Icon != "") || req.StripFrozenRelease {
 
 		appYamlPath := dstPath.Join("app.yaml")
 		if !appYamlPath.Exist() {
@@ -842,6 +883,10 @@ func CloneApp(
 		}
 		if req.Icon != nil && *req.Icon != "" {
 			descriptor.Icon = *req.Icon
+		}
+		if req.StripFrozenRelease {
+			// Clear the frozen-release marker so the clone runs as a regular (recompiled) app.
+			descriptor.FrozenRelease = nil
 		}
 
 		// TODO: implement MarshalYaml directly in the descriptor.

--- a/internal/orchestrator/release.go
+++ b/internal/orchestrator/release.go
@@ -1,0 +1,1642 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package orchestrator
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/arduino/arduino-cli/commands"
+	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
+	"github.com/arduino/go-paths-helper"
+	yaml "github.com/goccy/go-yaml"
+	"github.com/sirupsen/logrus"
+
+	"github.com/arduino/arduino-app-cli/internal/helpers"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
+	"github.com/arduino/arduino-app-cli/internal/platform"
+)
+
+// ReleaseFormatVersion is the version of the Arduino App Release format produced by
+// `release build`. Bump it on breaking changes to the release layout/manifest.
+const ReleaseFormatVersion = "1.0"
+
+// releaseFormatMajor returns the major component of a "major.minor" release format version
+// (the part before the first "."). Releases with a different major are considered
+// incompatible; a differing minor is assumed backward-compatible.
+func releaseFormatMajor(v string) string {
+	if i := strings.Index(v, "."); i >= 0 {
+		return v[:i]
+	}
+	return v
+}
+
+// ReleaseManifestFileName is the manifest file embedded at the root of an app release
+// (and dropped into the app folder on install). Its presence marks an installed app
+// as release-managed.
+const ReleaseManifestFileName = "arduino-app-release.yaml"
+
+// Limits that mitigate decompression bombs and resource-exhaustion from a crafted release.
+const (
+	maxReleaseFileSize  = 500 * 1024 * 1024        // per-file uncompressed cap
+	maxReleaseTotalSize = 4 * 1024 * 1024 * 1024   // aggregate uncompressed cap across all files
+	maxReleaseEntries   = 500 * 1000               // max number of archive entries
+	maxManifestSize     = 4 * 1024 * 1024          // the manifest is a few KB; cap generously
+)
+
+// minScrubbableSecretLen is the shortest secret value we will blanket-replace by value in the
+// frozen compose. Shorter values risk over-matching structural tokens (ports, tags) and are
+// covered by the precise env-key scrubbing instead.
+const minScrubbableSecretLen = 6
+
+// appHomePlaceholder and hostIPPlaceholder are the tokens substituted into the frozen
+// compose file in place of host-specific absolute paths/addresses, so the release can
+// be moved between machines. They are re-expanded at `release start` time via the
+// process environment.
+const (
+	appHomePlaceholder = "${APP_HOME}"
+	hostIPPlaceholder  = "${HOST_IP}"
+)
+
+// ReleaseManifest describes the provenance and compatibility of an Arduino App Release.
+type ReleaseManifest struct {
+	FormatVersion    string          `yaml:"format_version"`
+	AppName          string          `yaml:"app_name"`
+	Release          string          `yaml:"release"`
+	CreatedAt        time.Time       `yaml:"created_at"`
+	SourceCLIVersion string          `yaml:"source_cli_version"`
+	RunnerVersion    string          `yaml:"runner_version"`
+	PythonImage      string          `yaml:"python_image"`
+	BoardName        string          `yaml:"board_name"`
+	FQBN             string          `yaml:"fqbn"`
+	Arch             string          `yaml:"arch"`
+	Images           []string        `yaml:"images,omitempty"`
+	Models           []ReleaseModel  `yaml:"models,omitempty"`
+	RequiredSecrets  []ReleaseSecret `yaml:"required_secrets,omitempty"`
+}
+
+// ReleaseSecret declares a secret brick variable whose value is NOT bundled in the release.
+// The value must be supplied on the destination (in the app's data/secrets.env) before the
+// app can start.
+type ReleaseSecret struct {
+	Name  string `yaml:"name"`
+	Brick string `yaml:"brick,omitempty"`
+}
+
+// ReleaseModel records an AI model required by the app and how it is provided by the
+// release.
+type ReleaseModel struct {
+	ID        string   `yaml:"id"`
+	Name      string   `yaml:"name,omitempty"`
+	Runner    string   `yaml:"runner,omitempty"`
+	PreLoaded bool     `yaml:"preloaded"`       // shipped inside a (pinned) container image
+	Bundled   bool     `yaml:"bundled"`         // model files are bundled in this release
+	Paths     []string `yaml:"paths,omitempty"` // when bundled: artifact paths relative to the custom-models dir
+}
+
+// releaseModelsDirPrefix is the archive sub-path under which bundled model artifacts are
+// stored (mirroring their layout under the custom-models dir).
+const releaseModelsDirPrefix = "models"
+
+// customModelDirPlaceholder is the token substituted for the host custom-models dir in the
+// frozen compose, re-expanded on the destination at `release start`.
+const customModelDirPlaceholder = "${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}"
+
+// tarPath describes an additional file or directory tree to include in a release archive
+// at the given archive-relative path (under the release root).
+type tarPath struct {
+	archiveRel string
+	source     *paths.Path
+}
+
+// ErrNotFrozenRelease is returned when an operation expects an app installed from a release
+// but the app is missing the release artifacts (manifest / frozen compose).
+var ErrNotFrozenRelease = errors.New("app is not a release-installed app")
+
+// ErrIncompatibleRelease is returned by InstallRelease when the release targets a
+// different board than the current one and installation was not forced.
+var ErrIncompatibleRelease = errors.New("incompatible release")
+
+// BuildRelease builds a self-contained, reproducible Arduino App Release (.tar.gz)
+// from an app that has already been built and started at least once.
+//
+// The release contains the user code, the prebuilt sketch binary (.cache/sketch), the
+// provisioned Python venv (.cache/...), a flattened+version-pinned compose file and a
+// manifest. It deliberately requires the app to be pre-built: it never compiles the
+// sketch nor provisions the venv itself.
+func BuildRelease(
+	ctx context.Context,
+	bricksIndex *bricksindex.BricksIndex,
+	modelsIndex *modelsindex.ModelsIndex,
+	arduinoApp app.ArduinoApp,
+	cfg config.Configuration,
+	plat platform.Platform,
+	cliVersion string,
+	releaseNumber string,
+	outputPath *paths.Path,
+	includeModels bool,
+	keepSecrets bool,
+	cb func(StreamMessage),
+) error {
+	bricksIndex = bricksIndex.WithAppBricks(arduinoApp.LocalBricks)
+
+	emit := func(msg string) {
+		if cb != nil {
+			cb(StreamMessage{data: msg})
+		}
+	}
+
+	// A release number identifies this build of the release. Default to a timestamp.
+	if releaseNumber == "" {
+		releaseNumber = time.Now().Format("20060102150405")
+	}
+	emit(fmt.Sprintf("Release number: %s", releaseNumber))
+
+	// 1. Validate the app is pre-built.
+	if err := validatePrebuilt(arduinoApp); err != nil {
+		return err
+	}
+	emit("Pre-built artifacts found")
+
+	// 2. Handle secret brick variables. By default they are scrubbed from the release and
+	// replaced with ${NAME} env placeholders, to be provided on the destination; --keep-secrets
+	// keeps the values in the release (making the archive sensitive).
+	descriptor, err := app.ParseDescriptorFile(arduinoApp.GetDescriptorPath())
+	if err != nil {
+		return fmt.Errorf("failed to read app.yaml: %w", err)
+	}
+	var requiredSecrets []ReleaseSecret
+	var secretValues map[string][]string
+	if keepSecrets {
+		emit("Warning: --keep-secrets keeps configured secrets (API keys, passwords) in the release. Treat the archive as sensitive.")
+	} else {
+		requiredSecrets, secretValues = scrubAppSecrets(&descriptor, bricksIndex)
+		if len(requiredSecrets) > 0 {
+			emit(fmt.Sprintf("Scrubbed %d secret(s); they must be provided on the destination in data/secrets.env", len(requiredSecrets)))
+		}
+	}
+	appYamlBytes, err := yaml.Marshal(descriptor)
+	if err != nil {
+		return fmt.Errorf("failed to marshal app.yaml: %w", err)
+	}
+
+	// 3. Resolve the AI models required by the app and decide which to bundle.
+	modelEntries, modelArtifacts, err := resolveAppModels(ctx, arduinoApp, modelsIndex, cfg, includeModels, emit)
+	if err != nil {
+		return err
+	}
+
+	// 4. Flatten the generated compose into a single, version-pinned, relocatable file,
+	// scrubbing the secret values unless they are being kept.
+	emit("Freezing compose with pinned container versions")
+	envs := getAppEnvironmentVariables(ctx, arduinoApp, bricksIndex, modelsIndex, plat, cfg)
+	frozenCompose, err := buildFrozenCompose(ctx, arduinoApp, cfg, envs, secretValues)
+	if err != nil {
+		return fmt.Errorf("failed to freeze compose file: %w", err)
+	}
+
+	// 5. Build the manifest.
+	manifest := ReleaseManifest{
+		FormatVersion:    ReleaseFormatVersion,
+		AppName:          arduinoApp.Name,
+		Release:          releaseNumber,
+		CreatedAt:        time.Now().UTC(),
+		SourceCLIVersion: cliVersion,
+		RunnerVersion:    cfg.RunnerVersion,
+		PythonImage:      cfg.PythonImage,
+		BoardName:        plat.BoardName,
+		FQBN:             plat.FQBN,
+		Arch:             runtime.GOARCH,
+		Images:           extractComposeImages(frozenCompose),
+		Models:           modelEntries,
+		RequiredSecrets:  requiredSecrets,
+	}
+	manifestBytes, err := yaml.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("failed to marshal release manifest: %w", err)
+	}
+
+	// 6. Write the tar.gz. app.yaml is provided here (scrubbed) instead of from the walk.
+	emit("Writing release archive")
+	rootFolderName := releaseRootFolderName(arduinoApp.Name)
+	extraFiles := map[string][]byte{
+		"app.yaml":              appYamlBytes,
+		ReleaseManifestFileName: manifestBytes,
+		".cache/" + arduinoApp.ReleaseComposeFilePath().Base(): frozenCompose,
+	}
+	if err := writeAppTarGz(arduinoApp.FullPath, rootFolderName, outputPath, extraFiles, modelArtifacts); err != nil {
+		return fmt.Errorf("failed to write release archive: %w", err)
+	}
+
+	return nil
+}
+
+// scrubAppSecrets replaces, in place, the value of every brick variable flagged as secret
+// (and currently set to a non-empty value) with a ${NAME} env placeholder. It returns the
+// list of secrets that must be provided on the destination, plus a name->values map of the
+// scrubbed plaintext values (used to also strip those values from the frozen compose). The
+// env var name is the brick variable name (which is also how it reaches the container).
+//
+// The value map holds a slice per name because two bricks can declare a secret with the same
+// name but different values; every distinct value must be stripped, so keying a single value
+// per name (and thus dropping the others) would risk leaving one baked in the compose.
+func scrubAppSecrets(desc *app.AppDescriptor, bricksIndex *bricksindex.BricksIndex) ([]ReleaseSecret, map[string][]string) {
+	var required []ReleaseSecret
+	seen := make(map[string]struct{})
+	values := make(map[string][]string)
+	for i := range desc.Bricks {
+		b := &desc.Bricks[i]
+		brickDef, found := bricksIndex.FindBrickByID(b.ID)
+		if !found {
+			continue
+		}
+		for name, value := range b.Variables {
+			if value == "" {
+				continue
+			}
+			vDef, ok := brickDef.GetVariable(name)
+			if !ok || !vDef.Secret {
+				continue
+			}
+			if !slices.Contains(values[name], value) {
+				values[name] = append(values[name], value)
+			}
+			b.Variables[name] = "${" + name + "}"
+			if _, dup := seen[name]; !dup {
+				seen[name] = struct{}{}
+				required = append(required, ReleaseSecret{Name: name, Brick: b.ID})
+			}
+		}
+	}
+	return required, values
+}
+
+// resolveAppModels inspects the models referenced by the app's bricks and returns the
+// manifest entries plus the artifact paths to bundle. Preloaded models live inside
+// (version-pinned) container images and are not bundled. Every other required model is
+// bundled into the release from its on-disk artifacts so that installing the release never
+// has to download a model; only containers are pulled (at start).
+//
+// If a non-preloaded model has no locatable on-disk artifacts, packaging fails (the release
+// would otherwise be incomplete) — unless includeModels is false, which intentionally
+// excludes models and leaves installing them to the destination.
+func resolveAppModels(
+	ctx context.Context,
+	arduinoApp app.ArduinoApp,
+	modelsIndex *modelsindex.ModelsIndex,
+	cfg config.Configuration,
+	includeModels bool,
+	emit func(string),
+) ([]ReleaseModel, []tarPath, error) {
+	seen := make(map[string]struct{})
+	bundledArchiveRel := make(map[string]struct{})
+	var entries []ReleaseModel
+	var toBundle []tarPath
+
+	customModelsDir := cfg.CustomModelsDir()
+
+	for _, brick := range arduinoApp.Descriptor.Bricks {
+		modelID := brick.Model
+		if modelID == "" {
+			continue
+		}
+		if _, ok := seen[modelID]; ok {
+			continue
+		}
+		seen[modelID] = struct{}{}
+
+		model, err := modelsIndex.GetModelByID(ctx, modelID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to resolve model %q required by brick %q: %w", modelID, brick.ID, err)
+		}
+		if model == nil {
+			return nil, nil, fmt.Errorf("%w: model %q required by brick %q is not available", ErrBadRequest, modelID, brick.ID)
+		}
+
+		entry := ReleaseModel{ID: model.ID, Name: model.Name, Runner: model.Runner}
+
+		// Preloaded models travel inside their (pinned) container image.
+		if model.Deployment != nil && model.Deployment.PreLoaded {
+			entry.PreLoaded = true
+			entries = append(entries, entry)
+			continue
+		}
+
+		if !includeModels {
+			emit(fmt.Sprintf("Skipping model %q (--no-models); it must be installed on the destination", model.ID))
+			entries = append(entries, entry)
+			continue
+		}
+
+		// Bundle the model's on-disk artifacts so the release is self-contained.
+		artifacts := modelsIndex.GetModelLocalArtifacts(*model)
+		if len(artifacts) == 0 {
+			return nil, nil, fmt.Errorf("%w: model %q (required by brick %q) is not installed or its files could not be located; install it before packaging, or use --no-models",
+				ErrBadRequest, model.ID, brick.ID)
+		}
+
+		for _, artifact := range artifacts {
+			rel, relErr := filepath.Rel(customModelsDir.String(), artifact.String())
+			if relErr != nil || strings.HasPrefix(rel, "..") {
+				return nil, nil, fmt.Errorf("%w: model %q has an artifact outside the models dir (%s); cannot bundle it",
+					ErrBadRequest, model.ID, artifact.String())
+			}
+			rel = filepath.ToSlash(rel)
+			entry.Paths = append(entry.Paths, rel)
+			if _, dup := bundledArchiveRel[rel]; dup {
+				continue // shared artifact already queued (e.g. models sharing a repository folder)
+			}
+			bundledArchiveRel[rel] = struct{}{}
+			toBundle = append(toBundle, tarPath{
+				archiveRel: releaseModelsDirPrefix + "/" + rel,
+				source:     artifact,
+			})
+		}
+		entry.Bundled = true
+		emit(fmt.Sprintf("Bundling model %q", model.ID))
+		entries = append(entries, entry)
+	}
+
+	return entries, toBundle, nil
+}
+
+// validatePrebuilt ensures the app has the artifacts a release needs: a compiled sketch
+// (when the app has a sketch) and a provisioned Python venv, plus a generated compose.
+func validatePrebuilt(arduinoApp app.ArduinoApp) error {
+	if arduinoApp.AppComposeFilePath().NotExist() {
+		return fmt.Errorf("%w: app has not been started yet (missing %s). Start the app once before packaging",
+			ErrBadRequest, arduinoApp.AppComposeFilePath().Base())
+	}
+
+	if _, ok := arduinoApp.GetSketchPath(); ok {
+		buildPath := arduinoApp.SketchBuildPath()
+		if buildPath.NotExist() {
+			return fmt.Errorf("%w: sketch has not been compiled yet (missing %s). Start the app once before packaging",
+				ErrBadRequest, buildPath.String())
+		}
+		if entries, err := buildPath.ReadDir(); err != nil || len(entries) == 0 {
+			return fmt.Errorf("%w: sketch build directory is empty. Start the app once before packaging", ErrBadRequest)
+		}
+	}
+
+	if !hasProvisionedVenv(arduinoApp.ProvisioningStateDir()) {
+		return fmt.Errorf("%w: no provisioned Python venv found under %s. Start the app once before packaging",
+			ErrBadRequest, arduinoApp.ProvisioningStateDir().String())
+	}
+
+	return nil
+}
+
+// hasProvisionedVenv reports whether a Python virtual environment exists somewhere under
+// the given .cache directory, detected by the presence of a pyvenv.cfg file. This avoids
+// hard-coding the venv directory name, which is owned by the python runner image.
+// It uses filepath.WalkDir, which does not follow symlinks, so it never wanders out of the
+// app tree via the venv's internal links.
+func hasProvisionedVenv(cacheDir *paths.Path) bool {
+	if cacheDir.NotExist() {
+		return false
+	}
+	found := false
+	_ = filepath.WalkDir(cacheDir.String(), func(_ string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // ignore unreadable entries
+		}
+		if !d.IsDir() && d.Name() == "pyvenv.cfg" {
+			found = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+
+// Sentinels are substituted for the host-specific env vars before running
+// `docker compose config`, so their expanded occurrences in the flattened output can be
+// reverse-mapped to portable placeholders without matching real IPs/paths — or substrings
+// of them (e.g. host IP 192.168.1.5 inside 192.168.1.50) — elsewhere in the file. They are
+// unique, non-colliding tokens; the path-like ones stay absolute so `docker compose config`
+// still treats them as bind-mount sources rather than named volumes.
+const (
+	sentinelHostIP    = "__ARDUINO_RELEASE_PLACEHOLDER_HOST_IP__"
+	sentinelAppHome   = "/__ARDUINO_RELEASE_PLACEHOLDER_APP_HOME__"
+	sentinelModelsDir = "/__ARDUINO_RELEASE_PLACEHOLDER_CUSTOM_MODEL_DIR__"
+)
+
+// buildFrozenCompose flattens the app's generated compose files (merging all includes and
+// resolving concrete image references) into a single document, then re-tokenizes the
+// host-specific app path, models dir and host IP so the result is relocatable, and finally
+// removes any secret material.
+func buildFrozenCompose(ctx context.Context, arduinoApp app.ArduinoApp, cfg config.Configuration, envs helpers.EnvVars, secretValues map[string][]string) ([]byte, error) {
+	args := []string{"docker", "compose", "-f", arduinoApp.AppComposeFilePath().String()}
+	if override := arduinoApp.AppComposeOverrideFilePath(); override.Exist() {
+		args = append(args, "-f", override.String())
+	}
+	args = append(args, "config")
+
+	// Run with the host-specific vars set to unique sentinels, so ${HOST_IP}/${APP_HOME}/
+	// ${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR} interpolate to the sentinels (not to real
+	// host values) and can be reverse-mapped unambiguously below. Explicitly setting the
+	// models dir is required because it is otherwise inherited from the daemon environment.
+	frozenEnvs := make(helpers.EnvVars, len(envs)+3)
+	for k, v := range envs {
+		frozenEnvs[k] = v
+	}
+	frozenEnvs["HOST_IP"] = sentinelHostIP
+	frozenEnvs["APP_HOME"] = sentinelAppHome
+	frozenEnvs["ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR"] = sentinelModelsDir
+
+	process, err := paths.NewProcess(frozenEnvs.AsList(), args...)
+	if err != nil {
+		return nil, err
+	}
+	stdout, stderr, err := process.RunAndCaptureOutput(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("docker compose config failed: %w: %s", err, string(stderr))
+	}
+
+	flattened := tokenizeHostSpecificValues(string(stdout), cfg.CustomModelsDir().String(), arduinoApp.FullPath.String())
+
+	// The provisioned compose bakes host-specific env values (HOST_IP, MODELS_PATH,
+	// CUSTOM_MODEL_PATH, ...) as literals into the generated service `environment:` blocks
+	// and as bind-mount source/target paths. The sentinel reverse-mapping above only catches
+	// ${VAR} references, so these literals survive and would leak the build machine's IP and
+	// absolute paths into the release. Neutralize them to ${KEY} placeholders, which the
+	// destination re-provides at run time (getAppEnvironmentVariables) for docker compose to
+	// interpolate.
+	flattened = tokenizeHostSpecificEnv(flattened, envs)
+
+	// Remove secret material: rewrite the secret env entries by key, then strip any
+	// remaining literal secret values (e.g. embedded in a connection string), failing if
+	// any survive so the release never carries a secret.
+	names := make([]string, 0, len(secretValues))
+	for name := range secretValues {
+		names = append(names, name)
+	}
+	flattened = scrubComposeSecretKeys(flattened, names)
+	flattened, err = scrubComposeSecretValues(flattened, secretValues)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(flattened), nil
+}
+
+// tokenizeHostSpecificValues reverse-maps the sentinels injected before `docker compose
+// config` back to portable ${...} placeholders. As a safety net it also maps any literally
+// baked host paths (custom-models dir, app home) that did not come through the env vars;
+// those are long, unique absolute paths, so — unlike an IP — they cannot over-match a
+// substring. The host IP is intentionally handled only via its sentinel.
+func tokenizeHostSpecificValues(flattened, customModelsDir, appHome string) string {
+	flattened = strings.ReplaceAll(flattened, sentinelModelsDir, customModelDirPlaceholder)
+	flattened = strings.ReplaceAll(flattened, sentinelAppHome, appHomePlaceholder)
+	flattened = strings.ReplaceAll(flattened, sentinelHostIP, hostIPPlaceholder)
+	// Guard against empty/root paths, which would make ReplaceAll match everywhere.
+	if customModelsDir != "" && customModelsDir != "/" {
+		flattened = strings.ReplaceAll(flattened, customModelsDir, customModelDirPlaceholder)
+	}
+	if appHome != "" && appHome != "/" {
+		flattened = strings.ReplaceAll(flattened, appHome, appHomePlaceholder)
+	}
+	return flattened
+}
+
+// hostSpecificEnvKeys lists environment variables whose values are specific to the machine
+// that built the release: the host IP and the absolute AI-model directories. Unlike the
+// pinned image/config values a frozen release deliberately keeps, these must become ${KEY}
+// placeholders so the release is relocatable. The destination re-provides every one of them
+// at run time via getAppEnvironmentVariables (MODELS_PATH unconditionally; HOST_IP and
+// CUSTOM_MODEL_PATH from the same brick/model sources that populated them at build time), so
+// docker compose interpolates them for both `environment:` blocks and bind-mount paths.
+var hostSpecificEnvKeys = []string{"HOST_IP", "MODELS_PATH", "CUSTOM_MODEL_PATH"}
+
+// tokenizeHostSpecificEnv rewrites the host-specific env values baked as literals into the
+// flattened compose back to ${KEY} placeholders. It does so in two complementary ways:
+//   - by key: every `KEY: <value>` / `- KEY=<value>` entry for a host-specific key becomes
+//     ${KEY}, regardless of the literal value (this fixes the `environment:` blocks, whose
+//     values never came through a ${...} reference the sentinel mapping could catch);
+//   - by value: the literal MODELS_PATH / CUSTOM_MODEL_PATH paths are replaced wherever else
+//     they appear (e.g. bind-mount source/target). Those are long, unique absolute paths, so
+//     — unlike an IP — value replacement cannot over-match a substring; HOST_IP is therefore
+//     handled by key only.
+func tokenizeHostSpecificEnv(compose string, envs helpers.EnvVars) string {
+	compose = scrubComposeSecretKeys(compose, hostSpecificEnvKeys)
+	// Replace the longer path first so that when one value is a prefix of the other (e.g.
+	// CUSTOM_MODEL_PATH nested under MODELS_PATH) the more specific path is tokenized to its
+	// own placeholder instead of being partially rewritten via the shorter one.
+	pathKeys := []string{"MODELS_PATH", "CUSTOM_MODEL_PATH"}
+	sort.Slice(pathKeys, func(i, j int) bool { return len(envs[pathKeys[i]]) > len(envs[pathKeys[j]]) })
+	for _, key := range pathKeys {
+		v := envs[key]
+		if v == "" || v == "/" {
+			continue
+		}
+		compose = strings.ReplaceAll(compose, v, "${"+key+"}")
+	}
+	return compose
+}
+
+// scrubComposeSecretKeys rewrites the environment entries for the given secret variable
+// names so their value becomes a ${NAME} placeholder, resolved from the process environment
+// at run time. It targets the environment keys (in both the map and list compose forms)
+// rather than the raw secret values, so it never leaves a plaintext value behind.
+func scrubComposeSecretKeys(compose string, names []string) string {
+	for _, name := range names {
+		quoted := regexp.QuoteMeta(name)
+		// map form:  "      DB_PASSWORD: <value>"
+		reMap := regexp.MustCompile(`(?m)^(\s+)` + quoted + `:[ \t].*$`)
+		compose = reMap.ReplaceAllStringFunc(compose, func(line string) string {
+			indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+			return indent + name + ": ${" + name + "}"
+		})
+		// list form: "      - DB_PASSWORD=<value>"
+		reList := regexp.MustCompile(`(?m)^(\s*)-[ \t]+` + quoted + `=.*$`)
+		compose = reList.ReplaceAllStringFunc(compose, func(line string) string {
+			indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+			return indent + "- " + name + "=${" + name + "}"
+		})
+	}
+	return compose
+}
+
+// scrubComposeSecretValues removes any remaining occurrence of a secret's literal value
+// from the compose, replacing it with the ${NAME} placeholder. This catches values that
+// scrubComposeSecretKeys misses because they are embedded inside a larger value (e.g. a
+// password inside a "postgres://user:pass@host" connection string). Longer values are
+// replaced first so a shorter secret that is a substring of a longer one cannot corrupt it.
+// As defense-in-depth it returns an error if any secret value still appears afterwards, so
+// the release is never written with secret material in it.
+func scrubComposeSecretValues(compose string, values map[string][]string) (string, error) {
+	// Flatten to (name, value) pairs and replace longest values first, so a shorter secret
+	// that is a substring of a longer one cannot corrupt the longer replacement.
+	type sv struct{ name, value string }
+	var pairs []sv
+	for name, vs := range values {
+		for _, v := range vs {
+			if v != "" {
+				pairs = append(pairs, sv{name, v})
+			}
+		}
+	}
+	sort.Slice(pairs, func(i, j int) bool { return len(pairs[i].value) > len(pairs[j].value) })
+
+	for _, p := range pairs {
+		// Only blanket-replace values long enough to be distinctive. A very short value
+		// (e.g. "1", "8080", "true") would otherwise over-match unrelated tokens like ports
+		// or image tags — corrupting the compose, or tripping a false leak-abort on a
+		// coincidental structural match. Short secret values are still scrubbed precisely by
+		// scrubComposeSecretKeys via their own env entry.
+		if len(p.value) < minScrubbableSecretLen {
+			continue
+		}
+		compose = strings.ReplaceAll(compose, p.value, "${"+p.name+"}")
+	}
+
+	// Defense-in-depth: after all replacements, verify no (distinctive) secret value remains
+	// baked in — abort rather than ship one. Short values are excluded for the reason above.
+	leaked := map[string]struct{}{}
+	for _, p := range pairs {
+		if len(p.value) < minScrubbableSecretLen {
+			continue
+		}
+		if strings.Contains(compose, p.value) {
+			leaked[p.name] = struct{}{}
+		}
+	}
+	if len(leaked) > 0 {
+		names := make([]string, 0, len(leaked))
+		for n := range leaked {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		return "", fmt.Errorf("%w: secret value(s) %s could not be fully removed from the frozen compose; aborting to avoid leaking them (rename/lengthen the value or use --keep-secrets)",
+			ErrBadRequest, strings.Join(names, ", "))
+	}
+	return compose, nil
+}
+
+// extractComposeImages returns the list of container images referenced by a compose file.
+func extractComposeImages(composeBytes []byte) []string {
+	var doc struct {
+		Services map[string]struct {
+			Image string `yaml:"image"`
+		} `yaml:"services"`
+	}
+	if err := yaml.Unmarshal(composeBytes, &doc); err != nil {
+		slog.Warn("failed to parse frozen compose for image list", slog.Any("error", err))
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var images []string
+	for _, svc := range doc.Services {
+		if svc.Image == "" {
+			continue
+		}
+		if _, ok := seen[svc.Image]; ok {
+			continue
+		}
+		seen[svc.Image] = struct{}{}
+		images = append(images, svc.Image)
+	}
+	return images
+}
+
+// releaseRootFolderName returns a filesystem-safe root folder name for the release
+// archive, mirroring the behavior of the zip export.
+func releaseRootFolderName(appName string) string {
+	name := strings.ToLower(strings.ReplaceAll(appName, " ", "-"))
+	if name == "" {
+		name = "app-release"
+	}
+	return name
+}
+
+// writeAppTarGz writes the app folder (rooted at rootFolderName) as a gzip-compressed
+// tarball at outputPath. It preserves symlinks and file modes (required for the venv),
+// excludes the data folder and the non-portable generated compose files, injects the
+// provided extraFiles (manifest + frozen compose) and bundles any extraPaths (AI model
+// files or folders) under the same root.
+func writeAppTarGz(sourcePath *paths.Path, rootFolderName string, outputPath *paths.Path, extraFiles map[string][]byte, extraPaths []tarPath) error {
+	out, err := os.Create(outputPath.String())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	gw := gzip.NewWriter(out)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	// shouldSkip decides, by app-relative slash path, whether to exclude an app entry.
+	shouldSkip := func(rel string) bool {
+		switch rel {
+		case "data": // user/runtime data must not be shipped
+			return true
+		case "app.yaml": // provided via extraFiles (secrets scrubbed)
+			return true
+		case ".cache/app-compose.yaml", ".cache/app-compose-overrides.yaml": // host-path baked; superseded by release-compose.yaml
+			return true
+		case ReleaseManifestFileName: // regenerated below
+			return true
+		}
+		return false
+	}
+
+	// Bundle the app folder under rootFolderName.
+	if err := addTreeToTar(tw, sourcePath.String(), rootFolderName, shouldSkip); err != nil {
+		return err
+	}
+
+	// Bundle the extra files/trees (e.g. AI model artifacts).
+	for _, p := range extraPaths {
+		base := filepath.ToSlash(filepath.Join(rootFolderName, p.archiveRel))
+		if err := addPathToTar(tw, p.source.String(), base); err != nil {
+			return fmt.Errorf("bundling %s: %w", p.archiveRel, err)
+		}
+	}
+
+	// Inject the synthetic files (manifest + frozen compose).
+	for relName, content := range extraFiles {
+		header := &tar.Header{
+			Name:    filepath.ToSlash(filepath.Join(rootFolderName, relName)),
+			Mode:    0o644,
+			Size:    int64(len(content)),
+			ModTime: time.Now(),
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+		if _, err := tw.Write(content); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// addPathToTar bundles a single source path (file, directory tree or symlink) into tw at
+// archiveName. Directories are recursed via addTreeToTar.
+func addPathToTar(tw *tar.Writer, source string, archiveName string) error {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return addTreeToTar(tw, source, archiveName, nil)
+	}
+
+	var linkTarget string
+	if info.Mode()&os.ModeSymlink != 0 {
+		if linkTarget, err = os.Readlink(source); err != nil {
+			return err
+		}
+	}
+	header, err := tar.FileInfoHeader(info, linkTarget)
+	if err != nil {
+		return err
+	}
+	header.Name = filepath.ToSlash(archiveName)
+	if err := tw.WriteHeader(header); err != nil {
+		return err
+	}
+	if info.Mode().IsRegular() {
+		file, err := os.Open(source)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		if _, err := io.Copy(tw, file); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addTreeToTar walks the directory tree at sourceRoot and writes its entries into tw under
+// archiveBase. WalkDir does not follow symlinks, so they are archived as links (preserving
+// the venv's internal structure). The optional skip predicate (keyed by source-relative
+// slash path) excludes entries; returning true on a directory prunes it.
+func addTreeToTar(tw *tar.Writer, sourceRoot string, archiveBase string, skip func(rel string) bool) error {
+	return filepath.WalkDir(sourceRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == sourceRoot {
+			return nil // the base itself is implied by its entries
+		}
+		rel, err := filepath.Rel(sourceRoot, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if skip != nil && skip(rel) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Lstat so symlinks are described as links, not their targets.
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+
+		var linkTarget string
+		if info.Mode()&os.ModeSymlink != 0 {
+			if linkTarget, err = os.Readlink(path); err != nil {
+				return err
+			}
+		}
+
+		header, err := tar.FileInfoHeader(info, linkTarget)
+		if err != nil {
+			return err
+		}
+		header.Name = filepath.ToSlash(filepath.Join(archiveBase, rel))
+		if info.IsDir() {
+			header.Name += "/"
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+
+		if info.Mode().IsRegular() {
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			_, copyErr := io.Copy(tw, file)
+			file.Close()
+			if copyErr != nil {
+				return copyErr
+			}
+		}
+		return nil
+	})
+}
+
+// InstallRelease extracts an Arduino App Release into the apps directory so it is ready to
+// be launched with `release start`. It validates board compatibility against the current
+// platform (unless force is set) and returns the new app ID together with the manifest.
+func InstallRelease(
+	ctx context.Context,
+	cfg config.Configuration,
+	tarPath *paths.Path,
+	idProvider *app.IDProvider,
+	bricksIndex *bricksindex.BricksIndex,
+	modelsIndex *modelsindex.ModelsIndex,
+	plat platform.Platform,
+	force bool,
+) (app.ID, *ReleaseManifest, error) {
+	if tarPath == nil {
+		return app.ID{}, nil, fmt.Errorf("internal error: tarPath cannot be nil")
+	}
+
+	rootPrefix, manifest, err := readReleaseMetadata(tarPath)
+	if err != nil {
+		return app.ID{}, nil, fmt.Errorf("%w: %v", ErrBadRequest, err)
+	}
+
+	// Format-version gate: a release written by a future CLI with an incompatible layout must
+	// not install silently and fail obscurely later. Compare the major version.
+	if manifest.FormatVersion != "" && releaseFormatMajor(manifest.FormatVersion) != releaseFormatMajor(ReleaseFormatVersion) {
+		return app.ID{}, manifest, fmt.Errorf("%w: release format version %q is not supported by this CLI (expected %q)",
+			ErrIncompatibleRelease, manifest.FormatVersion, ReleaseFormatVersion)
+	}
+
+	// Compatibility check: the prebuilt sketch binary and images are board/arch specific.
+	if !force {
+		if manifest.BoardName != "" && plat.BoardName != "" && manifest.BoardName != plat.BoardName {
+			return app.ID{}, manifest, fmt.Errorf("%w: release was built for board %q but this board is %q (use --force to override)",
+				ErrIncompatibleRelease, manifest.BoardName, plat.BoardName)
+		}
+		if manifest.Arch != "" && manifest.Arch != runtime.GOARCH {
+			return app.ID{}, manifest, fmt.Errorf("%w: release was built for architecture %q but this host is %q (use --force to override)",
+				ErrIncompatibleRelease, manifest.Arch, runtime.GOARCH)
+		}
+	}
+
+	rawAppName := rootPrefix
+	if rawAppName == "" {
+		rawAppName = strings.TrimSuffix(tarPath.Base(), ".tar.gz")
+		rawAppName = strings.TrimSuffix(rawAppName, filepath.Ext(rawAppName))
+	}
+
+	finalDestPath, appExists := findAppPathByName(rawAppName, cfg)
+	if appExists {
+		suffix := time.Now().Format("-20060102-150405")
+		finalDestPath, _ = findAppPathByName(rawAppName+suffix, cfg)
+	}
+
+	if !app.IsValidFolderName(finalDestPath.Base()) {
+		return app.ID{}, manifest, fmt.Errorf("%w: root folder name %q is not valid", ErrBadRequest, finalDestPath.Base())
+	}
+
+	tempDestDir, err := paths.MkTempDir(finalDestPath.Parent().String(), "tmp_pkg_")
+	if err != nil {
+		return app.ID{}, manifest, fmt.Errorf("unable to create temp app directory: %w", err)
+	}
+	defer func() { _ = tempDestDir.RemoveAll() }()
+
+	if err := extractTarGz(tarPath, tempDestDir, rootPrefix); err != nil {
+		return app.ID{}, manifest, err
+	}
+
+	if finalDestPath.Exist() {
+		return app.ID{}, manifest, ErrAppAlreadyExists
+	}
+
+	// Restore bundled AI models into the custom-models dir (outside the app folder), then
+	// drop the staging "models" folder so it is not moved into the apps directory.
+	if err := restoreBundledModels(cfg, manifest, tempDestDir, force); err != nil {
+		return app.ID{}, manifest, err
+	}
+	_ = tempDestDir.Join(releaseModelsDirPrefix).RemoveAll()
+
+	// Turn the extracted release into a regular (but release-flagged) app: localize the
+	// frozen compose to this machine and stamp the release metadata into app.yaml. From now
+	// on the normal `app start`/`app stop` commands operate on it.
+	if err := localizeInstalledRelease(ctx, cfg, bricksIndex, modelsIndex, plat, manifest, tempDestDir, finalDestPath); err != nil {
+		return app.ID{}, manifest, err
+	}
+
+	// Drop a template data/secrets.env for the user to fill in (only if the release declares
+	// required secrets and the file does not already exist).
+	if err := writeSecretsTemplate(manifest, tempDestDir); err != nil {
+		return app.ID{}, manifest, err
+	}
+
+	// Validate the extracted app before moving it to its final destination.
+	if _, err := app.Load(tempDestDir); err != nil {
+		return app.ID{}, manifest, fmt.Errorf("%w: invalid app: %v", ErrBadRequest, err)
+	}
+
+	if err := tempDestDir.Rename(finalDestPath); err != nil {
+		return app.ID{}, manifest, fmt.Errorf("failed to finalize release install: %w", err)
+	}
+
+	id, err := idProvider.IDFromPath(finalDestPath)
+	if err != nil {
+		return app.ID{}, manifest, err
+	}
+
+	return id, manifest, nil
+}
+
+// restoreBundledModels copies the model artifacts bundled in the release into the
+// destination custom-models dir, preserving their relative layout so the frozen compose's
+// ${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR} placeholders resolve correctly. This only copies
+// from the archive — it never downloads. Artifacts already present are left untouched unless
+// force is set.
+func restoreBundledModels(cfg config.Configuration, manifest *ReleaseManifest, extractedAppDir *paths.Path, force bool) error {
+	if manifest == nil {
+		return nil
+	}
+	modelsRoot := extractedAppDir.Join(releaseModelsDirPrefix)
+	for _, m := range manifest.Models {
+		if !m.Bundled {
+			continue
+		}
+		for _, rel := range m.Paths {
+			if rel == "" {
+				continue
+			}
+			// The manifest is attacker-controlled; a "../" or absolute path would let the
+			// copy read from / write to outside the extracted tree and the custom-models dir.
+			// Mirror the validation resolveAppModels does at build time.
+			clean := filepath.ToSlash(filepath.Clean(rel))
+			if filepath.IsAbs(rel) || clean == ".." || strings.HasPrefix(clean, "../") {
+				return fmt.Errorf("%w: model %q declares an illegal artifact path %q", ErrBadRequest, m.ID, rel)
+			}
+			src := modelsRoot.Join(filepath.FromSlash(clean))
+			if src.NotExist() {
+				return fmt.Errorf("%w: model %q artifact %q declared in the manifest is missing from the release archive",
+					ErrBadRequest, m.ID, rel)
+			}
+			dst := cfg.CustomModelsDir().Join(filepath.FromSlash(clean))
+			if err := mergeCopy(src, dst, force); err != nil {
+				return fmt.Errorf("installing model %q: %w", m.ID, err)
+			}
+		}
+	}
+	return nil
+}
+
+// mergeCopy copies src (a file or directory) to dst, creating parent directories. For
+// directories it merges into an existing destination. Existing files are kept unless force
+// is set. It never follows or copies into locations outside dst.
+func mergeCopy(src, dst *paths.Path, force bool) error {
+	info, err := os.Lstat(src.String())
+	if err != nil {
+		return err
+	}
+
+	if info.IsDir() {
+		if err := dst.MkdirAll(); err != nil {
+			return err
+		}
+		entries, err := src.ReadDir()
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			if err := mergeCopy(entry, dst.Join(entry.Base()), force); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if dst.Exist() && !force {
+		slog.Info("model artifact already present; keeping existing copy", slog.String("path", dst.String()))
+		return nil
+	}
+	if err := dst.Parent().MkdirAll(); err != nil {
+		return err
+	}
+	if dst.Exist() {
+		if err := dst.RemoveAll(); err != nil {
+			return err
+		}
+	}
+	return src.CopyTo(dst)
+}
+
+// localizeInstalledRelease converts an extracted release into a ready-to-run app on this
+// machine:
+//   - it produces the standard .cache/app-compose.yaml from the relocatable frozen compose
+//     by resolving the app path and custom-models dir for this destination (the ${HOST_IP}
+//     placeholder is left for the run command to fill, as for any app);
+//   - it stamps the release metadata (release number) into app.yaml so the normal run
+//     command launches it as a release (no recompilation / re-provisioning).
+//
+// The manifest file (arduino-app-release.yaml) extracted next to app.yaml is preserved.
+func localizeInstalledRelease(ctx context.Context, cfg config.Configuration, bricksIndex *bricksindex.BricksIndex, modelsIndex *modelsindex.ModelsIndex, plat platform.Platform, manifest *ReleaseManifest, extractedAppDir *paths.Path, finalAppPath *paths.Path) error {
+	cacheDir := extractedAppDir.Join(".cache")
+	frozen := cacheDir.Join("release-compose.yaml")
+	if frozen.NotExist() {
+		return fmt.Errorf("%w: release is missing its compose file (%s)", ErrBadRequest, frozen.Base())
+	}
+
+	content, err := frozen.ReadFile()
+	if err != nil {
+		return fmt.Errorf("reading frozen compose: %w", err)
+	}
+	localized := string(content)
+	// Resolve the stable, host-specific paths now.
+	localized = strings.ReplaceAll(localized, appHomePlaceholder, finalAppPath.String())
+	localized = strings.ReplaceAll(localized, customModelDirPlaceholder, cfg.CustomModelsDir().String())
+
+	// Resolve the remaining host-specific env placeholders (HOST_IP, MODELS_PATH,
+	// CUSTOM_MODEL_PATH) to this machine's values, so the installed compose looks like a
+	// normally provisioned one and read-only commands (`app logs`, `app stop`) don't warn
+	// about unset variables. HOST_IP keeps a ${HOST_IP:-<ip>} form so each `app start` still
+	// re-resolves the current address while offline commands fall back to a concrete value.
+	localized = localizeHostSpecificEnv(ctx, localized, cfg, bricksIndex, modelsIndex, plat, extractedAppDir)
+
+	if err := cacheDir.Join("app-compose.yaml").WriteFile([]byte(localized)); err != nil {
+		return fmt.Errorf("writing app compose: %w", err)
+	}
+	_ = frozen.Remove() // superseded by app-compose.yaml
+
+	// Stamp the release metadata into app.yaml.
+	descriptorPath := extractedAppDir.Join("app.yaml")
+	descriptor, err := app.ParseDescriptorFile(descriptorPath)
+	if err != nil {
+		return fmt.Errorf("reading app.yaml: %w", err)
+	}
+	release := ""
+	if manifest != nil {
+		release = manifest.Release
+	}
+	descriptor.FrozenRelease = &app.FrozenReleaseInfo{Number: release}
+	out, err := yaml.Marshal(descriptor)
+	if err != nil {
+		return fmt.Errorf("marshaling app.yaml: %w", err)
+	}
+	if err := descriptorPath.WriteFile(out); err != nil {
+		return fmt.Errorf("writing app.yaml: %w", err)
+	}
+	return nil
+}
+
+// localizeHostSpecificEnv replaces the ${HOST_IP}/${MODELS_PATH}/${CUSTOM_MODEL_PATH}
+// placeholders that tokenizeHostSpecificEnv left in the frozen compose with this machine's
+// concrete values, computed the same way a normal `app start` would (getAppEnvironmentVariables).
+// The stable ones (paths) become literals; HOST_IP becomes a ${HOST_IP:-<ip>} default so it
+// still refreshes at each start but never renders empty for offline commands. If the app or
+// its environment cannot be resolved, the placeholders are left as-is (they are still filled
+// at run time) rather than failing the install.
+func localizeHostSpecificEnv(ctx context.Context, compose string, cfg config.Configuration, bricksIndex *bricksindex.BricksIndex, modelsIndex *modelsindex.ModelsIndex, plat platform.Platform, extractedAppDir *paths.Path) string {
+	installedApp, err := app.Load(extractedAppDir)
+	if err != nil {
+		slog.Warn("could not load app to localize release compose env; leaving placeholders", slog.String("error", err.Error()))
+		return compose
+	}
+	envs := getAppEnvironmentVariables(ctx, installedApp, bricksIndex, modelsIndex, plat, cfg)
+	return applyHostEnvDefaults(compose, envs)
+}
+
+// applyHostEnvDefaults rewrites each ${KEY} host-specific placeholder to its concrete value
+// from envs. Path values become literals (they are stable on this machine); HOST_IP becomes a
+// ${HOST_IP:-<ip>} default so `app start` still refreshes it from the run environment while
+// offline commands resolve it to a concrete address instead of a blank string. Keys missing
+// from envs are left as bare placeholders (still filled at run time).
+func applyHostEnvDefaults(compose string, envs helpers.EnvVars) string {
+	for _, key := range hostSpecificEnvKeys {
+		v := envs[key]
+		if v == "" {
+			continue
+		}
+		replacement := v
+		if key == "HOST_IP" {
+			replacement = "${" + key + ":-" + v + "}"
+		}
+		compose = strings.ReplaceAll(compose, "${"+key+"}", replacement)
+	}
+	return compose
+}
+
+// renderSecretsTemplate produces the content of a data/secrets.env template listing the
+// secrets the user must provide, so they know what to fill in.
+func renderSecretsTemplate(required []ReleaseSecret) []byte {
+	var b strings.Builder
+	b.WriteString("# Secrets required by this Arduino App.\n")
+	b.WriteString("# Fill in the values below, then start the app with `arduino-app-cli app start`.\n")
+	b.WriteString("# These values are NOT included in the release/export and stay on this machine.\n\n")
+	for _, s := range required {
+		if s.Brick != "" {
+			b.WriteString(fmt.Sprintf("# required by brick %s\n", s.Brick))
+		}
+		b.WriteString(s.Name + "=\n")
+	}
+	return []byte(b.String())
+}
+
+// writeSecretsTemplate creates a data/secrets.env template listing the secrets the release
+// requires, so the user knows what to fill in. It never overwrites an existing file.
+func writeSecretsTemplate(manifest *ReleaseManifest, extractedAppDir *paths.Path) error {
+	if manifest == nil || len(manifest.RequiredSecrets) == 0 {
+		return nil
+	}
+	dest := extractedAppDir.Join("data", "secrets.env")
+	if dest.Exist() {
+		return nil
+	}
+	if err := dest.Parent().MkdirAll(); err != nil {
+		return fmt.Errorf("creating data dir: %w", err)
+	}
+	if err := dest.WriteFile(renderSecretsTemplate(manifest.RequiredSecrets)); err != nil {
+		return fmt.Errorf("writing secrets template: %w", err)
+	}
+	return nil
+}
+
+// secretPlaceholderRE matches an env value that is exactly a ${NAME} reference, i.e. a
+// secret that was scrubbed at build time and must be supplied on this machine.
+var secretPlaceholderRE = regexp.MustCompile(`^\$\{[A-Za-z_][A-Za-z0-9_]*\}$`)
+
+// declaredSecretNames returns the authoritative set of secret variable names for an
+// installed app: those declared in its release manifest (a frozen release) and/or listed in
+// its data/secrets.env template (a scrubbed export). Driving secret resolution from this
+// declared set — rather than from any ${NAME}-shaped env value — avoids misclassifying a
+// legitimate non-secret ${...} value as a required secret.
+func declaredSecretNames(arduinoApp app.ArduinoApp) []string {
+	seen := make(map[string]struct{})
+	var names []string
+	add := func(n string) {
+		if n == "" {
+			return
+		}
+		if _, ok := seen[n]; !ok {
+			seen[n] = struct{}{}
+			names = append(names, n)
+		}
+	}
+
+	if mp := arduinoApp.ReleaseManifestPath(); mp != nil && mp.Exist() {
+		if data, err := mp.ReadFile(); err == nil {
+			var m ReleaseManifest
+			if err := yaml.Unmarshal(data, &m); err == nil {
+				for _, s := range m.RequiredSecrets {
+					add(s.Name)
+				}
+			} else {
+				slog.Warn("failed to parse release manifest for secret names", slog.String("path", mp.String()), slog.Any("error", err))
+			}
+		}
+	}
+
+	if sf := arduinoApp.SecretsEnvFilePath(); sf != nil && sf.Exist() {
+		if parsed, err := parseEnvFile(sf.String()); err == nil {
+			for k := range parsed {
+				add(k)
+			}
+		}
+	}
+
+	return names
+}
+
+// applyReleaseSecrets resolves the scrubbed secrets of a released app from its
+// data/secrets.env file and injects the values into envs (so `docker compose up` can
+// interpolate the ${NAME} placeholders in the frozen compose). The set of required secrets
+// is taken from the app's release manifest / secrets.env template (see declaredSecretNames);
+// only declared secrets that are actually referenced by this app's env (still a ${NAME}
+// placeholder) are resolved. It returns the names of secrets that are still missing/empty so
+// the caller can fail with a clear message. It never downloads anything.
+func applyReleaseSecrets(arduinoApp app.ArduinoApp, envs helpers.EnvVars) ([]string, error) {
+	declared := declaredSecretNames(arduinoApp)
+	// Fallback: infer required secrets from env values still shaped like ${NAME}. This is only
+	// safe for release/exported apps (whose secrets were deliberately scrubbed to placeholders);
+	// applying it to a normal app would misclassify a legitimate compose passthrough such as
+	// `TZ: ${TZ}` as a missing required secret and refuse to start. Restrict it to frozen
+	// releases, which is the only case where declaredSecretNames can come up empty yet the
+	// compose legitimately still contains ${NAME} secret placeholders (e.g. an unreadable
+	// manifest).
+	if len(declared) == 0 && arduinoApp.IsFrozenRelease() {
+		for name, value := range envs {
+			if secretPlaceholderRE.MatchString(value) {
+				declared = append(declared, name)
+			}
+		}
+	}
+	if len(declared) == 0 {
+		return nil, nil
+	}
+
+	values := map[string]string{}
+	secretsFile := arduinoApp.SecretsEnvFilePath()
+	if secretsFile.Exist() {
+		parsed, err := parseEnvFile(secretsFile.String())
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", secretsFile, err)
+		}
+		values = parsed
+	}
+
+	var missing []string
+	for _, name := range declared {
+		// Only act on declared secrets this app actually references and hasn't resolved yet.
+		cur, inEnv := envs[name]
+		if !inEnv || !secretPlaceholderRE.MatchString(cur) {
+			continue
+		}
+		if v, ok := values[name]; ok && v != "" {
+			envs[name] = v
+		} else {
+			missing = append(missing, name)
+		}
+	}
+	sort.Strings(missing)
+	return missing, nil
+}
+
+// parseEnvFile reads a minimal KEY=VALUE env file (blank lines and #-comments ignored).
+// Surrounding single/double quotes around the value are stripped.
+func parseEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path) // nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	values := map[string]string{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if len(value) >= 2 {
+			if (value[0] == '"' && value[len(value)-1] == '"') || (value[0] == '\'' && value[len(value)-1] == '\'') {
+				value = value[1 : len(value)-1]
+			}
+		}
+		if key != "" {
+			values[key] = value
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+// readReleaseMetadata scans the archive for its root prefix and parses the release
+// manifest. It validates the archive really is an app release.
+func readReleaseMetadata(tarPath *paths.Path) (string, *ReleaseManifest, error) {
+	f, err := os.Open(tarPath.String())
+	if err != nil {
+		return "", nil, fmt.Errorf("unable to open release: %w", err)
+	}
+	defer f.Close()
+
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		return "", nil, fmt.Errorf("not a valid .tar.gz release: %w", err)
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	var manifest *ReleaseManifest
+	rootPrefix := ""
+	foundManifest := false
+	// The real manifest lives at the archive root ("<root>/arduino-app-release.yaml" or the
+	// bare root). Pick the shallowest match so a decoy manifest planted deeper in the tree
+	// (e.g. under models/) cannot hijack the root prefix, regardless of entry order.
+	bestDepth := int(^uint(0) >> 1)
+
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return "", nil, fmt.Errorf("reading release: %w", err)
+		}
+		name := filepath.ToSlash(filepath.Clean(header.Name))
+		if filepath.Base(name) != ReleaseManifestFileName {
+			continue
+		}
+		dir := filepath.ToSlash(filepath.Dir(name))
+		depth := 0
+		if dir != "." {
+			depth = strings.Count(dir, "/") + 1
+		}
+		if depth >= bestDepth {
+			continue // a shallower (or equal, already-taken) manifest wins
+		}
+		data, err := io.ReadAll(io.LimitReader(tr, maxManifestSize))
+		if err != nil {
+			return "", nil, fmt.Errorf("reading manifest: %w", err)
+		}
+		var m ReleaseManifest
+		if err := yaml.Unmarshal(data, &m); err != nil {
+			return "", nil, fmt.Errorf("invalid manifest: %w", err)
+		}
+		manifest = &m
+		if dir != "." {
+			rootPrefix = dir
+		} else {
+			rootPrefix = ""
+		}
+		bestDepth = depth
+		foundManifest = true
+	}
+
+	if !foundManifest {
+		return "", nil, fmt.Errorf("%s not found in archive: not an Arduino App Release", ReleaseManifestFileName)
+	}
+	return rootPrefix, manifest, nil
+}
+
+// archiveRelativeName cleans a raw tar entry name and, if rootPrefixSlash is set, strips
+// it, reporting ok=false for entries outside rootPrefix (to be skipped by the caller).
+func archiveRelativeName(rawName, rootPrefixSlash string) (name string, ok bool) {
+	name = filepath.ToSlash(filepath.Clean(rawName))
+	if rootPrefixSlash != "" && rootPrefixSlash != "." {
+		if name != rootPrefixSlash && !strings.HasPrefix(name, rootPrefixSlash+"/") {
+			return "", false
+		}
+		name = strings.TrimPrefix(name, rootPrefixSlash)
+		name = strings.TrimPrefix(name, "/")
+	}
+	if name == "" || name == "." {
+		return "", false
+	}
+	return name, true
+}
+
+// collectArchiveNames does a first pass over the archive to gather every entry's
+// (rootPrefix-stripped) name, used to check whether an absolute symlink target would be
+// treated as a directory by another entry later in the same archive.
+func collectArchiveNames(tarPath *paths.Path, rootPrefixSlash string) ([]string, error) {
+	f, err := os.Open(tarPath.String())
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, err
+	}
+	defer gr.Close()
+
+	var names []string
+	tr := tar.NewReader(gr)
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading release entry: %w", err)
+		}
+		if name, ok := archiveRelativeName(header.Name, rootPrefixSlash); ok {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+// nestedUnder reports whether some other entry in names is nested under name, i.e. name
+// would be traversed as a directory component to reach it.
+func nestedUnder(names []string, name string) bool {
+	prefix := name + "/"
+	for _, n := range names {
+		if n != name && strings.HasPrefix(n, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// realParentWithinDest verifies that target's parent directory, after resolving any symlinks
+// already present on disk, is still inside dest. The lexical destClean-prefix check on target
+// only inspects the literal path; this catches writes that would traverse a symlinked path
+// component (e.g. a relative symlink pointing at an earlier absolute symlink) to escape dest.
+// The parent directory must already exist when this is called.
+func realParentWithinDest(target, destClean string) error {
+	realParent, err := filepath.EvalSymlinks(filepath.Dir(target))
+	if err != nil {
+		return fmt.Errorf("resolving parent of release entry %s: %w", target, err)
+	}
+	if !strings.HasPrefix(realParent+string(os.PathSeparator), destClean) {
+		return fmt.Errorf("illegal release entry (escapes destination via a symlinked path): %s", target)
+	}
+	return nil
+}
+
+// extractTarGz extracts the archive into dest, stripping rootPrefix, with protection
+// against path traversal and oversized files. Symlinks are preserved (needed by the venv).
+func extractTarGz(tarPath *paths.Path, dest *paths.Path, rootPrefix string) error {
+	rootPrefixSlash := filepath.ToSlash(rootPrefix)
+
+	// First pass: gather all entry names so absolute symlinks can be checked against being
+	// used as a directory by a later entry (which would let it write outside dest).
+	allNames, err := collectArchiveNames(tarPath, rootPrefixSlash)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(tarPath.String())
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer gr.Close()
+
+	destClean := filepath.Clean(dest.String()) + string(os.PathSeparator)
+
+	entryCount := 0
+	var totalWritten int64
+
+	tr := tar.NewReader(gr)
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading release entry: %w", err)
+		}
+
+		entryCount++
+		if entryCount > maxReleaseEntries {
+			return fmt.Errorf("release has too many entries (limit %d)", maxReleaseEntries)
+		}
+
+		name, ok := archiveRelativeName(header.Name, rootPrefixSlash)
+		if !ok {
+			continue
+		}
+
+		target := filepath.Join(dest.String(), filepath.FromSlash(name))
+		if !strings.HasPrefix(target, destClean) {
+			return fmt.Errorf("illegal file path in release: %s", header.Name)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("create parent directory: %w", err)
+			}
+			if err := realParentWithinDest(target, destClean); err != nil {
+				return err
+			}
+			if err := os.MkdirAll(target, os.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("create directory %s: %w", target, err)
+			}
+		case tar.TypeSymlink:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("create parent directory: %w", err)
+			}
+			if err := realParentWithinDest(target, destClean); err != nil {
+				return err
+			}
+			// Absolute targets are only safe when nothing else in the archive is nested
+			// under this entry's path: otherwise a later entry could be written through
+			// it to an arbitrary host location. The Python venv legitimately needs
+			// absolute symlinks (bin/python -> the interpreter baked into the base
+			// image), so a bare absolute leaf symlink is allowed; relative targets must
+			// still resolve inside dest.
+			if filepath.IsAbs(header.Linkname) {
+				if nestedUnder(allNames, name) {
+					return fmt.Errorf("illegal absolute symlink target in release: %s -> %s", header.Name, header.Linkname)
+				}
+			} else {
+				resolved := filepath.Join(filepath.Dir(target), filepath.FromSlash(header.Linkname))
+				if !strings.HasPrefix(resolved, destClean) {
+					return fmt.Errorf("illegal symlink target in release: %s -> %s", header.Name, header.Linkname)
+				}
+			}
+			_ = os.Remove(target)
+			if err := os.Symlink(header.Linkname, target); err != nil {
+				return fmt.Errorf("create symlink %s: %w", target, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("create parent directory: %w", err)
+			}
+			if err := realParentWithinDest(target, destClean); err != nil {
+				return err
+			}
+			// Remove any pre-existing entry (e.g. a symlink planted by an earlier entry with
+			// the same name) so we never truncate/write *through* it to an arbitrary path.
+			// O_EXCL then guarantees a fresh, non-followed regular file at this path.
+			_ = os.Remove(target)
+			outFile, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, os.FileMode(header.Mode))
+			if err != nil {
+				return fmt.Errorf("create file %s: %w", target, err)
+			}
+			written, err := io.Copy(outFile, io.LimitReader(tr, maxReleaseFileSize+1))
+			outFile.Close()
+			if err != nil {
+				return fmt.Errorf("write file %s: %w", target, err)
+			}
+			if written > maxReleaseFileSize {
+				return fmt.Errorf("file %s too large", header.Name)
+			}
+			totalWritten += written
+			if totalWritten > maxReleaseTotalSize {
+				return fmt.Errorf("release too large when uncompressed (limit %d bytes)", maxReleaseTotalSize)
+			}
+		default:
+			slog.Debug("skipping unsupported tar entry", slog.String("name", header.Name), slog.Int("type", int(header.Typeflag)))
+		}
+	}
+	return nil
+}
+
+// uploadPrebuiltSketch flashes the already-compiled sketch binary found in the app's
+// build cache to the microcontroller. It mirrors the upload tail of compileUploadSketch
+// but never invokes the compiler.
+func uploadPrebuiltSketch(
+	ctx context.Context,
+	plat platform.Platform,
+	arduinoApp app.ArduinoApp,
+	w io.Writer,
+) error {
+	sketchPath, ok := arduinoApp.GetSketchPath()
+	if !ok {
+		return fmt.Errorf("no sketch path found in the Arduino app")
+	}
+	buildPath := arduinoApp.SketchBuildPath()
+	if buildPath.NotExist() {
+		return fmt.Errorf("%w: prebuilt sketch not found at %s", ErrNotFrozenRelease, buildPath.String())
+	}
+
+	logrus.SetLevel(logrus.ErrorLevel) // Reduce the log level of arduino-cli
+	srv := commands.NewArduinoCoreServer()
+	if err := SetArduinoCliConfig(ctx, srv); err != nil {
+		return err
+	}
+
+	var inst *rpc.Instance
+	if resp, err := srv.Create(ctx, &rpc.CreateRequest{}); err != nil {
+		return err
+	} else {
+		inst = resp.GetInstance()
+	}
+	defer func() {
+		_, _ = srv.Destroy(ctx, &rpc.DestroyRequest{Instance: inst})
+	}()
+
+	sketchResp, err := srv.LoadSketch(ctx, &rpc.LoadSketchRequest{SketchPath: sketchPath.String()})
+	if err != nil {
+		return err
+	}
+	profile := sketchResp.GetSketch().GetDefaultProfile().GetName()
+	if profile == "" {
+		return fmt.Errorf("sketch %q has no default profile", sketchPath)
+	}
+
+	if err := srv.Init(
+		&rpc.InitRequest{Instance: inst, SketchPath: sketchPath.String(), Profile: profile},
+		commands.InitStreamResponseToCallbackFunction(ctx, func(r *rpc.InitResponse) error {
+			slog.Debug("Arduino init instance", slog.String("instance", r.String()))
+			return nil
+		}),
+	); err != nil {
+		return err
+	}
+
+	menuOptions, err := GetPlatformMenuOptions(ctx, plat)
+	if err != nil {
+		slog.Warn("failed to get platform menu options", slog.String("error", err.Error()))
+	}
+
+	// Support the legacy ram upload option if there isn't the new wait_linux_boot option.
+	if !menuOptions.Has(WaitForApp) && plat.SupportFlashToRam() {
+		if err := legacyUploadSketchInRam(ctx, w, srv, inst, plat, sketchPath.String(), buildPath.String()); err != nil {
+			slog.Warn("failed to upload in ram mode, retrying after configuring ram mode", slog.String("error", err.Error()))
+			if err := configureMicroInRamMode(ctx, w, srv, inst, plat); err != nil {
+				return err
+			}
+			return legacyUploadSketchInRam(ctx, w, srv, inst, plat, sketchPath.String(), buildPath.String())
+		}
+		return nil
+	}
+
+	stream, _ := commands.UploadToServerStreams(ctx, w, w)
+	return srv.Upload(&rpc.UploadRequest{
+		Instance:   inst,
+		Fqbn:       plat.FQBN,
+		SketchPath: sketchPath.String(),
+		ImportDir:  buildPath.String(),
+	}, stream)
+}

--- a/internal/orchestrator/release_prepare.go
+++ b/internal/orchestrator/release_prepare.go
@@ -1,0 +1,81 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/docker/cli/cli/command"
+
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+)
+
+// PrepareRelease pre-pulls the Docker images referenced by an installed app's localized
+// compose file (`.cache/app-compose.yaml`) so that a subsequent `app start` finds them
+// locally and does not need to reach the network.
+//
+// It deliberately does NOT start the app, and it never downloads AI models — model
+// artifacts are already on disk (restored at install time); only containers are ever
+// pulled. Images that are already present locally are skipped, mirroring the
+// `docker compose up --pull missing` behavior used at start.
+func PrepareRelease(ctx context.Context, arduinoApp app.ArduinoApp, dockerClient command.Cli, cb func(StreamMessage)) error {
+	emit := func(msg string) {
+		if cb != nil {
+			cb(StreamMessage{data: msg})
+		}
+	}
+
+	composePath := arduinoApp.AppComposeFilePath()
+	if composePath == nil || !composePath.Exist() {
+		return fmt.Errorf("%w: app has no prepared compose file (%s); install the release first", ErrBadRequest, composePath)
+	}
+	composeBytes, err := composePath.ReadFile()
+	if err != nil {
+		return fmt.Errorf("failed to read compose file %s: %w", composePath, err)
+	}
+
+	images := extractComposeImages(composeBytes)
+	if len(images) == 0 {
+		emit("No container images referenced by the app; nothing to prepare")
+		return nil
+	}
+
+	alreadyPulled, err := listImagesAlreadyPulled(ctx, dockerClient.Client())
+	if err != nil {
+		return fmt.Errorf("failed to list local docker images: %w", err)
+	}
+
+	toPull := imagesToPull(images, alreadyPulled)
+	emit(fmt.Sprintf("%d image(s) referenced, %d already present, %d to pull",
+		len(images), len(images)-len(toPull), len(toPull)))
+
+	writer := NewCallbackWriter(func(line string) { emit(line) })
+	for _, image := range toPull {
+		emit(fmt.Sprintf("Pulling %s", image))
+		if err := pullImage(ctx, writer, dockerClient.Client(), image); err != nil {
+			return fmt.Errorf("failed to pull image %s: %w", image, err)
+		}
+	}
+
+	emit("All required container images are present locally")
+	return nil
+}
+
+// imagesToPull returns, in input order, the subset of images that are not already present
+// locally. Order is preserved and inputs are assumed already de-duplicated (as produced by
+// extractComposeImages).
+func imagesToPull(images []string, alreadyPulled []string) []string {
+	var toPull []string
+	for _, image := range images {
+		if slices.Contains(alreadyPulled, image) {
+			continue
+		}
+		toPull = append(toPull, image)
+	}
+	return toPull
+}

--- a/internal/orchestrator/release_prepare_test.go
+++ b/internal/orchestrator/release_prepare_test.go
@@ -1,0 +1,53 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package orchestrator
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestImagesToPull(t *testing.T) {
+	tests := []struct {
+		name          string
+		images        []string
+		alreadyPulled []string
+		want          []string
+	}{
+		{
+			name:          "none present pulls all in order",
+			images:        []string{"a:1", "b:2", "c:3"},
+			alreadyPulled: nil,
+			want:          []string{"a:1", "b:2", "c:3"},
+		},
+		{
+			name:          "some present are skipped, order preserved",
+			images:        []string{"a:1", "b:2", "c:3"},
+			alreadyPulled: []string{"b:2"},
+			want:          []string{"a:1", "c:3"},
+		},
+		{
+			name:          "all present pulls nothing",
+			images:        []string{"a:1", "b:2"},
+			alreadyPulled: []string{"b:2", "a:1", "z:9"},
+			want:          nil,
+		},
+		{
+			name:          "no images",
+			images:        nil,
+			alreadyPulled: []string{"a:1"},
+			want:          nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := imagesToPull(tt.images, tt.alreadyPulled)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("imagesToPull(%v, %v) = %v, want %v", tt.images, tt.alreadyPulled, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/release_test.go
+++ b/internal/orchestrator/release_test.go
@@ -1,0 +1,711 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package orchestrator
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/arduino/go-paths-helper"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arduino/arduino-app-cli/internal/helpers"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
+	"github.com/arduino/arduino-app-cli/internal/platform"
+)
+
+func TestReleaseRootFolderName(t *testing.T) {
+	require.Equal(t, "my-app", releaseRootFolderName("My App"))
+	require.Equal(t, "smart-garden", releaseRootFolderName("Smart Garden"))
+	require.Equal(t, "app-release", releaseRootFolderName(""))
+}
+
+func TestExtractComposeImages(t *testing.T) {
+	compose := []byte(`
+name: demo
+services:
+  main:
+    image: ghcr.io/arduino/app-bricks/python-apps-base:0.11.0rc6
+  db:
+    image: postgres:16
+  db2:
+    image: postgres:16
+`)
+	images := extractComposeImages(compose)
+	require.ElementsMatch(t, []string{
+		"ghcr.io/arduino/app-bricks/python-apps-base:0.11.0rc6",
+		"postgres:16",
+	}, images)
+}
+
+// writeFile is a small helper to create a file with content, making parents as needed.
+func writeFile(t *testing.T, p *paths.Path, content string) {
+	t.Helper()
+	require.NoError(t, p.Parent().MkdirAll())
+	require.NoError(t, p.WriteFile([]byte(content)))
+}
+
+func TestWriteAndExtractTarGzRoundTrip(t *testing.T) {
+	src := paths.New(t.TempDir())
+
+	// A representative app layout.
+	writeFile(t, src.Join("app.yaml"), "name: Demo App\n")
+	writeFile(t, src.Join("python", "main.py"), "print('hi')\n")
+	writeFile(t, src.Join("sketch", "sketch.ino"), "void setup(){}\n")
+	writeFile(t, src.Join(".cache", "sketch", "sketch.ino.bin"), "BINARY")
+	writeFile(t, src.Join(".cache", "venv", "pyvenv.cfg"), "home = /usr\n")
+	// These must be excluded by the packer:
+	writeFile(t, src.Join("data", "secret.db"), "PRIVATE")
+	writeFile(t, src.Join(".cache", "app-compose.yaml"), "name: host-baked\n")
+	writeFile(t, src.Join(".cache", "app-compose-overrides.yaml"), "services: {}\n")
+
+	out := paths.New(t.TempDir()).Join("demo.tar.gz")
+
+	manifest := []byte("format_version: \"1.0\"\napp_name: Demo App\nboard_name: unoq\n")
+	frozen := []byte("name: demo\nservices:\n  main:\n    image: x:1\n")
+	// app.yaml is provided via extraFiles (scrubbed), not from the walk.
+	extra := map[string][]byte{
+		"app.yaml":                    []byte("name: Demo App\n"),
+		ReleaseManifestFileName:       manifest,
+		".cache/release-compose.yaml": frozen,
+	}
+
+	require.NoError(t, writeAppTarGz(src, "demo", out, extra, nil))
+	require.True(t, out.Exist())
+
+	// Metadata reads back the manifest and detects the root prefix.
+	rootPrefix, m, err := readReleaseMetadata(out)
+	require.NoError(t, err)
+	require.Equal(t, "demo", rootPrefix)
+	require.Equal(t, "Demo App", m.AppName)
+	require.Equal(t, "unoq", m.BoardName)
+
+	// Extract and verify contents.
+	dest := paths.New(t.TempDir()).Join("extracted")
+	require.NoError(t, dest.MkdirAll())
+	require.NoError(t, extractTarGz(out, dest, rootPrefix))
+
+	requireFileContent(t, dest.Join("app.yaml"), "name: Demo App\n")
+	requireFileContent(t, dest.Join("python", "main.py"), "print('hi')\n")
+	requireFileContent(t, dest.Join(".cache", "sketch", "sketch.ino.bin"), "BINARY")
+	requireFileContent(t, dest.Join(".cache", "venv", "pyvenv.cfg"), "home = /usr\n")
+	requireFileContent(t, dest.Join(ReleaseManifestFileName), string(manifest))
+	requireFileContent(t, dest.Join(".cache", "release-compose.yaml"), string(frozen))
+
+	// Excluded entries must not be present.
+	require.False(t, dest.Join("data", "secret.db").Exist(), "data/ must be excluded")
+	require.False(t, dest.Join(".cache", "app-compose.yaml").Exist(), "host-baked compose must be excluded")
+	require.False(t, dest.Join(".cache", "app-compose-overrides.yaml").Exist(), "host-baked override must be excluded")
+}
+
+// rawTarEntry describes a single tar entry built directly (bypassing the filesystem walk)
+// so tests can craft archives an attacker could produce, e.g. a symlink nested by another
+// entry, without ever touching the real filesystem outside the test's temp dirs.
+type rawTarEntry struct {
+	name     string
+	linkname string
+	typeflag byte
+	content  string
+}
+
+func writeRawTarGz(t *testing.T, out *paths.Path, entries []rawTarEntry) {
+	t.Helper()
+	require.NoError(t, out.Parent().MkdirAll())
+	f, err := os.Create(out.String())
+	require.NoError(t, err)
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	for _, e := range entries {
+		mode := int64(0o644)
+		if e.typeflag == tar.TypeSymlink {
+			mode = 0o777
+		}
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name:     e.name,
+			Linkname: e.linkname,
+			Typeflag: e.typeflag,
+			Mode:     mode,
+			Size:     int64(len(e.content)),
+		}))
+		if e.content != "" {
+			_, err := tw.Write([]byte(e.content))
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+}
+
+const testManifest = "format_version: \"1.0\"\napp_name: Demo App\nboard_name: unoq\n"
+
+func TestExtractTarGzAllowsLeafAbsoluteSymlink(t *testing.T) {
+	// A Python venv's bin/python is legitimately an absolute symlink to the interpreter
+	// baked into the base image; install must not reject it.
+	out := paths.New(t.TempDir()).Join("demo.tar.gz")
+	writeRawTarGz(t, out, []rawTarEntry{
+		{name: "demo/" + ReleaseManifestFileName, typeflag: tar.TypeReg, content: testManifest},
+		{name: "demo/.cache/venv/bin/python", typeflag: tar.TypeSymlink, linkname: "/usr/local/bin/python"},
+	})
+
+	rootPrefix, _, err := readReleaseMetadata(out)
+	require.NoError(t, err)
+
+	dest := paths.New(t.TempDir()).Join("extracted")
+	require.NoError(t, dest.MkdirAll())
+	require.NoError(t, extractTarGz(out, dest, rootPrefix))
+
+	target, err := os.Readlink(dest.Join(".cache", "venv", "bin", "python").String())
+	require.NoError(t, err)
+	require.Equal(t, "/usr/local/bin/python", target)
+}
+
+func TestExtractTarGzRejectsAbsoluteSymlinkUsedAsDirectory(t *testing.T) {
+	// An absolute symlink that a later entry nests under would let install write outside
+	// dest (e.g. onto /usr/local/bin on the host) once the OS resolves the path.
+	out := paths.New(t.TempDir()).Join("demo.tar.gz")
+	writeRawTarGz(t, out, []rawTarEntry{
+		{name: "demo/" + ReleaseManifestFileName, typeflag: tar.TypeReg, content: testManifest},
+		{name: "demo/.cache/escape", typeflag: tar.TypeSymlink, linkname: "/usr/local/bin"},
+		{name: "demo/.cache/escape/evil", typeflag: tar.TypeReg, content: "PAYLOAD"},
+	})
+
+	rootPrefix, _, err := readReleaseMetadata(out)
+	require.NoError(t, err)
+
+	dest := paths.New(t.TempDir()).Join("extracted")
+	require.NoError(t, dest.MkdirAll())
+	err = extractTarGz(out, dest, rootPrefix)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "illegal absolute symlink target")
+}
+
+func TestExtractTarGzRejectsEscapingRelativeSymlink(t *testing.T) {
+	out := paths.New(t.TempDir()).Join("demo.tar.gz")
+	writeRawTarGz(t, out, []rawTarEntry{
+		{name: "demo/" + ReleaseManifestFileName, typeflag: tar.TypeReg, content: testManifest},
+		{name: "demo/escape", typeflag: tar.TypeSymlink, linkname: "../../../etc/passwd"},
+	})
+
+	rootPrefix, _, err := readReleaseMetadata(out)
+	require.NoError(t, err)
+
+	dest := paths.New(t.TempDir()).Join("extracted")
+	require.NoError(t, dest.MkdirAll())
+	err = extractTarGz(out, dest, rootPrefix)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "illegal symlink target")
+}
+
+func TestExtractTarGzRejectsRegularFileThroughPlantedSymlink(t *testing.T) {
+	// A leaf absolute symlink is allowed, but a later regular-file entry with the SAME name
+	// must not be written *through* it (which would overwrite an arbitrary host file).
+	victim := paths.New(t.TempDir()).Join("victim.txt")
+	require.NoError(t, victim.WriteFile([]byte("ORIGINAL")))
+
+	out := paths.New(t.TempDir()).Join("demo.tar.gz")
+	writeRawTarGz(t, out, []rawTarEntry{
+		{name: "demo/" + ReleaseManifestFileName, typeflag: tar.TypeReg, content: testManifest},
+		{name: "demo/pwn", typeflag: tar.TypeSymlink, linkname: victim.String()},
+		{name: "demo/pwn", typeflag: tar.TypeReg, content: "PWNED"},
+	})
+
+	rootPrefix, _, err := readReleaseMetadata(out)
+	require.NoError(t, err)
+
+	dest := paths.New(t.TempDir()).Join("extracted")
+	require.NoError(t, dest.MkdirAll())
+	require.NoError(t, extractTarGz(out, dest, rootPrefix)) // remove-before-create makes it a no-op write
+
+	got, err := os.ReadFile(victim.String())
+	require.NoError(t, err)
+	require.Equal(t, "ORIGINAL", string(got), "host file must not be overwritten through the symlink")
+}
+
+func TestExtractTarGzRejectsRelativeToAbsoluteSymlinkChain(t *testing.T) {
+	// escape -> /abs (absolute, allowed), link -> escape (relative, lexically inside dest),
+	// then link/f: writing it must NOT traverse the chain to /abs.
+	outside := paths.New(t.TempDir()) // an existing absolute dir outside dest
+	out := paths.New(t.TempDir()).Join("demo.tar.gz")
+	writeRawTarGz(t, out, []rawTarEntry{
+		{name: "demo/" + ReleaseManifestFileName, typeflag: tar.TypeReg, content: testManifest},
+		{name: "demo/escape", typeflag: tar.TypeSymlink, linkname: outside.String()},
+		{name: "demo/link", typeflag: tar.TypeSymlink, linkname: "escape"},
+		{name: "demo/link/f", typeflag: tar.TypeReg, content: "PWNED"},
+	})
+
+	rootPrefix, _, err := readReleaseMetadata(out)
+	require.NoError(t, err)
+
+	dest := paths.New(t.TempDir()).Join("extracted")
+	require.NoError(t, dest.MkdirAll())
+	err = extractTarGz(out, dest, rootPrefix)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "escapes destination")
+	require.False(t, outside.Join("f").Exist(), "file must not be written outside dest")
+}
+
+func TestReadReleaseMetadataRejectsNonRelease(t *testing.T) {
+	// A tar.gz without a manifest is not a release.
+	src := paths.New(t.TempDir())
+	writeFile(t, src.Join("app.yaml"), "name: NoManifest\n")
+	out := paths.New(t.TempDir()).Join("plain.tar.gz")
+	require.NoError(t, writeAppTarGz(src, "plain", out, nil, nil))
+
+	_, _, err := readReleaseMetadata(out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not an Arduino App Release")
+}
+
+func TestReadReleaseMetadataPrefersShallowestManifest(t *testing.T) {
+	// A decoy manifest planted deeper in the tree (and appearing first) must not hijack the
+	// root prefix; the shallowest manifest wins regardless of order.
+	out := paths.New(t.TempDir()).Join("demo.tar.gz")
+	writeRawTarGz(t, out, []rawTarEntry{
+		{name: "app/models/decoy/" + ReleaseManifestFileName, typeflag: tar.TypeReg, content: "app_name: DECOY\n"},
+		{name: "app/" + ReleaseManifestFileName, typeflag: tar.TypeReg, content: "app_name: REAL\n"},
+	})
+	rootPrefix, m, err := readReleaseMetadata(out)
+	require.NoError(t, err)
+	require.Equal(t, "app", rootPrefix)
+	require.Equal(t, "REAL", m.AppName)
+}
+
+func TestModelBundlingAndRestore(t *testing.T) {
+	// Source config: a custom-models dir holding a fake Edge-Impulse model.
+	t.Setenv("ARDUINO_APP_CLI__APPS_DIR", t.TempDir())
+	t.Setenv("ARDUINO_APP_CLI__DATA_DIR", t.TempDir())
+	srcModelsDir := t.TempDir()
+	t.Setenv("ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR", srcModelsDir)
+	srcCfg, err := config.NewFromEnv()
+	require.NoError(t, err)
+
+	const modelRel = "custom-ei/ei-model-1-2"
+	modelFolder := srcCfg.CustomModelsDir().Join("custom-ei", "ei-model-1-2")
+	writeFile(t, modelFolder.Join("model.eim"), "MODELBLOB")
+	writeFile(t, modelFolder.Join("model.yaml"), "name: EI\n")
+
+	// Build a release that bundles that model folder.
+	appSrc := paths.New(t.TempDir())
+	writeFile(t, appSrc.Join("app.yaml"), "name: Model App\n")
+	writeFile(t, appSrc.Join("python", "main.py"), "x=1\n")
+
+	out := paths.New(t.TempDir()).Join("modelapp.tar.gz")
+	extra := map[string][]byte{ReleaseManifestFileName: []byte("app_name: Model App\n")}
+	modelArtifacts := []tarPath{{archiveRel: releaseModelsDirPrefix + "/" + modelRel, source: modelFolder}}
+	require.NoError(t, writeAppTarGz(appSrc, "modelapp", out, extra, modelArtifacts))
+
+	// Extract and confirm the model rides along under models/<rel>.
+	extracted := paths.New(t.TempDir()).Join("ex")
+	require.NoError(t, extracted.MkdirAll())
+	require.NoError(t, extractTarGz(out, extracted, "modelapp"))
+	requireFileContent(t, extracted.Join("models", "custom-ei", "ei-model-1-2", "model.eim"), "MODELBLOB")
+
+	// Restore into a fresh destination custom-models dir.
+	t.Setenv("ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR", t.TempDir())
+	destCfg, err := config.NewFromEnv()
+	require.NoError(t, err)
+	manifest := &ReleaseManifest{Models: []ReleaseModel{{ID: "ei-model-1-2", Bundled: true, Paths: []string{modelRel}}}}
+	require.NoError(t, restoreBundledModels(destCfg, manifest, extracted, false))
+
+	requireFileContent(t, destCfg.CustomModelsDir().Join("custom-ei", "ei-model-1-2", "model.eim"), "MODELBLOB")
+	requireFileContent(t, destCfg.CustomModelsDir().Join("custom-ei", "ei-model-1-2", "model.yaml"), "name: EI\n")
+
+	// Restoring again must not fail and must keep the existing copy (no force).
+	require.NoError(t, restoreBundledModels(destCfg, manifest, extracted, false))
+}
+
+func TestRestoreBundledModelsRejectsTraversalPath(t *testing.T) {
+	t.Setenv("ARDUINO_APP_CLI__DATA_DIR", t.TempDir())
+	t.Setenv("ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR", t.TempDir())
+	cfg, err := config.NewFromEnv()
+	require.NoError(t, err)
+
+	extracted := paths.New(t.TempDir())
+	// Plant a file the traversal would point at, to prove it is NOT copied out.
+	writeFile(t, extracted.Join("secret.txt"), "SENSITIVE")
+
+	manifest := &ReleaseManifest{Models: []ReleaseModel{{ID: "evil", Bundled: true, Paths: []string{"../secret.txt"}}}}
+	err = restoreBundledModels(cfg, manifest, extracted, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "illegal artifact path")
+	require.False(t, cfg.CustomModelsDir().Parent().Join("secret.txt").Exist())
+}
+
+func TestRestoreBundledModelsFailsOnMissingArtifact(t *testing.T) {
+	t.Setenv("ARDUINO_APP_CLI__DATA_DIR", t.TempDir())
+	t.Setenv("ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR", t.TempDir())
+	cfg, err := config.NewFromEnv()
+	require.NoError(t, err)
+
+	extracted := paths.New(t.TempDir()) // no models/ payload
+	manifest := &ReleaseManifest{Models: []ReleaseModel{{ID: "m", Bundled: true, Paths: []string{"custom-ei/m"}}}}
+	err = restoreBundledModels(cfg, manifest, extracted, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing from the release archive")
+}
+
+func TestLocalizeInstalledRelease(t *testing.T) {
+	t.Setenv("ARDUINO_APP_CLI__APPS_DIR", t.TempDir())
+	t.Setenv("ARDUINO_APP_CLI__DATA_DIR", t.TempDir())
+	t.Setenv("ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR", t.TempDir())
+	cfg, err := config.NewFromEnv()
+	require.NoError(t, err)
+
+	extracted := paths.New(t.TempDir())
+	writeFile(t, extracted.Join("app.yaml"), "name: Demo\ndescription: d\n")
+	writeFile(t, extracted.Join("python", "main.py"), "x=1\n")
+	frozen := "name: demo\n" +
+		"services:\n" +
+		"  main:\n" +
+		"    environment:\n" +
+		"      HOST_IP: ${HOST_IP}\n" +
+		"    volumes:\n" +
+		"      - ${APP_HOME}:/app\n" +
+		"      - ${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}/edge-impulse:/models\n"
+	writeFile(t, extracted.Join(".cache", "release-compose.yaml"), frozen)
+
+	finalPath := paths.New(t.TempDir()).Join("my-app")
+	manifest := &ReleaseManifest{Release: "20260101120000"}
+	require.NoError(t, localizeInstalledRelease(context.Background(), cfg, &bricksindex.BricksIndex{}, &modelsindex.ModelsIndex{}, platform.Platform{}, manifest, extracted, finalPath))
+
+	// The staging compose is gone; the standard one exists with resolved paths.
+	require.False(t, extracted.Join(".cache", "release-compose.yaml").Exist())
+	composeBytes, err := os.ReadFile(extracted.Join(".cache", "app-compose.yaml").String())
+	require.NoError(t, err)
+	compose := string(composeBytes)
+	require.Contains(t, compose, finalPath.String()+":/app")
+	require.Contains(t, compose, cfg.CustomModelsDir().String()+"/edge-impulse:/models")
+	require.Contains(t, compose, "${HOST_IP")     // kept dynamic (bare or with a :-default) for the run command
+	require.NotContains(t, compose, "${APP_HOME}") // resolved at install time
+
+	// app.yaml is stamped as a frozen release with the release number.
+	desc, err := app.ParseDescriptorFile(extracted.Join("app.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, desc.FrozenRelease)
+	require.Equal(t, "20260101120000", desc.FrozenRelease.Number)
+}
+
+func TestScrubAppSecrets(t *testing.T) {
+	desc := app.AppDescriptor{
+		Bricks: []app.Brick{
+			{ID: "arduino:db", Variables: map[string]string{"DB_PASSWORD": "s3cr3t", "DB_HOST": "localhost"}},
+			{ID: "arduino:weather", Variables: map[string]string{"API_KEY": "abc123"}},
+			{ID: "arduino:empty", Variables: map[string]string{"OPTIONAL_SECRET": ""}},
+		},
+	}
+	idx := &bricksindex.BricksIndex{BuiltInBricks: []bricksindex.Brick{
+		{ID: "arduino:db", Variables: []bricksindex.BrickVariable{
+			{Name: "DB_PASSWORD", Secret: true},
+			{Name: "DB_HOST"}, // not secret
+		}},
+		{ID: "arduino:weather", Variables: []bricksindex.BrickVariable{{Name: "API_KEY", Secret: true}}},
+		{ID: "arduino:empty", Variables: []bricksindex.BrickVariable{{Name: "OPTIONAL_SECRET", Secret: true}}},
+	}}
+
+	required, values := scrubAppSecrets(&desc, idx)
+
+	// Non-empty secret values are replaced with ${NAME} placeholders.
+	require.Equal(t, "${DB_PASSWORD}", desc.Bricks[0].Variables["DB_PASSWORD"])
+	require.Equal(t, "${API_KEY}", desc.Bricks[1].Variables["API_KEY"])
+	// Non-secret and empty-secret variables are left untouched.
+	require.Equal(t, "localhost", desc.Bricks[0].Variables["DB_HOST"])
+	require.Equal(t, "", desc.Bricks[2].Variables["OPTIONAL_SECRET"])
+
+	names := make([]string, 0, len(required))
+	for _, s := range required {
+		names = append(names, s.Name)
+	}
+	require.ElementsMatch(t, []string{"DB_PASSWORD", "API_KEY"}, names)
+
+	// The returned values map carries the scrubbed plaintext (used to also strip the
+	// values from the frozen compose); non-secret and empty-secret vars are not captured.
+	require.Equal(t, map[string][]string{"DB_PASSWORD": {"s3cr3t"}, "API_KEY": {"abc123"}}, values)
+}
+
+func TestScrubComposeSecretKeys(t *testing.T) {
+	compose := "services:\n" +
+		"  main:\n" +
+		"    environment:\n" +
+		"      DB_PASSWORD: s3cr3t\n" +
+		"      OTHER: keepme\n" +
+		"  legacy:\n" +
+		"    environment:\n" +
+		"      - API_KEY=abc123\n" +
+		"      - KEEP=yes\n"
+	out := scrubComposeSecretKeys(compose, []string{"DB_PASSWORD", "API_KEY"})
+
+	require.Contains(t, out, "DB_PASSWORD: ${DB_PASSWORD}")
+	require.NotContains(t, out, "s3cr3t")
+	require.Contains(t, out, "- API_KEY=${API_KEY}")
+	require.NotContains(t, out, "abc123")
+	// Non-secret entries are untouched.
+	require.Contains(t, out, "OTHER: keepme")
+	require.Contains(t, out, "- KEEP=yes")
+}
+
+func TestParseEnvFile(t *testing.T) {
+	dir := paths.New(t.TempDir())
+	writeFile(t, dir.Join("secrets.env"), "# a comment\n\nDB_PASSWORD=s3cr3t\nAPI_KEY=\"quoted value\"\nEMPTY=\nBAD LINE\n")
+	values, err := parseEnvFile(dir.Join("secrets.env").String())
+	require.NoError(t, err)
+	require.Equal(t, "s3cr3t", values["DB_PASSWORD"])
+	require.Equal(t, "quoted value", values["API_KEY"])
+	require.Equal(t, "", values["EMPTY"])
+	require.NotContains(t, values, "BAD LINE")
+}
+
+func TestApplyReleaseSecrets(t *testing.T) {
+	appDir := paths.New(t.TempDir())
+	// secrets.env is the template written at install time: it lists every required secret
+	// (declaring them), with the user having filled in only DB_PASSWORD.
+	writeFile(t, appDir.Join("data", "secrets.env"), "DB_PASSWORD=fromfile\nAPI_KEY=\n")
+	arduinoApp := app.ArduinoApp{FullPath: appDir}
+
+	// DB_PASSWORD resolves from the file; API_KEY is declared but left empty -> missing.
+	envs := helpers.EnvVars{
+		"DB_PASSWORD": "${DB_PASSWORD}",
+		"API_KEY":     "${API_KEY}",
+		"HOST_IP":     "192.168.1.5", // real value, not a placeholder -> not a secret
+	}
+	missing, err := applyReleaseSecrets(arduinoApp, envs)
+	require.NoError(t, err)
+	require.Equal(t, "fromfile", envs["DB_PASSWORD"])
+	require.Equal(t, "192.168.1.5", envs["HOST_IP"])
+	require.Equal(t, []string{"API_KEY"}, missing)
+	require.True(t, strings.HasPrefix(envs["API_KEY"], "${")) // left as placeholder when missing
+}
+
+func TestApplyReleaseSecretsIgnoresUndeclaredPlaceholders(t *testing.T) {
+	appDir := paths.New(t.TempDir())
+	// The manifest declares only DB_PASSWORD as a secret.
+	writeFile(t, appDir.Join(ReleaseManifestFileName),
+		"format_version: \"1.0\"\napp_name: X\nrequired_secrets:\n  - name: DB_PASSWORD\n")
+	writeFile(t, appDir.Join("data", "secrets.env"), "DB_PASSWORD=fromfile\n")
+	arduinoApp := app.ArduinoApp{FullPath: appDir}
+
+	envs := helpers.EnvVars{
+		"DB_PASSWORD": "${DB_PASSWORD}",
+		"SOME_URL":    "${NOT_A_SECRET}", // legitimate placeholder, NOT a declared secret
+	}
+	missing, err := applyReleaseSecrets(arduinoApp, envs)
+	require.NoError(t, err)
+	// The undeclared ${NOT_A_SECRET} placeholder must not be treated as a missing secret.
+	require.Empty(t, missing)
+	require.Equal(t, "fromfile", envs["DB_PASSWORD"])
+	require.Equal(t, "${NOT_A_SECRET}", envs["SOME_URL"]) // left untouched
+}
+
+func TestApplyReleaseSecretsFallbackOnlyForReleases(t *testing.T) {
+	// A normal (non-release) app with neither a manifest nor a secrets.env, whose env has a
+	// legitimate compose passthrough like ${TZ}. The fallback must NOT treat it as a missing
+	// required secret, so start is not blocked. (Regression: previously it aborted the start.)
+	normal := app.ArduinoApp{FullPath: paths.New(t.TempDir())}
+	envs := helpers.EnvVars{"TZ": "${TZ}"}
+	missing, err := applyReleaseSecrets(normal, envs)
+	require.NoError(t, err)
+	require.Empty(t, missing)
+
+	// A frozen release with no readable manifest still gets the inference fallback, so a
+	// scrubbed ${API_KEY} placeholder with no provided value is reported missing.
+	release := app.ArduinoApp{
+		FullPath:   paths.New(t.TempDir()),
+		Descriptor: app.AppDescriptor{FrozenRelease: &app.FrozenReleaseInfo{Number: "1"}},
+	}
+	missing, err = applyReleaseSecrets(release, helpers.EnvVars{"API_KEY": "${API_KEY}"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"API_KEY"}, missing)
+}
+
+func TestScrubComposeSecretValues(t *testing.T) {
+	// A secret value embedded inside a larger value (connection string) that
+	// scrubComposeSecretKeys does not catch, plus one whose value is a prefix of a longer
+	// secret's value, to exercise the longest-first replacement.
+	compose := "services:\n" +
+		"  main:\n" +
+		"    environment:\n" +
+		"      DATABASE_URL: postgres://user:s3cr3t@db:5432/app\n" +
+		"      TOKEN: abc123def\n"
+	values := map[string][]string{
+		"DB_PASSWORD": {"s3cr3t"},
+		"API_KEY":     {"abc123def"},
+		"SHORT":       {"abc123"}, // substring of API_KEY's value; must not corrupt it
+	}
+	out, err := scrubComposeSecretValues(compose, values)
+	require.NoError(t, err)
+	require.NotContains(t, out, "s3cr3t")
+	require.NotContains(t, out, "abc123def")
+	require.Contains(t, out, "postgres://user:${DB_PASSWORD}@db:5432/app")
+	require.Contains(t, out, "TOKEN: ${API_KEY}")
+
+	// Defense-in-depth: if a value literally cannot be removed the build fails rather than
+	// leaking it. (Contrived: replacement is exhaustive, so this only guards regressions.)
+	_, err = scrubComposeSecretValues("plain text", map[string][]string{"X": {""}})
+	require.NoError(t, err) // empty value is a no-op
+}
+
+func TestScrubComposeSecretValuesMultipleValuesPerName(t *testing.T) {
+	// Two bricks declare the same secret NAME with different values; both must be stripped,
+	// even when one is only embedded (not on its own env line).
+	compose := "services:\n" +
+		"  main:\n" +
+		"    environment:\n" +
+		"      URL_A: http://user:alpha-secret@a\n" +
+		"      URL_B: http://user:bravo-secret@b\n"
+	values := map[string][]string{"API_KEY": {"alpha-secret", "bravo-secret"}}
+	out, err := scrubComposeSecretValues(compose, values)
+	require.NoError(t, err)
+	require.NotContains(t, out, "alpha-secret")
+	require.NotContains(t, out, "bravo-secret")
+}
+
+func TestScrubComposeSecretValuesShortValueNotCorrupting(t *testing.T) {
+	// A short secret value ("8080") must NOT be blanket-replaced across the compose (which
+	// would corrupt the port mapping). It is left for env-key scrubbing; here it appears only
+	// in a structural position, so it must survive untouched and not trip the leak check.
+	compose := "    ports:\n      - \"8080:8080\"\n"
+	out, err := scrubComposeSecretValues(compose, map[string][]string{"PORTVAR": {"8080"}})
+	require.NoError(t, err)
+	require.Equal(t, compose, out) // unchanged
+}
+
+func TestTokenizeHostSpecificValues(t *testing.T) {
+	// Simulates the flattened `docker compose config` output produced with the host-specific
+	// vars set to sentinels, alongside an unrelated IP that is a superstring of a plausible
+	// host IP. The sentinel must map to ${HOST_IP} while the unrelated IP is left intact.
+	flattened := "services:\n" +
+		"  main:\n" +
+		"    environment:\n" +
+		"      HOST_IP: " + sentinelHostIP + "\n" +
+		"      PEER: 192.168.1.50\n" + // must NOT be tokenized
+		"    volumes:\n" +
+		"      - " + sentinelAppHome + ":/app\n" +
+		"      - " + sentinelModelsDir + "/edge-impulse:/models\n"
+
+	out := tokenizeHostSpecificValues(flattened, "/home/arduino/.models", "/home/arduino/apps/demo")
+
+	require.Contains(t, out, "HOST_IP: ${HOST_IP}")
+	require.Contains(t, out, "PEER: 192.168.1.50") // untouched: no over-match on the host IP
+	require.Contains(t, out, "- ${APP_HOME}:/app")
+	require.Contains(t, out, "- ${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}/edge-impulse:/models")
+	require.NotContains(t, out, sentinelHostIP)
+	require.NotContains(t, out, sentinelAppHome)
+	require.NotContains(t, out, sentinelModelsDir)
+}
+
+func TestTokenizeHostSpecificEnv(t *testing.T) {
+	// Reproduces host-specific values baked as literals by provisioning: an `environment:`
+	// block (as emitted by `docker compose config`) plus bind-mount source/target paths for
+	// the model directories. All must become ${KEY} placeholders while pinned, non-host
+	// values (image tags, BOARD_NAME, BIND_ADDRESS) are left untouched.
+	flattened := "services:\n" +
+		"  runner:\n" +
+		"    image: ghcr.io/arduino/app-bricks/ei-models-runner:0.11.2\n" +
+		"    environment:\n" +
+		"      APP_HOME: ${APP_HOME}\n" +
+		"      BIND_ADDRESS: 127.0.0.1\n" +
+		"      BOARD_NAME: unoq\n" +
+		"      CUSTOM_MODEL_PATH: /home/arduino/.arduino-bricks/ei-models\n" +
+		"      HOST_IP: 192.168.1.61\n" +
+		"      MODELS_PATH: /var/lib/arduino-app-cli/models\n" +
+		"    volumes:\n" +
+		"      - type: bind\n" +
+		"        source: /home/arduino/.arduino-bricks/ei-models\n" +
+		"        target: /home/arduino/.arduino-bricks/ei-models\n" +
+		"      - type: bind\n" +
+		"        source: /var/lib/arduino-app-cli/models/edge-impulse\n" +
+		"        target: /var/lib/arduino-app-cli/models/edge-impulse\n"
+
+	envs := helpers.EnvVars{
+		"HOST_IP":           "192.168.1.61",
+		"MODELS_PATH":       "/var/lib/arduino-app-cli/models",
+		"CUSTOM_MODEL_PATH": "/home/arduino/.arduino-bricks/ei-models",
+	}
+
+	out := tokenizeHostSpecificEnv(flattened, envs)
+
+	// Env blocks neutralized by key.
+	require.Contains(t, out, "HOST_IP: ${HOST_IP}")
+	require.Contains(t, out, "MODELS_PATH: ${MODELS_PATH}")
+	require.Contains(t, out, "CUSTOM_MODEL_PATH: ${CUSTOM_MODEL_PATH}")
+	// Bind-mount paths neutralized by value.
+	require.Contains(t, out, "source: ${CUSTOM_MODEL_PATH}")
+	require.Contains(t, out, "source: ${MODELS_PATH}/edge-impulse")
+	require.Contains(t, out, "target: ${MODELS_PATH}/edge-impulse")
+	// No host-specific literal survives anywhere.
+	require.NotContains(t, out, "192.168.1.61")
+	require.NotContains(t, out, "/home/arduino/.arduino-bricks/ei-models")
+	require.NotContains(t, out, "/var/lib/arduino-app-cli/models")
+	// Pinned, non-host values are preserved.
+	require.Contains(t, out, "image: ghcr.io/arduino/app-bricks/ei-models-runner:0.11.2")
+	require.Contains(t, out, "BOARD_NAME: unoq")
+	require.Contains(t, out, "BIND_ADDRESS: 127.0.0.1")
+	require.Contains(t, out, "APP_HOME: ${APP_HOME}")
+}
+
+func TestApplyHostEnvDefaults(t *testing.T) {
+	// The frozen compose carries the portable ${KEY} placeholders produced at build time,
+	// both in env blocks and bind-mount paths. Localization must turn the stable paths into
+	// literals and HOST_IP into a ${HOST_IP:-<ip>} default so offline commands never see a
+	// blank value while `app start` still overrides it.
+	compose := "services:\n" +
+		"  main:\n" +
+		"    environment:\n" +
+		"      CUSTOM_MODEL_PATH: ${CUSTOM_MODEL_PATH}\n" +
+		"      HOST_IP: ${HOST_IP}\n" +
+		"      MODELS_PATH: ${MODELS_PATH}\n" +
+		"    volumes:\n" +
+		"      - source: ${CUSTOM_MODEL_PATH}\n" +
+		"      - source: ${MODELS_PATH}/edge-impulse\n"
+
+	envs := helpers.EnvVars{
+		"HOST_IP":           "10.0.0.7",
+		"MODELS_PATH":       "/var/lib/arduino-app-cli/models",
+		"CUSTOM_MODEL_PATH": "/home/arduino/.arduino-bricks/ei-models",
+	}
+
+	out := applyHostEnvDefaults(compose, envs)
+
+	require.Contains(t, out, "HOST_IP: ${HOST_IP:-10.0.0.7}")
+	require.Contains(t, out, "MODELS_PATH: /var/lib/arduino-app-cli/models")
+	require.Contains(t, out, "CUSTOM_MODEL_PATH: /home/arduino/.arduino-bricks/ei-models")
+	require.Contains(t, out, "source: /home/arduino/.arduino-bricks/ei-models")
+	require.Contains(t, out, "source: /var/lib/arduino-app-cli/models/edge-impulse")
+	// No bare, unresolved placeholder remains (which is what makes docker compose warn).
+	require.NotContains(t, out, "${MODELS_PATH}")
+	require.NotContains(t, out, "${CUSTOM_MODEL_PATH}")
+	require.NotContains(t, out, "HOST_IP: ${HOST_IP}\n")
+}
+
+// A missing key must be left as a bare placeholder rather than substituted with a blank.
+func TestApplyHostEnvDefaultsMissingKey(t *testing.T) {
+	compose := "      HOST_IP: ${HOST_IP}\n      MODELS_PATH: ${MODELS_PATH}\n"
+	out := applyHostEnvDefaults(compose, helpers.EnvVars{"MODELS_PATH": "/m"})
+	require.Contains(t, out, "HOST_IP: ${HOST_IP}") // untouched: no value to default to
+	require.Contains(t, out, "MODELS_PATH: /m")
+}
+
+func TestHasProvisionedVenv(t *testing.T) {
+	cache := paths.New(t.TempDir())
+	require.False(t, hasProvisionedVenv(cache))
+	writeFile(t, cache.Join("venv", "pyvenv.cfg"), "home = /usr\n")
+	require.True(t, hasProvisionedVenv(cache))
+}
+
+func requireFileContent(t *testing.T, p *paths.Path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(p.String())
+	require.NoError(t, err, "reading %s", p)
+	require.Equal(t, want, string(got))
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -8,6 +8,7 @@ package render
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 )
@@ -59,5 +60,38 @@ func EncodeZipResponse(w http.ResponseWriter, statusCode int, resp []byte, filen
 
 	if _, err := w.Write(resp); err != nil {
 		slog.Error("failed to write zip response", slog.String("error", err.Error()))
+	}
+}
+
+func EncodeTarGzResponse(w http.ResponseWriter, statusCode int, resp []byte, filename string) {
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+
+	w.WriteHeader(statusCode)
+
+	if resp == nil {
+		return
+	}
+
+	if _, err := w.Write(resp); err != nil {
+		slog.Error("failed to write tar.gz response", slog.String("error", err.Error()))
+	}
+}
+
+// EncodeTarGzStream streams a .tar.gz body from r to the client without buffering it in
+// memory. Use it for potentially large payloads (e.g. releases bundling AI models) where
+// EncodeTarGzResponse's full []byte would risk OOM on memory-constrained devices.
+func EncodeTarGzStream(w http.ResponseWriter, statusCode int, r io.Reader, filename string) {
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+
+	w.WriteHeader(statusCode)
+
+	if r == nil {
+		return
+	}
+
+	if _, err := io.Copy(w, r); err != nil {
+		slog.Error("failed to stream tar.gz response", slog.String("error", err.Error()))
 	}
 }


### PR DESCRIPTION
## Proof of concept: Arduino App Releases

> **Status: proof-of-concept.** This PR implements a complete, compiling, unit-tested first
> version of an app **release** mechanism. It is intended as a basis for discussion and
> iteration — the core flows have **not yet been validated end-to-end on real hardware** (see
> *Not yet verified* below). Please review the design as much as the code.

### What & why

Today an Arduino App can be moved between boards with `app export` / `app import`, but that
ships **source only**: on the first `app start` the destination board **recompiles the sketch**
and **re-runs pip**. That is slow, needs network, and is not reproducible.

This PR adds a second, complementary path — a **release**: an immutable, locked `.tar.gz` that
also carries the **build artifacts** (prebuilt sketch binary, provisioned Python venv, a frozen
version-pinned compose, and any bundled AI models). Installed on another identical board it runs
**without recompiling and without pip** — only container images are pulled.

|  | `app export` / `import` (existing) | `release build` / `install` / `clone` (this PR) |
|---|---|---|
| Contents | source only | source **+ build artifacts** |
| On destination | editable; recompiles + re-runs pip | immutable; flashes prebuilt binary, reuses venv |
| Network at install | n/a | never downloads models; only pulls containers |
| Format | `.zip` | `.tar.gz` (preserves symlinks + modes) |

### What's included

**CLI** (`arduino-app-cli release …`):
- `release build <app> [out.tar.gz]` — freeze a pre-built app into a release (`--release-number`, `--overwrite`, `--no-models`, `--keep-secrets`).
- `release install <file.tar.gz>` — install a release (`--force`, `--no-prepare`, `-` for stdin). By default pre-pulls container images (the *prepare* step) so first start needs no network.
- `release prepare <app>` — pre-pull the app's container images on demand.
- `release clone <app> <new-name>` — turn an installed release back into an editable app.
- No `release start` — an installed release runs via the ordinary `app start` (detected via a `frozen_release` marker in `app.yaml`).

**HTTP API** (`internal/api`): `GET /v1/apps/{id}/release`, `POST /v1/apps/release/install`,
`POST /v1/apps/{id}/prepare`, `GET /v1/apps/{id}/export?scrub_secrets=`, and
`POST /v1/apps/{id}/clone` with `strip_release`. OpenAPI spec + regenerated e2e client included.

**Design highlights** (full detail in `docs/release_feature_specification.md`):
- **Relocatable compose** — `docker compose config` flattens + version-pins images; host-specific
  values are tokenized to `${APP_HOME}` / `${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}` (resolved at
  install) and `${HOST_IP}` (resolved fresh at every start).
- **Secrets never leave the build machine** — brick variables flagged `secret: true` are scrubbed
  to `${NAME}` placeholders in both `app.yaml` and the frozen compose; the build **fails** if any
  literal secret value survives. `install` writes a `data/secrets.env` template; `app start`
  resolves them and fails fast if a required one is missing. Also exposed as `app export --scrub-secrets`.
- **Models are bundled, never downloaded at install** — preloaded models ride in their pinned
  image; custom / Edge Impulse / handler-downloaded models (incl. on-device LLM weights) are
  copied into the archive and restored on install.
- **Hardened extraction** — tar-slip, malicious-symlink, and oversized-file guards.

### Commit layout

9 focused commits, ordered so each compiles on its own:

1. `docs:` feature specification (this document set)
2. frozen-release descriptor in the app parser
3. resolve local model artifacts in modelsindex
4. release build/install/clone/prepare engine
5. wire frozen releases into `StartApp` + clone/strip
6. scrub secrets from plain app exports
7. release CLI commands
8. release HTTP API endpoints
9. `docs:` user-facing documentation

### Verified

- `go build ./...` and `GOOS=linux GOARCH=arm64 go build ./...` — clean.
- `go vet ./internal/... ./cmd/...` — clean.
- Unit tests for scrubbing, tokenization, secret resolution, localization, model
  bundling/restore, tar round-trip and release-metadata validation — green.

### Not yet verified (needs a real board) — why this is a POC

1. **venv-skip linchpin** — assumes the python-runner image does not re-run pip when the venv
   already exists in `.cache`. If it always reinstalls, bundling the venv is moot.
2. **Local-LLM over-bundling** — a Qwen3/Gemma release currently bundles the whole
   `genai/`/`llamacpp/` repo folder rather than just the one model (weights are multi-GB).
3. **Compose secret scrub / handler-model resolution** — validated by unit tests + code review,
   but not yet confirmed against a full generated compose and a real handler-downloaded model on
   hardware.
4. `data/secrets.env` remains plaintext on the destination by design — the guarantee is only that
   the *release archive* carries no secrets.

Feedback on the overall approach (archive format, freeze/localize model, secret handling) is
especially welcome before we invest in on-hardware hardening.
