### PR TITLE
Read additional examples folder

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,7 +8,7 @@ vars:
   GOLANGCI_LINT_VERSION: v2.11.4
   GOIMPORTS_VERSION: v0.42.0
   DPRINT_VERSION: 0.48.0
-  EXAMPLE_VERSION: "0.11.0"
+  EXAMPLE_VERSION: "0.12.0rc1"
   RUNNER_VERSION: "0.11.0"
   VERSION: # if version is not passed we hack the semver by encoding the commit as pre-release
     sh: echo "${VERSION:-0.0.0-$(git rev-parse --short HEAD)}"
@@ -144,9 +144,12 @@ tasks:
           echo "Cloning arduino/app-bricks-examples into temporary directory ${TMP_PATH}..."
           git clone --depth 1 --branch "{{ .EXAMPLE_VERSION }}" https://github.com/arduino/app-bricks-examples "${TMP_PATH}"
           rm -rf "${DEST_PATH}/examples"
-          mkdir -p "${DEST_PATH}"
-          mv "${TMP_PATH}/examples" "${DEST_PATH}"
-          rm -rf "${TMP_PATH}/examples"
+          mkdir -p "${DEST_PATH}/examples"
+          mv "${TMP_PATH}/core-and-foundational" "${DEST_PATH}/examples"
+          mv "${TMP_PATH}/inspirational" "${DEST_PATH}/examples"
+          mv "${TMP_PATH}/bricks" "${DEST_PATH}/examples"
+          mv "${TMP_PATH}/examples.json" "${DEST_PATH}/examples"
+          rm -rf "${TMP_PATH}"
           echo "Examples successfully cloned."
     silent: false
 

--- a/debian/arduino-app-cli/DEBIAN/preinst
+++ b/debian/arduino-app-cli/DEBIAN/preinst
@@ -44,7 +44,8 @@ if [ "$1" = "upgrade" ]; then
         sed -s "s|/home/arduino/.local/share|/var/lib|" ${DEFAULT_APP_FILE} > /var/lib/arduino-app-cli/default.app
     fi
 
-    // the examples directory changed its structure,
-    // remove it to cleanup stale files
+    
+    # the examples directory changed its structure,
+    # remove it to cleanup stale files
     rm -rf /home/arduino/.local/share/arduino-app-cli/examples
 fi

--- a/debian/arduino-app-cli/DEBIAN/preinst
+++ b/debian/arduino-app-cli/DEBIAN/preinst
@@ -43,4 +43,8 @@ if [ "$1" = "upgrade" ]; then
     if [ -f "${DEFAULT_APP_FILE}" ]; then
         sed -s "s|/home/arduino/.local/share|/var/lib|" ${DEFAULT_APP_FILE} > /var/lib/arduino-app-cli/default.app
     fi
+
+    // the examples directory changed its structure,
+    // remove it to cleanup stale files
+    rm -rf /home/arduino/.local/share/arduino-app-cli/examples
 fi

--- a/internal/api/handlers/app_details.go
+++ b/internal/api/handlers/app_details.go
@@ -32,7 +32,7 @@ func HandleAppDetails(
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := idProvider.IDFromBase64(r.PathValue("appID"))
 		if err != nil {
-			render.EncodeResponse(w, http.StatusPreconditionFailed, models.ErrorResponse{Details: "invalid id"})
+			render.EncodeResponse(w, http.StatusPreconditionFailed, models.ErrorResponse{Details: err.Error()})
 			return
 		}
 

--- a/internal/api/handlers/app_details.go
+++ b/internal/api/handlers/app_details.go
@@ -32,7 +32,8 @@ func HandleAppDetails(
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := idProvider.IDFromBase64(r.PathValue("appID"))
 		if err != nil {
-			render.EncodeResponse(w, http.StatusPreconditionFailed, models.ErrorResponse{Details: err.Error()})
+			slog.Warn("invalid id", slog.String("error", err.Error()))
+			render.EncodeResponse(w, http.StatusPreconditionFailed, models.ErrorResponse{Details: "invalid id"})
 			return
 		}
 

--- a/internal/e2e/daemon/app_test.go
+++ b/internal/e2e/daemon/app_test.go
@@ -437,6 +437,7 @@ func TestDeleteApp(t *testing.T) {
 
 	// This test is trying to delete a missing example
 	// so the pre-condition should fail
+	// because the examples is missing (invalid id)
 	t.Run("DeletingExampleApp_Fail", func(t *testing.T) {
 		var actualResponseBody models.ErrorResponse
 		deleteResp, err := httpClient.DeleteApp(t.Context(), "ZXhhbXBsZXM6anVzdGJsaW5f")
@@ -448,7 +449,7 @@ func TestDeleteApp(t *testing.T) {
 		require.NoError(t, err)
 		err = json.Unmarshal(body, &actualResponseBody)
 		require.NoError(t, err)
-		require.Equal(t, "cannot delete example", actualResponseBody.Details)
+		require.Equal(t, "invalid id", actualResponseBody.Details)
 	})
 
 	t.Run("NonExistentAppId_Fail", func(t *testing.T) {

--- a/internal/e2e/daemon/app_test.go
+++ b/internal/e2e/daemon/app_test.go
@@ -435,13 +435,15 @@ func TestDeleteApp(t *testing.T) {
 		require.Equal(t, "invalid id", actualResponseBody.Details)
 	})
 
+	// This test is trying to delete a missing example
+	// so the pre-condition should fail
 	t.Run("DeletingExampleApp_Fail", func(t *testing.T) {
 		var actualResponseBody models.ErrorResponse
 		deleteResp, err := httpClient.DeleteApp(t.Context(), "ZXhhbXBsZXM6anVzdGJsaW5f")
 		require.NoError(t, err)
 		defer deleteResp.Body.Close()
 
-		require.Equal(t, http.StatusBadRequest, deleteResp.StatusCode)
+		require.Equal(t, http.StatusPreconditionFailed, deleteResp.StatusCode)
 		body, err := io.ReadAll(deleteResp.Body)
 		require.NoError(t, err)
 		err = json.Unmarshal(body, &actualResponseBody)

--- a/internal/orchestrator/appid/id.go
+++ b/internal/orchestrator/appid/id.go
@@ -142,54 +142,62 @@ func (p *Provider) ParseID(id string) (ID, error) {
 }
 
 func (p *Provider) parseID(id string) (ID, error) {
-	var path *paths.Path
 	prefix, appPath, found := strings.Cut(id, ":")
-	if found {
-		var isExample bool
-		switch prefix {
-		case "user":
-			path = p.cfg.AppsDir().Join(appPath)
-		case "examples":
-			isExample = true
-
-			// examples: always process examples/inspirational (legacy)
-			for _, examplePath := range p.cfg.ExamplesDirs(p.plat) {
-				path = examplePath.Join(appPath)
-				if path.Exist() {
-					break // for
-				}
-			}
-			if path.Exist() {
-				break // switch
-			}
-
-			// inspirational is reserved and must not be addressable directly
-			selector, _, found := strings.Cut(appPath, "/")
-			if found && selector == "inspirational" {
-				return ID{}, ErrInvalidID
-			}
-
-			// new roots: core-and-foundational and bricks
-			if found && (selector == "core-and-foundational" || selector == "bricks") {
-				path = p.cfg.ExamplesBaseDir().Join(appPath)
-				if path.Exist() {
-					break
-				}
-			}
-			return ID{}, ErrInvalidID
-
-		default:
-			return ID{}, ErrInvalidID
-		}
-		return ID{
-			path:                 path,
-			encodedID:            base64.RawURLEncoding.EncodeToString([]byte(id)),
-			isFromKnownLocaltion: true,
-			isExample:            isExample,
-		}, nil
+	if !found {
+		return p.buildIdFromSystemPath(id)
 	}
 
-	path = paths.New(id)
+	switch prefix {
+	case "user":
+		return p.buildIDFromKnownLocation(id, p.cfg.AppsDir().Join(appPath), false), nil
+	case "examples":
+		path, err := p.resolveExamplePath(appPath)
+		if err != nil {
+			return ID{}, err
+		}
+		return p.buildIDFromKnownLocation(id, path, true), nil
+	}
+	return ID{}, ErrInvalidID
+}
+
+// resolveExamplePath resolves the path for an "examples:" id.
+func (p *Provider) resolveExamplePath(appPath string) (*paths.Path, error) {
+	// examples: always process examples/inspirational (legacy)
+	for _, examplePath := range p.cfg.ExamplesDirs(p.plat) {
+		if path := examplePath.Join(appPath); path.Exist() {
+			return path, nil
+		}
+	}
+
+	firstPath, _, found := strings.Cut(appPath, "/")
+	// inspirational is reserved and must not be addressable directly
+	if found && firstPath == "inspirational" {
+		return nil, ErrInvalidID
+	}
+
+	// process core-and-foundational and bricks
+	if found && (firstPath == "core-and-foundational" || firstPath == "bricks") {
+		if path := p.cfg.ExamplesBaseDir().Join(appPath); path.Exist() {
+			return path, nil
+		}
+	}
+
+	return nil, ErrInvalidID
+}
+
+// builds an ID from a configuration defined path
+func (p *Provider) buildIDFromKnownLocation(id string, path *paths.Path, isExample bool) ID {
+	return ID{
+		path:                 path,
+		encodedID:            base64.RawURLEncoding.EncodeToString([]byte(id)),
+		isFromKnownLocaltion: true,
+		isExample:            isExample,
+	}
+}
+
+// builds an ID from a raw filesystem path
+func (p *Provider) buildIdFromSystemPath(id string) (ID, error) {
+	path := paths.New(id)
 	if path == nil {
 		return ID{}, ErrInvalidID
 	}

--- a/internal/orchestrator/appid/id.go
+++ b/internal/orchestrator/appid/id.go
@@ -87,6 +87,7 @@ func (p *Provider) IDFromPath(path *paths.Path) (ID, error) {
 		isFromKnownLocation bool
 		isExample           bool
 	)
+	// users app
 	if strings.HasPrefix(path.String(), p.cfg.AppsDir().String()) {
 		rel, err := path.RelFrom(p.cfg.AppsDir())
 		if err != nil {
@@ -95,16 +96,29 @@ func (p *Provider) IDFromPath(path *paths.Path) (ID, error) {
 		id = "user:" + rel.String()
 		isFromKnownLocation = true
 	} else {
-		for _, example := range p.cfg.ExamplesDirs(p.plat) {
-			if strings.HasPrefix(path.String(), example.String()) {
-				rel, err := path.RelFrom(example)
-				if err != nil {
-					return ID{}, ErrInvalidID
+		// search in "core-and-foundational" and "bricks"
+		if strings.HasPrefix(path.String(), p.cfg.ExamplesBaseDir().Join("core-and-foundational").String()) ||
+			strings.HasPrefix(path.String(), p.cfg.ExamplesBaseDir().Join("bricks").String()) {
+			rel, err := path.RelFrom(p.cfg.ExamplesBaseDir())
+			if err != nil {
+				return ID{}, ErrInvalidID
+			}
+			id = "examples:" + rel.String()
+			isFromKnownLocation = true
+			isExample = true
+		} else {
+			// search in examples/inspirational
+			for _, example := range p.cfg.ExamplesDirs(p.plat) {
+				if strings.HasPrefix(path.String(), example.String()) {
+					rel, err := path.RelFrom(example)
+					if err != nil {
+						return ID{}, ErrInvalidID
+					}
+					id = "examples:" + rel.String()
+					isFromKnownLocation = true
+					isExample = true
+					break
 				}
-				id = "examples:" + rel.String()
-				isFromKnownLocation = true
-				isExample = true
-				break
 			}
 		}
 	}
@@ -129,7 +143,6 @@ func (p *Provider) ParseID(id string) (ID, error) {
 
 func (p *Provider) parseID(id string) (ID, error) {
 	var path *paths.Path
-
 	prefix, appPath, found := strings.Cut(id, ":")
 	if found {
 		var isExample bool
@@ -138,17 +151,34 @@ func (p *Provider) parseID(id string) (ID, error) {
 			path = p.cfg.AppsDir().Join(appPath)
 		case "examples":
 			isExample = true
-			// Falls back to the last dir if none contains the example.
+
+			// examples: always process examples/inspirational (legacy)
 			for _, examplePath := range p.cfg.ExamplesDirs(p.plat) {
 				path = examplePath.Join(appPath)
+				if path.Exist() {
+					break //for
+				}
+			}
+			if path.Exist() {
+				break // switch
+			}
+
+			// search for core-and-foundational and bricks
+			selector, _, found := strings.Cut(appPath, "/")
+			if found && selector == "inspirational" {
+				return ID{}, ErrInvalidID
+			}
+			if found && (selector == "core-and-foundational" || selector == "bricks") {
+				path = p.cfg.ExamplesBaseDir().Join(appPath)
 				if path.Exist() {
 					break
 				}
 			}
+			return ID{}, ErrInvalidID
+
 		default:
 			return ID{}, ErrInvalidID
 		}
-
 		return ID{
 			path:                 path,
 			encodedID:            base64.RawURLEncoding.EncodeToString([]byte(id)),
@@ -158,7 +188,7 @@ func (p *Provider) parseID(id string) (ID, error) {
 	}
 
 	path = paths.New(id)
-	if path == nil {
+	if path == nil { //TODO Normalize here?
 		return ID{}, ErrInvalidID
 	}
 

--- a/internal/orchestrator/appid/id.go
+++ b/internal/orchestrator/appid/id.go
@@ -156,18 +156,20 @@ func (p *Provider) parseID(id string) (ID, error) {
 			for _, examplePath := range p.cfg.ExamplesDirs(p.plat) {
 				path = examplePath.Join(appPath)
 				if path.Exist() {
-					break //for
+					break // for
 				}
 			}
 			if path.Exist() {
 				break // switch
 			}
 
-			// search for core-and-foundational and bricks
+			// inspirational is reserved and must not be addressable directly
 			selector, _, found := strings.Cut(appPath, "/")
 			if found && selector == "inspirational" {
 				return ID{}, ErrInvalidID
 			}
+
+			// new roots: core-and-foundational and bricks
 			if found && (selector == "core-and-foundational" || selector == "bricks") {
 				path = p.cfg.ExamplesBaseDir().Join(appPath)
 				if path.Exist() {

--- a/internal/orchestrator/appid/id.go
+++ b/internal/orchestrator/appid/id.go
@@ -188,7 +188,7 @@ func (p *Provider) parseID(id string) (ID, error) {
 	}
 
 	path = paths.New(id)
-	if path == nil { //TODO Normalize here?
+	if path == nil {
 		return ID{}, ErrInvalidID
 	}
 

--- a/internal/orchestrator/appid/id_test.go
+++ b/internal/orchestrator/appid/id_test.go
@@ -6,6 +6,7 @@
 package appid
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/arduino/go-paths-helper"
@@ -158,6 +159,11 @@ func TestParseID(t *testing.T) {
 			in:      "/non/existing/path",
 			wantErr: true,
 		},
+		{
+			name:    "not_existing_selector:my_example",
+			in:      "not_existing_selector:my_example",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -171,4 +177,146 @@ func TestParseID(t *testing.T) {
 			assert.Equal(t, tt.wantPath.String(), got.ToPath().String())
 		})
 	}
+}
+
+func TestNewExamplesLayout(t *testing.T) {
+	tmp := paths.New(t.TempDir())
+	t.Setenv("ARDUINO_APP_CLI__APPS_DIR", tmp.Join("apps").String())
+	t.Setenv("ARDUINO_APP_CLI__DATA_DIR", tmp.Join("data").String())
+
+	orchestratorConfig, err := config.NewFromEnv()
+	idProvider := NewAppProvider(orchestratorConfig, unoQPlatform)
+	require.NoError(t, err)
+	// Legacy dir examples: refers examples/inspirational
+	examplesBoardUno := orchestratorConfig.DataDir().Join("examples/inspirational", "platform_unoq")
+	examplesBoardVentuno := orchestratorConfig.DataDir().Join("examples/inspirational", "platform_ventunoq")
+	examplesCommon := orchestratorConfig.DataDir().Join("examples/inspirational", "common")
+	// New examples
+	examplesCoreAndFoundational := orchestratorConfig.DataDir().Join("examples/core-and-foundational")
+	examplesBricks := orchestratorConfig.DataDir().Join("examples/bricks")
+	examplesOther := orchestratorConfig.DataDir().Join("examples/other")
+
+	// Create the full examples structure for testing all cases
+	require.NoError(t, examplesBoardUno.Join("specific_example").MkdirAll())
+	require.NoError(t, examplesBoardVentuno.Join("specific_example").MkdirAll())
+	require.NoError(t, examplesBoardVentuno.Join("ventuno_specific_example").MkdirAll())
+	require.NoError(t, examplesCommon.Join("common_example").MkdirAll())
+	require.NoError(t, examplesCoreAndFoundational.Join("coreEx0").MkdirAll())
+	require.NoError(t, examplesCoreAndFoundational.Join("coreDir1/coreEx10").MkdirAll())
+	require.NoError(t, examplesCoreAndFoundational.Join("coreDir1/coreEx11").MkdirAll())
+	require.NoError(t, examplesCoreAndFoundational.Join("coreDir2/coreEx21").MkdirAll())
+	require.NoError(t, examplesBricks.Join("arduino").Join("brick1").Join("brickEx10").MkdirAll())
+	require.NoError(t, examplesBricks.Join("arduino").Join("brick1").Join("brickEx11").MkdirAll())
+	require.NoError(t, examplesBricks.Join("arduino").Join("brick2").Join("brickEx20").MkdirAll())
+	require.NoError(t, examplesOther.Join("other1").Join("otherEx11").MkdirAll())
+	require.NoError(t, examplesOther.Join("other2").MkdirAll())
+
+	tests := []struct {
+		name         string
+		id           string
+		path         *paths.Path
+		idNotFound   bool
+		pathNotFound bool
+	}{
+		{
+			name: "legacy, get unoq example",
+			id:   "examples:specific_example",
+			path: examplesBoardUno.Join("specific_example"),
+		},
+		{
+			name:       "legacy, get unoq example defined in the ventuno path",
+			id:         "examples:ventuno_specific_example",
+			path:       examplesBoardVentuno.Join("ventuno_specific_example"),
+			idNotFound: true,
+		},
+		{
+			name: "legacy, get common example",
+			id:   "examples:common_example",
+			path: examplesCommon.Join("common_example"),
+		},
+		{
+			name:       "legacy, coreEx10 is a core example. examples: should not look outside inspirational",
+			id:         "examples:coreEx10",
+			idNotFound: true,
+			path:       examplesCoreAndFoundational.Join("coreDir1/coreEx10"),
+		},
+		{
+			name:       "legacy, brickEx10 is a brick example. examples: should not look outside inspirational",
+			id:         "examples:brickEx10",
+			idNotFound: true,
+			path:       examplesBricks.Join("arduino").Join("brick1").Join("brickEx10"),
+		},
+		{
+			name:       "legacy, otherEx11 is another location example. examples: should not look outside inspirational",
+			id:         "examples:otherEx11",
+			idNotFound: true,
+			path:       examplesOther.Join("other1").Join("otherEx11"),
+		},
+		{
+			name:       "inspirational is reserved, need to avoid to retrieve non platform examples",
+			id:         "examples:inspirational/platform_unoq/specific_example",
+			idNotFound: true,
+			path:       examplesBoardUno.Join("specific_example"),
+		},
+		{
+			name: "get an example from core-and-foundational",
+			id:   "examples:core-and-foundational/coreEx0",
+			path: examplesCoreAndFoundational.Join("coreEx0"),
+		},
+		{
+			name: "get a nested example from core-and-foundational",
+			id:   "examples:core-and-foundational/coreDir1/coreEx10",
+			path: examplesCoreAndFoundational.Join("coreDir1/coreEx10"),
+		},
+		{
+			name:         "core-and-foundational missing id example",
+			id:           "examples:core-and-foundational/common_example",
+			idNotFound:   true,
+			path:         examplesCoreAndFoundational.Join("common_example"),
+			pathNotFound: true,
+		},
+		{
+			name:         "core-and-foundational missing path example",
+			id:           "examples:core-and-foundational/missing_example",
+			path:         examplesCoreAndFoundational.Join("missing_example"),
+			idNotFound:   true,
+			pathNotFound: true,
+		},
+		{
+			name: "get an example from bricks",
+			id:   "examples:bricks/arduino/brick1/brickEx10",
+			path: examplesBricks.Join("arduino").Join("brick1").Join("brickEx10"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			/* Test path from id */
+			got, err := idProvider.ParseID(tt.id)
+			if tt.idNotFound {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.path.String(), got.ToPath().String())
+			}
+			if tt.idNotFound == false && tt.pathNotFound == false {
+				assert.Equal(t, tt.path.String(), got.ToPath().String())
+			}
+
+			/* Test id from path */
+			got, err = idProvider.IDFromPath(tt.path)
+			if tt.pathNotFound {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+
+			}
+			if tt.idNotFound == false && tt.pathNotFound == false {
+				assert.Equal(t, base64.RawURLEncoding.EncodeToString([]byte(tt.id)), got.encodedID)
+			}
+
+		})
+	}
+
 }

--- a/internal/orchestrator/appid/id_test.go
+++ b/internal/orchestrator/appid/id_test.go
@@ -300,9 +300,6 @@ func TestNewExamplesLayout(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.path.String(), got.ToPath().String())
 			}
-			if tt.idNotFound == false && tt.pathNotFound == false {
-				assert.Equal(t, tt.path.String(), got.ToPath().String())
-			}
 
 			/* Test id from path */
 			got, err = idProvider.IDFromPath(tt.path)


### PR DESCRIPTION
### Motivation

This PR is based upon: https://github.com/arduino/arduino-app-cli/pull/537
The current code only processes the /inspirational directory.
For this task, we need to process others subdirectories inside /var/lib/arduino-app-cli/examples/, (core-and-foudation and bricks) excluding /inspirational/, which is already handled from legacy code.

### Test Legacy
The current UI behavior is unchanged.
The current cli behavior is unchanged: arduino-app-cli app list

### Test new features
#### Get example list
curl localhost:8800/v1/examples |jq

#### Some curl tests can be done by:
curl localhost:8800/v1/apps/`echo -n "examples:audio-classification" | base64 -w 0| tr -d '='` |jq
curl localhost:8800/v1/apps/`echo -n "examples:video-face-detection" | base64 -w 0| tr -d '='` |jq
** Expected error on unoq: not working because the example belongs to ventunoq**
curl localhost:8800/v1/apps/`echo -n "examples:edge-speech-assistant" | base64 -w 0| tr -d '='` |jq

curl localhost:8800/v1/apps/`echo -n "examples:core-and-foundational/06-camera-basics/02-camera-from-sources" | base64 -w 0| tr -d '='` |jq
curl localhost:8800/v1/apps/`echo -n "examples:bricks/arduino/web_ui/04_on_message" | base64 -w 0| tr -d '='` |jq

**Expected error, we can not refer inspirational directly becase we should not be able to refer other board examples**
curl localhost:8800/v1/apps/`echo -n "examples:inspirational/common/blink" | base64 -w 0| tr -d '='` |jq
curl localhost:8800/v1/apps/`echo -n "examples:blink" | base64 -w 0| tr -d '='` |jq


### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
