### PR TITLE
Move id in a separated package

### DIFF
--- a/cmd/arduino-app-cli/internal/cmdutil/cmdutil.go
+++ b/cmd/arduino-app-cli/internal/cmdutil/cmdutil.go
@@ -13,12 +13,12 @@ import (
 	"golang.org/x/term"
 
 	"github.com/arduino/arduino-app-cli/cmd/feedback"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 )
 
 // IDToAlias returns the string representation of an app ID in a readable and short way.
 // Either with the id itself or a relative path if possible.
-func IDToAlias(id app.ID) string {
+func IDToAlias(id id.ID) string {
 	v := id.String()
 	res, err := base64.RawURLEncoding.DecodeString(v)
 	if err != nil {

--- a/cmd/arduino-app-cli/internal/cmdutil/cmdutil.go
+++ b/cmd/arduino-app-cli/internal/cmdutil/cmdutil.go
@@ -13,12 +13,12 @@ import (
 	"golang.org/x/term"
 
 	"github.com/arduino/arduino-app-cli/cmd/feedback"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 )
 
 // IDToAlias returns the string representation of an app ID in a readable and short way.
 // Either with the id itself or a relative path if possible.
-func IDToAlias(id id.ID) string {
+func IDToAlias(id appid.ID) string {
 	v := id.String()
 	res, err := base64.RawURLEncoding.DecodeString(v)
 	if err != nil {

--- a/cmd/arduino-app-cli/internal/servicelocator/servicelocator.go
+++ b/cmd/arduino-app-cli/internal/servicelocator/servicelocator.go
@@ -16,10 +16,10 @@ import (
 	"go.bug.st/f"
 
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricks"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
@@ -82,8 +82,8 @@ var (
 		)
 	})
 
-	GetAppIDProvider = sync.OnceValue(func() *app.IDProvider {
-		return app.NewAppIDProvider(globalConfig, GetPlatform())
+	GetAppIDProvider = sync.OnceValue(func() *id.IDProvider {
+		return id.NewAppIDProvider(globalConfig, GetPlatform())
 	})
 
 	GetPlatform = sync.OnceValue(func() platform.Platform {

--- a/cmd/arduino-app-cli/internal/servicelocator/servicelocator.go
+++ b/cmd/arduino-app-cli/internal/servicelocator/servicelocator.go
@@ -16,10 +16,10 @@ import (
 	"go.bug.st/f"
 
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricks"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
@@ -82,8 +82,8 @@ var (
 		)
 	})
 
-	GetAppIDProvider = sync.OnceValue(func() *id.IDProvider {
-		return id.NewAppIDProvider(globalConfig, GetPlatform())
+	GetAppIDProvider = sync.OnceValue(func() *appid.Provider {
+		return appid.NewAppProvider(globalConfig, GetPlatform())
 	})
 
 	GetPlatform = sync.OnceValue(func() platform.Platform {

--- a/cmd/gendoc/docs.go
+++ b/cmd/gendoc/docs.go
@@ -22,8 +22,8 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/handlers"
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricks"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/update"
 )
@@ -264,7 +264,7 @@ func NewOpenApiGenerator(version string) *Generator {
 				return true, nil
 			}
 			// We treat the orchestrator.ID as a string in the OpenAPI spec.
-			if params.Value.Type() == reflect.TypeOf(id.ID{}) {
+			if params.Value.Type() == reflect.TypeOf(appid.ID{}) {
 				params.Schema.WithType(jsonschema.Type{
 					SimpleTypes: new(jsonschema.String),
 				})

--- a/cmd/gendoc/docs.go
+++ b/cmd/gendoc/docs.go
@@ -22,8 +22,8 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/handlers"
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricks"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/update"
 )
@@ -264,7 +264,7 @@ func NewOpenApiGenerator(version string) *Generator {
 				return true, nil
 			}
 			// We treat the orchestrator.ID as a string in the OpenAPI spec.
-			if params.Value.Type() == reflect.TypeOf(app.ID{}) {
+			if params.Value.Type() == reflect.TypeOf(id.ID{}) {
 				params.Schema.WithType(jsonschema.Type{
 					SimpleTypes: new(jsonschema.String),
 				})

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/api/handlers"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricks"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
@@ -37,7 +37,7 @@ func NewHTTPRouter(
 	bricksIndex *bricksindex.BricksIndex,
 	servicesIndex *servicesindex.ServicesIndex,
 	brickService *bricks.Service,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	platform platform.Platform,
 	cfg config.Configuration,
 	allowedOrigins []string,

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/api/handlers"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricks"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
@@ -37,7 +37,7 @@ func NewHTTPRouter(
 	bricksIndex *bricksindex.BricksIndex,
 	servicesIndex *servicesindex.ServicesIndex,
 	brickService *bricks.Service,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	platform platform.Platform,
 	cfg config.Configuration,
 	allowedOrigins []string,

--- a/internal/api/handlers/ai_models.go
+++ b/internal/api/handlers/ai_models.go
@@ -19,9 +19,9 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/edgeimpulse"
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 	"github.com/arduino/arduino-app-cli/internal/render"
@@ -67,7 +67,7 @@ func HandlerModelByID(modelsIndex *modelsindex.ModelsIndex) http.HandlerFunc {
 	}
 }
 
-func HandlerDeleteModelByID(dockerClient command.Cli, cfg config.Configuration, modelsIndex *modelsindex.ModelsIndex, bricksIndex *bricksindex.BricksIndex, idProvider *id.IDProvider, platform platform.Platform) http.HandlerFunc {
+func HandlerDeleteModelByID(dockerClient command.Cli, cfg config.Configuration, modelsIndex *modelsindex.ModelsIndex, bricksIndex *bricksindex.BricksIndex, idProvider *appid.Provider, platform platform.Platform) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := strings.TrimSpace(r.PathValue("modelID"))
 		if id == "" {

--- a/internal/api/handlers/ai_models.go
+++ b/internal/api/handlers/ai_models.go
@@ -19,9 +19,9 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/edgeimpulse"
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 	"github.com/arduino/arduino-app-cli/internal/render"
@@ -67,7 +67,7 @@ func HandlerModelByID(modelsIndex *modelsindex.ModelsIndex) http.HandlerFunc {
 	}
 }
 
-func HandlerDeleteModelByID(dockerClient command.Cli, cfg config.Configuration, modelsIndex *modelsindex.ModelsIndex, bricksIndex *bricksindex.BricksIndex, idProvider *app.IDProvider, platform platform.Platform) http.HandlerFunc {
+func HandlerDeleteModelByID(dockerClient command.Cli, cfg config.Configuration, modelsIndex *modelsindex.ModelsIndex, bricksIndex *bricksindex.BricksIndex, idProvider *id.IDProvider, platform platform.Platform) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := strings.TrimSpace(r.PathValue("modelID"))
 		if id == "" {

--- a/internal/api/handlers/app_brick_create.go
+++ b/internal/api/handlers/app_brick_create.go
@@ -17,7 +17,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app/generator"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
@@ -29,7 +29,7 @@ type AppLocalBrickCreateResponse struct {
 	ID string `json:"id"`
 }
 
-func HandleAppLocalBrickCreate(idProvider *id.IDProvider) http.HandlerFunc {
+func HandleAppLocalBrickCreate(idProvider *appid.Provider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))
 		if err != nil {

--- a/internal/api/handlers/app_brick_create.go
+++ b/internal/api/handlers/app_brick_create.go
@@ -17,6 +17,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app/generator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
@@ -28,7 +29,7 @@ type AppLocalBrickCreateResponse struct {
 	ID string `json:"id"`
 }
 
-func HandleAppLocalBrickCreate(idProvider *app.IDProvider) http.HandlerFunc {
+func HandleAppLocalBrickCreate(idProvider *id.IDProvider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))
 		if err != nil {

--- a/internal/api/handlers/app_clone.go
+++ b/internal/api/handlers/app_clone.go
@@ -16,6 +16,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
@@ -25,7 +26,7 @@ type CloneRequest struct {
 }
 
 func HandleAppClone(
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	cfg config.Configuration,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/app_clone.go
+++ b/internal/api/handlers/app_clone.go
@@ -15,8 +15,8 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
@@ -26,7 +26,7 @@ type CloneRequest struct {
 }
 
 func HandleAppClone(
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	cfg config.Configuration,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/app_create.go
+++ b/internal/api/handlers/app_create.go
@@ -15,8 +15,8 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
@@ -27,7 +27,7 @@ type CreateAppRequest struct {
 }
 
 func HandleAppCreate(
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	cfg config.Configuration,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/app_create.go
+++ b/internal/api/handlers/app_create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
@@ -26,7 +27,7 @@ type CreateAppRequest struct {
 }
 
 func HandleAppCreate(
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	cfg config.Configuration,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/app_delete.go
+++ b/internal/api/handlers/app_delete.go
@@ -14,14 +14,14 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
 func HandleAppDelete(
 	dockerClient command.Cli,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	platform platform.Platform,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/app_delete.go
+++ b/internal/api/handlers/app_delete.go
@@ -14,13 +14,14 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
 func HandleAppDelete(
 	dockerClient command.Cli,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	platform platform.Platform,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/app_details.go
+++ b/internal/api/handlers/app_details.go
@@ -15,9 +15,9 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 
 	"github.com/docker/cli/cli/command"
@@ -26,7 +26,7 @@ import (
 func HandleAppDetails(
 	dockerClient command.Cli,
 	bricksIndex *bricksindex.BricksIndex,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	cfg config.Configuration,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -63,7 +63,7 @@ type EditRequest struct {
 func HandleAppDetailsEdits(
 	dockerClient command.Cli,
 	bricksIndex *bricksindex.BricksIndex,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	cfg config.Configuration,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/app_details.go
+++ b/internal/api/handlers/app_details.go
@@ -17,6 +17,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 
 	"github.com/docker/cli/cli/command"
@@ -25,7 +26,7 @@ import (
 func HandleAppDetails(
 	dockerClient command.Cli,
 	bricksIndex *bricksindex.BricksIndex,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	cfg config.Configuration,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -62,7 +63,7 @@ type EditRequest struct {
 func HandleAppDetailsEdits(
 	dockerClient command.Cli,
 	bricksIndex *bricksindex.BricksIndex,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	cfg config.Configuration,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/app_export.go
+++ b/internal/api/handlers/app_export.go
@@ -17,11 +17,12 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
 func HandleAppExport(
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	bricksIndex *bricksindex.BricksIndex,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/app_export.go
+++ b/internal/api/handlers/app_export.go
@@ -16,13 +16,13 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
 func HandleAppExport(
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	bricksIndex *bricksindex.BricksIndex,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/app_import.go
+++ b/internal/api/handlers/app_import.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
@@ -27,7 +27,7 @@ type AppImportResponse struct {
 
 func HandleAppImport(
 	cfg config.Configuration,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		file, header, err := r.FormFile("file")

--- a/internal/api/handlers/app_import.go
+++ b/internal/api/handlers/app_import.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
@@ -27,7 +27,7 @@ type AppImportResponse struct {
 
 func HandleAppImport(
 	cfg config.Configuration,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		file, header, err := r.FormFile("file")

--- a/internal/api/handlers/app_list.go
+++ b/internal/api/handlers/app_list.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
@@ -29,7 +29,7 @@ type AppListResponse struct {
 
 func HandleAppList(
 	dockerCli command.Cli,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	bricksIndex *bricksindex.BricksIndex,
 	cfg config.Configuration,
 	platform platform.Platform,

--- a/internal/api/handlers/app_list.go
+++ b/internal/api/handlers/app_list.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
@@ -29,7 +29,7 @@ type AppListResponse struct {
 
 func HandleAppList(
 	dockerCli command.Cli,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	bricksIndex *bricksindex.BricksIndex,
 	cfg config.Configuration,
 	platform platform.Platform,

--- a/internal/api/handlers/app_local_brick_rename.go
+++ b/internal/api/handlers/app_local_brick_rename.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricks"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
@@ -23,7 +23,7 @@ type AppLocalBrickRenameRequest struct {
 	Name string `json:"name"`
 }
 
-func HandleAppLocalBrickRename(brickService *bricks.Service, idProvider *id.IDProvider) http.HandlerFunc {
+func HandleAppLocalBrickRename(brickService *bricks.Service, idProvider *appid.Provider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))
 		if err != nil {

--- a/internal/api/handlers/app_local_brick_rename.go
+++ b/internal/api/handlers/app_local_brick_rename.go
@@ -15,6 +15,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricks"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
@@ -22,7 +23,7 @@ type AppLocalBrickRenameRequest struct {
 	Name string `json:"name"`
 }
 
-func HandleAppLocalBrickRename(brickService *bricks.Service, idProvider *app.IDProvider) http.HandlerFunc {
+func HandleAppLocalBrickRename(brickService *bricks.Service, idProvider *id.IDProvider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))
 		if err != nil {

--- a/internal/api/handlers/app_logs.go
+++ b/internal/api/handlers/app_logs.go
@@ -17,14 +17,14 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
 func HandleAppLogs(
 	dockerClient command.Cli,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	bricksIndex *bricksindex.BricksIndex,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/app_logs.go
+++ b/internal/api/handlers/app_logs.go
@@ -18,12 +18,13 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
 func HandleAppLogs(
 	dockerClient command.Cli,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	bricksIndex *bricksindex.BricksIndex,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/app_ports.go
+++ b/internal/api/handlers/app_ports.go
@@ -14,6 +14,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
@@ -28,7 +29,7 @@ type port struct {
 
 func HandleAppPorts(
 	bricksIndex *bricksindex.BricksIndex,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := idProvider.IDFromBase64(r.PathValue("appID"))

--- a/internal/api/handlers/app_ports.go
+++ b/internal/api/handlers/app_ports.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
@@ -29,7 +29,7 @@ type port struct {
 
 func HandleAppPorts(
 	bricksIndex *bricksindex.BricksIndex,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := idProvider.IDFromBase64(r.PathValue("appID"))

--- a/internal/api/handlers/app_sketch_libs.go
+++ b/internal/api/handlers/app_sketch_libs.go
@@ -12,12 +12,13 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/render"
 
 	"go.bug.st/f"
 )
 
-func HandleSketchAddLibrary(idProvider *app.IDProvider) http.HandlerFunc {
+func HandleSketchAddLibrary(idProvider *id.IDProvider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := idProvider.IDFromBase64(r.PathValue("appID"))
 		if err != nil {
@@ -59,7 +60,7 @@ type SketchAddLibraryResponse struct {
 	AddedLibraries []string `json:"libraries"`
 }
 
-func HandleSketchRemoveLibrary(idProvider *app.IDProvider) http.HandlerFunc {
+func HandleSketchRemoveLibrary(idProvider *id.IDProvider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := idProvider.IDFromBase64(r.PathValue("appID"))
 		if err != nil {
@@ -101,7 +102,7 @@ type SketchRemoveLibraryResponse struct {
 	RemovedLibraries []string `json:"libraries"`
 }
 
-func HandleSketchListLibraries(idProvider *app.IDProvider) http.HandlerFunc {
+func HandleSketchListLibraries(idProvider *id.IDProvider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := idProvider.IDFromBase64(r.PathValue("appID"))
 		if err != nil {

--- a/internal/api/handlers/app_sketch_libs.go
+++ b/internal/api/handlers/app_sketch_libs.go
@@ -12,13 +12,13 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/render"
 
 	"go.bug.st/f"
 )
 
-func HandleSketchAddLibrary(idProvider *id.IDProvider) http.HandlerFunc {
+func HandleSketchAddLibrary(idProvider *appid.Provider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := idProvider.IDFromBase64(r.PathValue("appID"))
 		if err != nil {
@@ -60,7 +60,7 @@ type SketchAddLibraryResponse struct {
 	AddedLibraries []string `json:"libraries"`
 }
 
-func HandleSketchRemoveLibrary(idProvider *id.IDProvider) http.HandlerFunc {
+func HandleSketchRemoveLibrary(idProvider *appid.Provider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := idProvider.IDFromBase64(r.PathValue("appID"))
 		if err != nil {
@@ -102,7 +102,7 @@ type SketchRemoveLibraryResponse struct {
 	RemovedLibraries []string `json:"libraries"`
 }
 
-func HandleSketchListLibraries(idProvider *id.IDProvider) http.HandlerFunc {
+func HandleSketchListLibraries(idProvider *appid.Provider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := idProvider.IDFromBase64(r.PathValue("appID"))
 		if err != nil {

--- a/internal/api/handlers/app_start.go
+++ b/internal/api/handlers/app_start.go
@@ -14,9 +14,9 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
@@ -29,7 +29,7 @@ func HandleAppStart(
 	modelsIndex *modelsindex.ModelsIndex,
 	bricksIndex *bricksindex.BricksIndex,
 	servicesIndex *servicesindex.ServicesIndex,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	cfg config.Configuration,
 	platform platform.Platform,
 ) http.HandlerFunc {

--- a/internal/api/handlers/app_start.go
+++ b/internal/api/handlers/app_start.go
@@ -16,6 +16,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
@@ -28,7 +29,7 @@ func HandleAppStart(
 	modelsIndex *modelsindex.ModelsIndex,
 	bricksIndex *bricksindex.BricksIndex,
 	servicesIndex *servicesindex.ServicesIndex,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	cfg config.Configuration,
 	platform platform.Platform,
 ) http.HandlerFunc {

--- a/internal/api/handlers/app_status.go
+++ b/internal/api/handlers/app_status.go
@@ -13,16 +13,16 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
 func HandlerAppStatus(
 	dockerCli command.Cli,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	bricksIndex *bricksindex.BricksIndex,
 	cfg config.Configuration,
 	platform platform.Platform,

--- a/internal/api/handlers/app_status.go
+++ b/internal/api/handlers/app_status.go
@@ -13,16 +13,16 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
 func HandlerAppStatus(
 	dockerCli command.Cli,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	bricksIndex *bricksindex.BricksIndex,
 	cfg config.Configuration,
 	platform platform.Platform,

--- a/internal/api/handlers/app_stop.go
+++ b/internal/api/handlers/app_stop.go
@@ -12,7 +12,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 	"github.com/arduino/arduino-app-cli/internal/render"
 
@@ -21,7 +21,7 @@ import (
 
 func HandleAppStop(
 	dockerClient command.Cli,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	platform platform.Platform,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/app_stop.go
+++ b/internal/api/handlers/app_stop.go
@@ -12,6 +12,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 	"github.com/arduino/arduino-app-cli/internal/render"
 
@@ -20,7 +21,7 @@ import (
 
 func HandleAppStop(
 	dockerClient command.Cli,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	platform platform.Platform,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/bricks.go
+++ b/internal/api/handlers/bricks.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/api/models"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricks"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
@@ -30,7 +30,7 @@ func HandleBrickList(brickService *bricks.Service) http.HandlerFunc {
 
 func HandleAppBrickInstancesList(
 	brickService *bricks.Service,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))
@@ -54,7 +54,7 @@ func HandleAppBrickInstancesList(
 
 func HandleAppBrickInstanceDetails(
 	brickService *bricks.Service,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))
@@ -89,7 +89,7 @@ func HandleAppBrickInstanceDetails(
 
 func HandleBrickCreate(
 	brickService *bricks.Service,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))
@@ -133,7 +133,7 @@ func HandleBrickCreate(
 	}
 }
 
-func HandleBrickDetails(brickService *bricks.Service, idProvider *id.IDProvider,
+func HandleBrickDetails(brickService *bricks.Service, idProvider *appid.Provider,
 	cfg config.Configuration, platform platform.Platform) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("brickID")
@@ -159,7 +159,7 @@ func HandleBrickDetails(brickService *bricks.Service, idProvider *id.IDProvider,
 
 func HandleBrickUpdates(
 	brickService *bricks.Service,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))
@@ -205,7 +205,7 @@ func HandleBrickUpdates(
 
 func HandleBrickDelete(
 	brickService *bricks.Service,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))

--- a/internal/api/handlers/bricks.go
+++ b/internal/api/handlers/bricks.go
@@ -17,6 +17,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricks"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
@@ -29,7 +30,7 @@ func HandleBrickList(brickService *bricks.Service) http.HandlerFunc {
 
 func HandleAppBrickInstancesList(
 	brickService *bricks.Service,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))
@@ -53,7 +54,7 @@ func HandleAppBrickInstancesList(
 
 func HandleAppBrickInstanceDetails(
 	brickService *bricks.Service,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))
@@ -88,7 +89,7 @@ func HandleAppBrickInstanceDetails(
 
 func HandleBrickCreate(
 	brickService *bricks.Service,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))
@@ -132,7 +133,7 @@ func HandleBrickCreate(
 	}
 }
 
-func HandleBrickDetails(brickService *bricks.Service, idProvider *app.IDProvider,
+func HandleBrickDetails(brickService *bricks.Service, idProvider *id.IDProvider,
 	cfg config.Configuration, platform platform.Platform) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("brickID")
@@ -158,7 +159,7 @@ func HandleBrickDetails(brickService *bricks.Service, idProvider *app.IDProvider
 
 func HandleBrickUpdates(
 	brickService *bricks.Service,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))
@@ -204,7 +205,7 @@ func HandleBrickUpdates(
 
 func HandleBrickDelete(
 	brickService *bricks.Service,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appId, err := idProvider.IDFromBase64(r.PathValue("appID"))

--- a/internal/orchestrator/app_status.go
+++ b/internal/orchestrator/app_status.go
@@ -17,11 +17,11 @@ import (
 	"github.com/docker/docker/api/types/filters"
 
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 )
 
-func AppStatusEvents(ctx context.Context, cfg config.Configuration, docker command.Cli, idProvider *id.IDProvider) iter.Seq2[AppInfo, error] {
+func AppStatusEvents(ctx context.Context, cfg config.Configuration, docker command.Cli, idProvider *appid.Provider) iter.Seq2[AppInfo, error] {
 	chanMsg, chanError := docker.Client().Events(ctx, events.ListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("label", DockerAppLabel+"=true"),
@@ -70,7 +70,7 @@ func AppStatusEvents(ctx context.Context, cfg config.Configuration, docker comma
 	}
 }
 
-func parseDockerStatusEvent(ctx context.Context, cfg config.Configuration, docker command.Cli, idProvider *id.IDProvider, event events.Message) (AppInfo, error) {
+func parseDockerStatusEvent(ctx context.Context, cfg config.Configuration, docker command.Cli, idProvider *appid.Provider, event events.Message) (AppInfo, error) {
 
 	if pathLabel, ok := event.Actor.Attributes[DockerAppPathLabel]; ok {
 		app, err := app.Load(paths.New(pathLabel))

--- a/internal/orchestrator/app_status.go
+++ b/internal/orchestrator/app_status.go
@@ -18,9 +18,10 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 )
 
-func AppStatusEvents(ctx context.Context, cfg config.Configuration, docker command.Cli, idProvider *app.IDProvider) iter.Seq2[AppInfo, error] {
+func AppStatusEvents(ctx context.Context, cfg config.Configuration, docker command.Cli, idProvider *id.IDProvider) iter.Seq2[AppInfo, error] {
 	chanMsg, chanError := docker.Client().Events(ctx, events.ListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("label", DockerAppLabel+"=true"),
@@ -69,7 +70,7 @@ func AppStatusEvents(ctx context.Context, cfg config.Configuration, docker comma
 	}
 }
 
-func parseDockerStatusEvent(ctx context.Context, cfg config.Configuration, docker command.Cli, idProvider *app.IDProvider, event events.Message) (AppInfo, error) {
+func parseDockerStatusEvent(ctx context.Context, cfg config.Configuration, docker command.Cli, idProvider *id.IDProvider, event events.Message) (AppInfo, error) {
 
 	if pathLabel, ok := event.Actor.Attributes[DockerAppPathLabel]; ok {
 		app, err := app.Load(paths.New(pathLabel))

--- a/internal/orchestrator/appid/id.go
+++ b/internal/orchestrator/appid/id.go
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package id
+package appid
 
 import (
 	"encoding/base64"
@@ -56,16 +56,16 @@ func (id ID) Equal(other ID) bool {
 		id.encodedID == other.encodedID
 }
 
-type IDProvider struct {
+type Provider struct {
 	cfg  config.Configuration
 	plat platform.Platform
 }
 
-func NewAppIDProvider(cfg config.Configuration, plat platform.Platform) *IDProvider {
-	return &IDProvider{cfg: cfg, plat: plat}
+func NewAppProvider(cfg config.Configuration, plat platform.Platform) *Provider {
+	return &Provider{cfg: cfg, plat: plat}
 }
 
-func (p *IDProvider) IDFromBase64(id string) (ID, error) {
+func (p *Provider) IDFromBase64(id string) (ID, error) {
 	decodedID, err := base64.RawURLEncoding.DecodeString(id)
 	if err != nil {
 		return ID{}, err
@@ -73,7 +73,7 @@ func (p *IDProvider) IDFromBase64(id string) (ID, error) {
 	return p.parseID(string(decodedID))
 }
 
-func (p *IDProvider) IDFromPath(path *paths.Path) (ID, error) {
+func (p *Provider) IDFromPath(path *paths.Path) (ID, error) {
 	if path == nil || !path.Exist() {
 		return ID{}, ErrInvalidID
 	}
@@ -123,11 +123,11 @@ func (p *IDProvider) IDFromPath(path *paths.Path) (ID, error) {
 
 // ParseID parses a string into an ID.
 // It accepts both absolute paths and relative paths.
-func (p *IDProvider) ParseID(id string) (ID, error) {
+func (p *Provider) ParseID(id string) (ID, error) {
 	return p.parseID(id)
 }
 
-func (p *IDProvider) parseID(id string) (ID, error) {
+func (p *Provider) parseID(id string) (ID, error) {
 	var path *paths.Path
 
 	prefix, appPath, found := strings.Cut(id, ":")

--- a/internal/orchestrator/appid/id_test.go
+++ b/internal/orchestrator/appid/id_test.go
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package id
+package appid
 
 import (
 	"testing"
@@ -37,7 +37,7 @@ func TestNewIDFromPath(t *testing.T) {
 	require.NoError(t, examplesBoardDir.Join("nested", "platform-example").MkdirAll())
 	require.NoError(t, tmp.Join("other-app").MkdirAll())
 
-	idProvider := NewAppIDProvider(orchestratorConfig, unoQPlatform)
+	idProvider := NewAppProvider(orchestratorConfig, unoQPlatform)
 
 	tests := []struct {
 		name    string
@@ -110,7 +110,7 @@ func TestParseID(t *testing.T) {
 	require.NoError(t, examplesCommonDir.Join("nested", "deep", "example-app").MkdirAll())
 	require.NoError(t, examplesBoardDir.Join("nested", "platform-example").MkdirAll())
 
-	idProvider := NewAppIDProvider(orchestratorConfig, unoQPlatform)
+	idProvider := NewAppProvider(orchestratorConfig, unoQPlatform)
 
 	tests := []struct {
 		name     string

--- a/internal/orchestrator/archive.go
+++ b/internal/orchestrator/archive.go
@@ -22,9 +22,9 @@ import (
 	yaml "github.com/goccy/go-yaml"
 
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 )
 
 func ExportAppZip(
@@ -144,21 +144,21 @@ func zipAppToBuffer(bricksIndex *bricksindex.BricksIndex, sourcePath string, roo
 func ImportAppFromZip(
 	cfg config.Configuration,
 	zipPath *paths.Path,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	originalZipName string,
-) (id.ID, error) {
+) (appid.ID, error) {
 	if zipPath == nil {
-		return id.ID{}, fmt.Errorf("internal error: zipPath cannot be nil")
+		return appid.ID{}, fmt.Errorf("internal error: zipPath cannot be nil")
 	}
 	r, err := zip.OpenReader(zipPath.String())
 	if err != nil {
-		return id.ID{}, fmt.Errorf("unable to open zip archive: %w", err)
+		return appid.ID{}, fmt.Errorf("unable to open zip archive: %w", err)
 	}
 	defer r.Close()
 
 	rootPrefix, err := findZipRoot(&r.Reader)
 	if err != nil {
-		return id.ID{}, fmt.Errorf("%w: %v", ErrBadRequest, err)
+		return appid.ID{}, fmt.Errorf("%w: %v", ErrBadRequest, err)
 	}
 
 	var rawAppName string
@@ -170,11 +170,11 @@ func ImportAppFromZip(
 
 	appDescriptor, err := readAppDescriptorFromZip(&r.Reader, rootPrefix)
 	if err != nil {
-		return id.ID{}, fmt.Errorf("failed to read app.yaml: %w", err)
+		return appid.ID{}, fmt.Errorf("failed to read app.yaml: %w", err)
 	}
 
 	if strings.TrimSpace(appDescriptor.Name) == "" {
-		return id.ID{}, fmt.Errorf("%w: app name is missing", ErrBadRequest)
+		return appid.ID{}, fmt.Errorf("%w: app name is missing", ErrBadRequest)
 	}
 
 	finalDestPath, appExists := findAppPathByName(rawAppName, cfg)
@@ -186,32 +186,32 @@ func ImportAppFromZip(
 
 	tempDestDir, err := paths.MkTempDir(finalDestPath.Parent().String(), "tmp_")
 	if err != nil {
-		return id.ID{}, fmt.Errorf("unable to create temp app directory: %w", err)
+		return appid.ID{}, fmt.Errorf("unable to create temp app directory: %w", err)
 	}
 	defer func() { _ = tempDestDir.RemoveAll() }()
 
 	if err := extractZip(&r.Reader, tempDestDir.String(), rootPrefix); err != nil {
-		return id.ID{}, err
+		return appid.ID{}, err
 	}
 
 	if finalDestPath.Exist() {
-		return id.ID{}, ErrAppAlreadyExists
+		return appid.ID{}, ErrAppAlreadyExists
 	}
 	if !app.IsValidFolderName(finalDestPath.Base()) {
-		return id.ID{}, fmt.Errorf("root folder name %q is not valid: use only alphanumeric, underscores, dashes and spaces", finalDestPath.Base())
+		return appid.ID{}, fmt.Errorf("root folder name %q is not valid: use only alphanumeric, underscores, dashes and spaces", finalDestPath.Base())
 	}
 	// Validate the extracted app before moving to final destination.
 	if _, err := app.Load(tempDestDir); err != nil {
-		return id.ID{}, fmt.Errorf("invalid app: %w: %v", ErrBadRequest, err)
+		return appid.ID{}, fmt.Errorf("invalid app: %w: %v", ErrBadRequest, err)
 	}
 
 	if err := tempDestDir.Rename(finalDestPath); err != nil {
-		return id.ID{}, fmt.Errorf("failed to finalize app import (swap): %w", err)
+		return appid.ID{}, fmt.Errorf("failed to finalize app import (swap): %w", err)
 	}
 
 	appId, err := idProvider.IDFromPath(finalDestPath)
 	if err != nil {
-		return id.ID{}, err
+		return appid.ID{}, err
 	}
 
 	return appId, nil

--- a/internal/orchestrator/archive.go
+++ b/internal/orchestrator/archive.go
@@ -24,6 +24,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 )
 
 func ExportAppZip(
@@ -143,21 +144,21 @@ func zipAppToBuffer(bricksIndex *bricksindex.BricksIndex, sourcePath string, roo
 func ImportAppFromZip(
 	cfg config.Configuration,
 	zipPath *paths.Path,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	originalZipName string,
-) (app.ID, error) {
+) (id.ID, error) {
 	if zipPath == nil {
-		return app.ID{}, fmt.Errorf("internal error: zipPath cannot be nil")
+		return id.ID{}, fmt.Errorf("internal error: zipPath cannot be nil")
 	}
 	r, err := zip.OpenReader(zipPath.String())
 	if err != nil {
-		return app.ID{}, fmt.Errorf("unable to open zip archive: %w", err)
+		return id.ID{}, fmt.Errorf("unable to open zip archive: %w", err)
 	}
 	defer r.Close()
 
 	rootPrefix, err := findZipRoot(&r.Reader)
 	if err != nil {
-		return app.ID{}, fmt.Errorf("%w: %v", ErrBadRequest, err)
+		return id.ID{}, fmt.Errorf("%w: %v", ErrBadRequest, err)
 	}
 
 	var rawAppName string
@@ -169,11 +170,11 @@ func ImportAppFromZip(
 
 	appDescriptor, err := readAppDescriptorFromZip(&r.Reader, rootPrefix)
 	if err != nil {
-		return app.ID{}, fmt.Errorf("failed to read app.yaml: %w", err)
+		return id.ID{}, fmt.Errorf("failed to read app.yaml: %w", err)
 	}
 
 	if strings.TrimSpace(appDescriptor.Name) == "" {
-		return app.ID{}, fmt.Errorf("%w: app name is missing", ErrBadRequest)
+		return id.ID{}, fmt.Errorf("%w: app name is missing", ErrBadRequest)
 	}
 
 	finalDestPath, appExists := findAppPathByName(rawAppName, cfg)
@@ -185,35 +186,35 @@ func ImportAppFromZip(
 
 	tempDestDir, err := paths.MkTempDir(finalDestPath.Parent().String(), "tmp_")
 	if err != nil {
-		return app.ID{}, fmt.Errorf("unable to create temp app directory: %w", err)
+		return id.ID{}, fmt.Errorf("unable to create temp app directory: %w", err)
 	}
 	defer func() { _ = tempDestDir.RemoveAll() }()
 
 	if err := extractZip(&r.Reader, tempDestDir.String(), rootPrefix); err != nil {
-		return app.ID{}, err
+		return id.ID{}, err
 	}
 
 	if finalDestPath.Exist() {
-		return app.ID{}, ErrAppAlreadyExists
+		return id.ID{}, ErrAppAlreadyExists
 	}
 	if !app.IsValidFolderName(finalDestPath.Base()) {
-		return app.ID{}, fmt.Errorf("root folder name %q is not valid: use only alphanumeric, underscores, dashes and spaces", finalDestPath.Base())
+		return id.ID{}, fmt.Errorf("root folder name %q is not valid: use only alphanumeric, underscores, dashes and spaces", finalDestPath.Base())
 	}
 	// Validate the extracted app before moving to final destination.
 	if _, err := app.Load(tempDestDir); err != nil {
-		return app.ID{}, fmt.Errorf("invalid app: %w: %v", ErrBadRequest, err)
+		return id.ID{}, fmt.Errorf("invalid app: %w: %v", ErrBadRequest, err)
 	}
 
 	if err := tempDestDir.Rename(finalDestPath); err != nil {
-		return app.ID{}, fmt.Errorf("failed to finalize app import (swap): %w", err)
+		return id.ID{}, fmt.Errorf("failed to finalize app import (swap): %w", err)
 	}
 
-	id, err := idProvider.IDFromPath(finalDestPath)
+	appId, err := idProvider.IDFromPath(finalDestPath)
 	if err != nil {
-		return app.ID{}, err
+		return id.ID{}, err
 	}
 
-	return id, nil
+	return appId, nil
 }
 
 func extractZip(r *zip.Reader, dest string, rootPrefix string) error {

--- a/internal/orchestrator/archive_test.go
+++ b/internal/orchestrator/archive_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
 
@@ -302,7 +303,7 @@ func TestImportAppFromZip(t *testing.T) {
 			cfg, err := config.NewFromEnv()
 			require.NoError(t, err)
 
-			idProvider := app.NewAppIDProvider(cfg, unkownPlatform)
+			idProvider := id.NewAppIDProvider(cfg, unkownPlatform)
 
 			if tc.preExisting {
 				// create pre-existing app folder to force conflict

--- a/internal/orchestrator/archive_test.go
+++ b/internal/orchestrator/archive_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
 
@@ -303,7 +303,7 @@ func TestImportAppFromZip(t *testing.T) {
 			cfg, err := config.NewFromEnv()
 			require.NoError(t, err)
 
-			idProvider := id.NewAppIDProvider(cfg, unkownPlatform)
+			idProvider := appid.NewAppProvider(cfg, unkownPlatform)
 
 			if tc.preExisting {
 				// create pre-existing app folder to force conflict

--- a/internal/orchestrator/bricks/bricks.go
+++ b/internal/orchestrator/bricks/bricks.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/fatomic"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
@@ -174,7 +174,7 @@ func getInstanceBrickConfigVariableDetails(
 	return variablesMap, variableDetails
 }
 
-func (s *Service) BricksDetails(id string, idProvider *id.IDProvider,
+func (s *Service) BricksDetails(id string, idProvider *appid.Provider,
 	cfg config.Configuration, platform platform.Platform) (BrickDetailsResult, error) {
 	brick, found := s.bricksIndex.FindBrickByID(id)
 	if !found {
@@ -260,7 +260,7 @@ func getBrickConfigVariableDetails(
 	return variablesMap, variableDetails
 }
 
-func getUsedByApps(cfg config.Configuration, brickId string, idProvider *id.IDProvider, platform platform.Platform) ([]AppReference, error) {
+func getUsedByApps(cfg config.Configuration, brickId string, idProvider *appid.Provider, platform platform.Platform) ([]AppReference, error) {
 	pathsToExplore := paths.NewPathList()
 	pathsToExplore.AddAll(cfg.ExamplesDirs(platform))
 	pathsToExplore.Add(cfg.AppsDir())

--- a/internal/orchestrator/bricks/bricks.go
+++ b/internal/orchestrator/bricks/bricks.go
@@ -21,6 +21,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
@@ -173,7 +174,7 @@ func getInstanceBrickConfigVariableDetails(
 	return variablesMap, variableDetails
 }
 
-func (s *Service) BricksDetails(id string, idProvider *app.IDProvider,
+func (s *Service) BricksDetails(id string, idProvider *id.IDProvider,
 	cfg config.Configuration, platform platform.Platform) (BrickDetailsResult, error) {
 	brick, found := s.bricksIndex.FindBrickByID(id)
 	if !found {
@@ -259,7 +260,7 @@ func getBrickConfigVariableDetails(
 	return variablesMap, variableDetails
 }
 
-func getUsedByApps(cfg config.Configuration, brickId string, idProvider *app.IDProvider, platform platform.Platform) ([]AppReference, error) {
+func getUsedByApps(cfg config.Configuration, brickId string, idProvider *id.IDProvider, platform platform.Platform) ([]AppReference, error) {
 	pathsToExplore := paths.NewPathList()
 	pathsToExplore.AddAll(cfg.ExamplesDirs(platform))
 	pathsToExplore.Add(cfg.AppsDir())

--- a/internal/orchestrator/bricks/bricks_test.go
+++ b/internal/orchestrator/bricks/bricks_test.go
@@ -15,9 +15,9 @@ import (
 	"go.bug.st/f"
 
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
@@ -435,7 +435,7 @@ bricks:
 		bricksIndex: bIndex,
 		modelsIndex: mIndex,
 	}
-	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := appid.NewAppProvider(cfg, unoQPlatform)
 
 	t.Run("Brick Not Found", func(t *testing.T) {
 		res, err := svc.BricksDetails("arduino:non_existing", idProvider, cfg, unoQPlatform)

--- a/internal/orchestrator/bricks/bricks_test.go
+++ b/internal/orchestrator/bricks/bricks_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
@@ -434,7 +435,7 @@ bricks:
 		bricksIndex: bIndex,
 		modelsIndex: mIndex,
 	}
-	idProvider := app.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
 
 	t.Run("Brick Not Found", func(t *testing.T) {
 		res, err := svc.BricksDetails("arduino:non_existing", idProvider, cfg, unoQPlatform)

--- a/internal/orchestrator/id/id.go
+++ b/internal/orchestrator/id/id.go
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package app
+package id
 
 import (
 	"encoding/base64"

--- a/internal/orchestrator/id/id_test.go
+++ b/internal/orchestrator/id/id_test.go
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package app
+package id
 
 import (
 	"testing"

--- a/internal/orchestrator/models.go
+++ b/internal/orchestrator/models.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/arduino/arduino-app-cli/internal/api/edgeimpulse"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex/custommodel"
 	"github.com/arduino/arduino-app-cli/internal/platform"
@@ -113,7 +113,7 @@ var (
 	ErrIncompleteImpulse   = errors.New("impulse not ready for deployment")
 )
 
-func AIModelDelete(ctx context.Context, dockerClient command.Cli, cfg config.Configuration, modelsIndex *modelsindex.ModelsIndex, bricksIndex *bricksindex.BricksIndex, platform platform.Platform, id string, idProvider *id.IDProvider, force bool) (err error) {
+func AIModelDelete(ctx context.Context, dockerClient command.Cli, cfg config.Configuration, modelsIndex *modelsindex.ModelsIndex, bricksIndex *bricksindex.BricksIndex, platform platform.Platform, id string, idProvider *appid.Provider, force bool) (err error) {
 	res, err := modelsIndex.GetModelByID(ctx, id)
 	if err != nil {
 		return err
@@ -171,7 +171,7 @@ func buildModelInUseMessage(references []string, runningAppRef *app.ArduinoApp) 
 // This allows the user to see both issues before deciding to use the flag
 // preventing the second error from being masked.
 func checkForModelReferences(ctx context.Context, dockerClient command.Cli,
-	cfg config.Configuration, idProvider *id.IDProvider, bricksIndex *bricksindex.BricksIndex,
+	cfg config.Configuration, idProvider *appid.Provider, bricksIndex *bricksindex.BricksIndex,
 	modelId string, platform platform.Platform) ([]string, *app.ArduinoApp, error) {
 	apps, err := ListApps(
 		ctx, dockerClient, ListAppRequest{

--- a/internal/orchestrator/models.go
+++ b/internal/orchestrator/models.go
@@ -25,6 +25,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex/custommodel"
 	"github.com/arduino/arduino-app-cli/internal/platform"
@@ -112,7 +113,7 @@ var (
 	ErrIncompleteImpulse   = errors.New("impulse not ready for deployment")
 )
 
-func AIModelDelete(ctx context.Context, dockerClient command.Cli, cfg config.Configuration, modelsIndex *modelsindex.ModelsIndex, bricksIndex *bricksindex.BricksIndex, platform platform.Platform, id string, idProvider *app.IDProvider, force bool) (err error) {
+func AIModelDelete(ctx context.Context, dockerClient command.Cli, cfg config.Configuration, modelsIndex *modelsindex.ModelsIndex, bricksIndex *bricksindex.BricksIndex, platform platform.Platform, id string, idProvider *id.IDProvider, force bool) (err error) {
 	res, err := modelsIndex.GetModelByID(ctx, id)
 	if err != nil {
 		return err
@@ -170,7 +171,7 @@ func buildModelInUseMessage(references []string, runningAppRef *app.ArduinoApp) 
 // This allows the user to see both issues before deciding to use the flag
 // preventing the second error from being masked.
 func checkForModelReferences(ctx context.Context, dockerClient command.Cli,
-	cfg config.Configuration, idProvider *app.IDProvider, bricksIndex *bricksindex.BricksIndex,
+	cfg config.Configuration, idProvider *id.IDProvider, bricksIndex *bricksindex.BricksIndex,
 	modelId string, platform platform.Platform) ([]string, *app.ArduinoApp, error) {
 	apps, err := ListApps(
 		ctx, dockerClient, ListAppRequest{

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -34,6 +34,7 @@ import (
 	appgenerator "github.com/arduino/arduino-app-cli/internal/orchestrator/app/generator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	linuxconfig "github.com/arduino/arduino-app-cli/internal/orchestrator/linuxConfig"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/peripherals"
@@ -442,7 +443,7 @@ func StartDefaultApp(
 	modelsIndex *modelsindex.ModelsIndex,
 	bricksIndex *bricksindex.BricksIndex,
 	servicesIndex *servicesindex.ServicesIndex,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	cfg config.Configuration,
 	platform platform.Platform,
 ) error {
@@ -477,7 +478,7 @@ type ListAppResult struct {
 }
 
 type AppInfo struct {
-	ID          app.ID `json:"id"`
+	ID          id.ID  `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Icon        string `json:"icon"`
@@ -507,7 +508,7 @@ func ListApps(
 	ctx context.Context,
 	docker command.Cli,
 	req ListAppRequest,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	bricksIndex *bricksindex.BricksIndex,
 	cfg config.Configuration,
 	platform platform.Platform,
@@ -625,7 +626,7 @@ func exampleCompatibleWithBricksIndex(a app.ArduinoApp, idx *bricksindex.BricksI
 }
 
 type AppDetailedInfo struct {
-	ID          app.ID             `json:"id" required:"true" `
+	ID          id.ID              `json:"id" required:"true" `
 	Name        string             `json:"name" required:"true"`
 	Path        string             `json:"path"`
 	Description string             `json:"description"`
@@ -648,7 +649,7 @@ func AppDetails(
 	docker command.Cli,
 	userApp app.ArduinoApp,
 	bricksIndex *bricksindex.BricksIndex,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	cfg config.Configuration,
 ) (AppDetailedInfo, error) {
 	bricksIndex = bricksIndex.WithAppBricks(userApp.LocalBricks)
@@ -718,12 +719,12 @@ type CreateAppRequest struct {
 }
 
 type CreateAppResponse struct {
-	ID app.ID `json:"id"`
+	ID id.ID `json:"id"`
 }
 
 func CreateApp(
 	req CreateAppRequest,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	cfg config.Configuration,
 ) (CreateAppResponse, error) {
 	if req.Name == "" {
@@ -756,19 +757,19 @@ func CreateApp(
 }
 
 type CloneAppRequest struct {
-	FromID app.ID
+	FromID id.ID
 
 	Name *string
 	Icon *string
 }
 
 type CloneAppResponse struct {
-	ID app.ID `json:"id"`
+	ID id.ID `json:"id"`
 }
 
 func CloneApp(
 	req CloneAppRequest,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	cfg config.Configuration,
 ) (response CloneAppResponse, cloneErr error) {
 	originPath := req.FromID.ToPath()

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -478,13 +478,13 @@ type ListAppResult struct {
 }
 
 type AppInfo struct {
-	ID          appid.ID  `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Icon        string `json:"icon"`
-	Status      Status `json:"status,omitempty"`
-	Example     bool   `json:"example"`
-	Default     bool   `json:"default"`
+	ID          appid.ID `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Icon        string   `json:"icon"`
+	Status      Status   `json:"status,omitempty"`
+	Example     bool     `json:"example"`
+	Default     bool     `json:"default"`
 }
 
 type BrokenAppInfo struct {
@@ -626,7 +626,7 @@ func exampleCompatibleWithBricksIndex(a app.ArduinoApp, idx *bricksindex.BricksI
 }
 
 type AppDetailedInfo struct {
-	ID          appid.ID              `json:"id" required:"true" `
+	ID          appid.ID           `json:"id" required:"true" `
 	Name        string             `json:"name" required:"true"`
 	Path        string             `json:"path"`
 	Description string             `json:"description"`

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -32,9 +32,9 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/helpers"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	appgenerator "github.com/arduino/arduino-app-cli/internal/orchestrator/app/generator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	linuxconfig "github.com/arduino/arduino-app-cli/internal/orchestrator/linuxConfig"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/peripherals"
@@ -443,7 +443,7 @@ func StartDefaultApp(
 	modelsIndex *modelsindex.ModelsIndex,
 	bricksIndex *bricksindex.BricksIndex,
 	servicesIndex *servicesindex.ServicesIndex,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	cfg config.Configuration,
 	platform platform.Platform,
 ) error {
@@ -478,7 +478,7 @@ type ListAppResult struct {
 }
 
 type AppInfo struct {
-	ID          id.ID  `json:"id"`
+	ID          appid.ID  `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Icon        string `json:"icon"`
@@ -508,7 +508,7 @@ func ListApps(
 	ctx context.Context,
 	docker command.Cli,
 	req ListAppRequest,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	bricksIndex *bricksindex.BricksIndex,
 	cfg config.Configuration,
 	platform platform.Platform,
@@ -626,7 +626,7 @@ func exampleCompatibleWithBricksIndex(a app.ArduinoApp, idx *bricksindex.BricksI
 }
 
 type AppDetailedInfo struct {
-	ID          id.ID              `json:"id" required:"true" `
+	ID          appid.ID              `json:"id" required:"true" `
 	Name        string             `json:"name" required:"true"`
 	Path        string             `json:"path"`
 	Description string             `json:"description"`
@@ -649,7 +649,7 @@ func AppDetails(
 	docker command.Cli,
 	userApp app.ArduinoApp,
 	bricksIndex *bricksindex.BricksIndex,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	cfg config.Configuration,
 ) (AppDetailedInfo, error) {
 	bricksIndex = bricksIndex.WithAppBricks(userApp.LocalBricks)
@@ -719,12 +719,12 @@ type CreateAppRequest struct {
 }
 
 type CreateAppResponse struct {
-	ID id.ID `json:"id"`
+	ID appid.ID `json:"id"`
 }
 
 func CreateApp(
 	req CreateAppRequest,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	cfg config.Configuration,
 ) (CreateAppResponse, error) {
 	if req.Name == "" {
@@ -757,19 +757,19 @@ func CreateApp(
 }
 
 type CloneAppRequest struct {
-	FromID id.ID
+	FromID appid.ID
 
 	Name *string
 	Icon *string
 }
 
 type CloneAppResponse struct {
-	ID id.ID `json:"id"`
+	ID appid.ID `json:"id"`
 }
 
 func CloneApp(
 	req CloneAppRequest,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	cfg config.Configuration,
 ) (response CloneAppResponse, cloneErr error) {
 	originPath := req.FromID.ToPath()

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
@@ -30,7 +31,7 @@ var unoQPlatform = platform.Platform{BoardName: "unoq"}
 
 func TestCloneApp(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := app.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
 
 	originalAppID := f.Must(idProvider.ParseID("user:original-app"))
 	originalAppPath := originalAppID.ToPath()
@@ -150,7 +151,7 @@ func TestCloneApp(t *testing.T) {
 
 func TestEditApp(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := app.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
 
 	t.Run("with default", func(t *testing.T) {
 		_, err := CreateApp(CreateAppRequest{Name: "app-default"}, idProvider, cfg)
@@ -236,7 +237,7 @@ func TestEditApp(t *testing.T) {
 
 func TestListApp(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := app.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
 
 	docker, err := dockerClient.NewClientWithOpts(
 		dockerClient.FromEnv,
@@ -397,7 +398,7 @@ func TestListApp(t *testing.T) {
 
 func TestListAppsFiltersByBricksIndex(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := app.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
 
 	docker, err := dockerClient.NewClientWithOpts(
 		dockerClient.FromEnv,
@@ -476,7 +477,7 @@ bricks:
 
 func TestListAppsLocalBricksCompatibility(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := app.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
 
 	docker, err := dockerClient.NewClientWithOpts(
 		dockerClient.FromEnv,
@@ -536,9 +537,9 @@ func createApp(
 	t *testing.T,
 	name string,
 	isExample bool,
-	idProvider *app.IDProvider,
+	idProvider *id.IDProvider,
 	cfg config.Configuration,
-) app.ID {
+) id.ID {
 	t.Helper()
 
 	res, err := CreateApp(CreateAppRequest{
@@ -562,7 +563,7 @@ func createApp(
 
 func TestGetAppEnvironmentVariablesWithDefaults(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := app.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
 
 	docker, err := dockerClient.NewClientWithOpts(
 		dockerClient.FromEnv,
@@ -643,7 +644,7 @@ models:
 
 func TestGetAppEnvironmentVariablesWithCustomModelOverrides(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := app.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
 
 	docker, err := dockerClient.NewClientWithOpts(
 		dockerClient.FromEnv,
@@ -723,7 +724,7 @@ models:
 
 func TestGetAppEnvironmentVariablesUsingMultipleBricks(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := app.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
 
 	docker, err := dockerClient.NewClientWithOpts(
 		dockerClient.FromEnv,

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -20,9 +20,9 @@ import (
 	"go.bug.st/f"
 
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/id"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
@@ -31,7 +31,7 @@ var unoQPlatform = platform.Platform{BoardName: "unoq"}
 
 func TestCloneApp(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := appid.NewAppProvider(cfg, unoQPlatform)
 
 	originalAppID := f.Must(idProvider.ParseID("user:original-app"))
 	originalAppPath := originalAppID.ToPath()
@@ -151,7 +151,7 @@ func TestCloneApp(t *testing.T) {
 
 func TestEditApp(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := appid.NewAppProvider(cfg, unoQPlatform)
 
 	t.Run("with default", func(t *testing.T) {
 		_, err := CreateApp(CreateAppRequest{Name: "app-default"}, idProvider, cfg)
@@ -237,7 +237,7 @@ func TestEditApp(t *testing.T) {
 
 func TestListApp(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := appid.NewAppProvider(cfg, unoQPlatform)
 
 	docker, err := dockerClient.NewClientWithOpts(
 		dockerClient.FromEnv,
@@ -398,7 +398,7 @@ func TestListApp(t *testing.T) {
 
 func TestListAppsFiltersByBricksIndex(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := appid.NewAppProvider(cfg, unoQPlatform)
 
 	docker, err := dockerClient.NewClientWithOpts(
 		dockerClient.FromEnv,
@@ -477,7 +477,7 @@ bricks:
 
 func TestListAppsLocalBricksCompatibility(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := appid.NewAppProvider(cfg, unoQPlatform)
 
 	docker, err := dockerClient.NewClientWithOpts(
 		dockerClient.FromEnv,
@@ -537,9 +537,9 @@ func createApp(
 	t *testing.T,
 	name string,
 	isExample bool,
-	idProvider *id.IDProvider,
+	idProvider *appid.Provider,
 	cfg config.Configuration,
-) id.ID {
+) appid.ID {
 	t.Helper()
 
 	res, err := CreateApp(CreateAppRequest{
@@ -563,7 +563,7 @@ func createApp(
 
 func TestGetAppEnvironmentVariablesWithDefaults(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := appid.NewAppProvider(cfg, unoQPlatform)
 
 	docker, err := dockerClient.NewClientWithOpts(
 		dockerClient.FromEnv,
@@ -644,7 +644,7 @@ models:
 
 func TestGetAppEnvironmentVariablesWithCustomModelOverrides(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := appid.NewAppProvider(cfg, unoQPlatform)
 
 	docker, err := dockerClient.NewClientWithOpts(
 		dockerClient.FromEnv,
@@ -724,7 +724,7 @@ models:
 
 func TestGetAppEnvironmentVariablesUsingMultipleBricks(t *testing.T) {
 	cfg := setTestOrchestratorConfig(t)
-	idProvider := id.NewAppIDProvider(cfg, unoQPlatform)
+	idProvider := appid.NewAppProvider(cfg, unoQPlatform)
 
 	docker, err := dockerClient.NewClientWithOpts(
 		dockerClient.FromEnv,


### PR DESCRIPTION
### Motivation

Linking existing examples returned by  GetExamplesPath() defined here: 
https://github.com/arduino/arduino-app-cli/blob/main/internal/orchestrator/bricksindex/bricks_index.go#L173
need to resolve each example ID to its full path.

To do that, an idProvider is needed at this layer. However, importing it here would create an import cycle, because the app package already imports bricks_index.

Refactor: move ID logic into a separate package.


### Change description

Moves id.go and id_test.go out of the app package into a new id package.
Only the package declaration changes; contents are unchanged.

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
