### PR TITLE
VentunoQ: add CSI cameras support 

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -114,7 +114,7 @@ func StartApp(
 		return err
 	}
 
-	devices, err := peripherals.Detect(ctx)
+	devices, err := peripherals.Detect(ctx, platform)
 	if err != nil {
 		return err
 	}

--- a/internal/orchestrator/peripherals/devices.go
+++ b/internal/orchestrator/peripherals/devices.go
@@ -176,36 +176,49 @@ func HasVirtualDevice(deviceClass DeviceClass, devices []string) bool {
 	return false
 }
 
+type CSICameraDriver string
+
+const (
+	CSICameraDriverNone  CSICameraDriver = ""
+	CSICameraDriverCamss CSICameraDriver = "camss"
+	CSICameraDriverCamx  CSICameraDriver = "camx"
+)
+
 // HasNativeCSICameraDriver reports if the board has built-in MIPI-CSI interfaces
 func HasNativeCSICameraDriver() bool {
-	return hasNativeCSICameraDriver("/sys/bus/platform/drivers", "/run/cam_server/le_cam_socket")
+	return DetectCSICameraDriver() != CSICameraDriverNone
 }
 
-func hasNativeCSICameraDriver(driversDir string, camxSocket string) bool {
+// DetectCSICameraDriver returns the CSI camera driver available on the board, if any
+func DetectCSICameraDriver() CSICameraDriver {
+	return detectCSICameraDriver("/sys/bus/platform/drivers", "/run/cam_server/le_cam_socket")
+}
+
+func detectCSICameraDriver(driversDir string, camxSocket string) CSICameraDriver {
 	// Detect camss
 	if _, err := os.Stat(filepath.Join(driversDir, "qcom-camss")); err == nil {
 		slog.Debug("detected camss CSI camera driver")
-		return true
+		return CSICameraDriverCamss
 	}
 
 	// Detect camx
 	entries, err := os.ReadDir(driversDir)
 	if err != nil {
 		slog.Debug("unable to list platform drivers", slog.String("dir", driversDir), slog.String("error", err.Error()))
-		return false
+		return CSICameraDriverNone
 	}
 	hasCamxDriver := slices.ContainsFunc(entries, func(e os.DirEntry) bool {
 		return e.IsDir() && strings.HasPrefix(e.Name(), "cam_")
 	})
 	if !hasCamxDriver {
-		return false
+		return CSICameraDriverNone
 	}
 	if _, err := os.Stat(camxSocket); err != nil {
-		return false
+		return CSICameraDriverNone
 	}
 	slog.Debug("detected camx CSI camera driver")
 
-	return true
+	return CSICameraDriverCamx
 }
 
 func HasCarrierDevices(carriers []linuxconfig.Carrier, devices AvailableDevices) AvailableDevices {

--- a/internal/orchestrator/peripherals/devices.go
+++ b/internal/orchestrator/peripherals/devices.go
@@ -65,6 +65,7 @@ func Detect(ctx context.Context) (AvailableDevices, error) {
 		slog.Warn("unable to get enabled devices from linux config", slog.String("error", err.Error()))
 	}
 	devices = HasCarrierDevices(carriers, devices)
+	devices.HasCSICameraDevice = devices.HasCSICameraDevice || HasNativeCSICameraDriver()
 
 	return devices, nil
 }
@@ -175,8 +176,39 @@ func HasVirtualDevice(deviceClass DeviceClass, devices []string) bool {
 	return false
 }
 
-func HasCarrierDevices(carriers []linuxconfig.Carrier, devices AvailableDevices) AvailableDevices {
+// HasNativeCSICameraDriver reports if the board has built-in MIPI-CSI interfaces
+func HasNativeCSICameraDriver() bool {
+	return hasNativeCSICameraDriver("/sys/bus/platform/drivers", "/run/cam_server/le_cam_socket")
+}
 
+func hasNativeCSICameraDriver(driversDir string, camxSocket string) bool {
+	// Detect camss
+	if _, err := os.Stat(filepath.Join(driversDir, "qcom-camss")); err == nil {
+		slog.Debug("detected camss CSI camera driver")
+		return true
+	}
+
+	// Detect camx
+	entries, err := os.ReadDir(driversDir)
+	if err != nil {
+		slog.Debug("unable to list platform drivers", slog.String("dir", driversDir), slog.String("error", err.Error()))
+		return false
+	}
+	hasCamxDriver := slices.ContainsFunc(entries, func(e os.DirEntry) bool {
+		return e.IsDir() && strings.HasPrefix(e.Name(), "cam_")
+	})
+	if !hasCamxDriver {
+		return false
+	}
+	if _, err := os.Stat(camxSocket); err != nil {
+		return false
+	}
+	slog.Debug("detected camx CSI camera driver")
+
+	return true
+}
+
+func HasCarrierDevices(carriers []linuxconfig.Carrier, devices AvailableDevices) AvailableDevices {
 	for _, c := range carriers {
 		if c.CarrierName == "media-carrier" {
 			devices.HasCarrierSoundDevice = true

--- a/internal/orchestrator/peripherals/devices.go
+++ b/internal/orchestrator/peripherals/devices.go
@@ -18,6 +18,7 @@ import (
 	"github.com/arduino/go-paths-helper"
 
 	linuxconfig "github.com/arduino/arduino-app-cli/internal/orchestrator/linuxConfig"
+	"github.com/arduino/arduino-app-cli/internal/platform"
 )
 
 type AvailableDevices struct {
@@ -36,7 +37,7 @@ const (
 	SpeakerClass    DeviceClass = "speaker"
 )
 
-func Detect(ctx context.Context) (AvailableDevices, error) {
+func Detect(ctx context.Context, plat platform.Platform) (AvailableDevices, error) {
 	devices := AvailableDevices{}
 
 	deviceList, err := paths.New("/dev").ReadDir()
@@ -65,7 +66,11 @@ func Detect(ctx context.Context) (AvailableDevices, error) {
 		slog.Warn("unable to get enabled devices from linux config", slog.String("error", err.Error()))
 	}
 	devices = HasCarrierDevices(carriers, devices)
-	devices.HasCSICameraDevice = devices.HasCSICameraDevice || HasNativeCSICameraDriver()
+	// A CSI camera is usable only if a CSI driver is bound AND the board exposes the
+	// interface natively or a hat with configured cameras provides it. The driver alone
+	// is not enough on hat-based boards: it gets bound as soon as the hat DTBO is loaded,
+	// even with no camera configured.
+	devices.HasCSICameraDevice = HasCSICameraDriver() && (plat.HasNativeCSICameraSupport() || HasCSICameraOnCarrier(carriers))
 
 	return devices, nil
 }
@@ -184,8 +189,8 @@ const (
 	CSICameraDriverCamx  CSICameraDriver = "camx"
 )
 
-// HasNativeCSICameraDriver reports if the board has built-in MIPI-CSI interfaces
-func HasNativeCSICameraDriver() bool {
+// HasCSICameraDriver reports if a CSI camera driver is bound on the board
+func HasCSICameraDriver() bool {
 	return DetectCSICameraDriver() != CSICameraDriverNone
 }
 
@@ -221,16 +226,25 @@ func detectCSICameraDriver(driversDir string, camxSocket string) CSICameraDriver
 	return CSICameraDriverCamx
 }
 
+// HasCarrierDevices reports carrier-provided devices that are not CSI cameras
 func HasCarrierDevices(carriers []linuxconfig.Carrier, devices AvailableDevices) AvailableDevices {
 	for _, c := range carriers {
 		if c.CarrierName == "media-carrier" {
 			devices.HasCarrierSoundDevice = true
-			if slices.ContainsFunc(c.EnabledDevices(), func(d linuxconfig.Device) bool { return strings.Contains(d.Device, "camera") }) {
-				devices.HasCSICameraDevice = true
-				return devices
-			}
 		}
-
 	}
 	return devices
+}
+
+// HasCSICameraOnCarrier reports if a CSI camera is configured on an enabled media carrier
+func HasCSICameraOnCarrier(carriers []linuxconfig.Carrier) bool {
+	for _, c := range carriers {
+		if c.CarrierName != "media-carrier" {
+			continue
+		}
+		if slices.ContainsFunc(c.EnabledDevices(), func(d linuxconfig.Device) bool { return strings.Contains(d.Device, "camera") }) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/orchestrator/peripherals/devices.go
+++ b/internal/orchestrator/peripherals/devices.go
@@ -65,11 +65,7 @@ func Detect(ctx context.Context, plat platform.Platform) (AvailableDevices, erro
 	if err != nil {
 		slog.Warn("unable to get enabled devices from linux config", slog.String("error", err.Error()))
 	}
-	devices = HasCarrierDevices(carriers, devices)
-	// A CSI camera is usable only if a CSI driver is bound AND the board exposes the
-	// interface natively or a hat with configured cameras provides it. The driver alone
-	// is not enough on hat-based boards: it gets bound as soon as the hat DTBO is loaded,
-	// even with no camera configured.
+	devices.HasCarrierSoundDevice = HasSoundDeviceOnCarrier(carriers)
 	devices.HasCSICameraDevice = HasCSICameraDriver() && (plat.HasNativeCSICameraSupport() || HasCSICameraOnCarrier(carriers))
 
 	return devices, nil
@@ -226,14 +222,9 @@ func detectCSICameraDriver(driversDir string, camxSocket string) CSICameraDriver
 	return CSICameraDriverCamx
 }
 
-// HasCarrierDevices reports carrier-provided devices that are not CSI cameras
-func HasCarrierDevices(carriers []linuxconfig.Carrier, devices AvailableDevices) AvailableDevices {
-	for _, c := range carriers {
-		if c.CarrierName == "media-carrier" {
-			devices.HasCarrierSoundDevice = true
-		}
-	}
-	return devices
+// HasSoundDeviceOnCarrier reports if an enabled media carrier provides a sound device
+func HasSoundDeviceOnCarrier(carriers []linuxconfig.Carrier) bool {
+	return slices.ContainsFunc(carriers, func(c linuxconfig.Carrier) bool { return c.CarrierName == "media-carrier" })
 }
 
 // HasCSICameraOnCarrier reports if a CSI camera is configured on an enabled media carrier

--- a/internal/orchestrator/peripherals/devices_test.go
+++ b/internal/orchestrator/peripherals/devices_test.go
@@ -111,7 +111,7 @@ func TestDetectCSICameraDriver(t *testing.T) {
 			}
 			socketPath := filepath.Join(t.TempDir(), "le_cam_socket")
 			if tt.camxSocket {
-				require.NoError(t, os.WriteFile(socketPath, nil, 0o644))
+				require.NoError(t, os.WriteFile(socketPath, nil, 0o600))
 			}
 			assert.Equal(t, tt.want, detectCSICameraDriver(driversDir, socketPath))
 		})

--- a/internal/orchestrator/peripherals/devices_test.go
+++ b/internal/orchestrator/peripherals/devices_test.go
@@ -67,39 +67,39 @@ func TestExtractIndexFromVideoDeviceName(t *testing.T) {
 	}
 }
 
-func TestHasNativeCSICameraDriver(t *testing.T) {
+func TestDetectCSICameraDriver(t *testing.T) {
 	tests := []struct {
 		name       string
 		drivers    []string
 		camxSocket bool
-		want       bool
+		want       CSICameraDriver
 	}{
 		{
 			name:    "camss driver present",
 			drivers: []string{"qcom-camss"},
-			want:    true,
+			want:    CSICameraDriverCamss,
 		},
 		{
 			name:       "camx drivers with socket",
 			drivers:    []string{"cam_sync", "cam_smmu", "other-driver"},
 			camxSocket: true,
-			want:       true,
+			want:       CSICameraDriverCamx,
 		},
 		{
 			name:       "camx drivers without socket",
 			drivers:    []string{"cam_sync", "cam_smmu"},
 			camxSocket: false,
-			want:       false,
+			want:       CSICameraDriverNone,
 		},
 		{
 			name:       "socket without camx drivers",
 			drivers:    []string{"other-driver"},
 			camxSocket: true,
-			want:       false,
+			want:       CSICameraDriverNone,
 		},
 		{
 			name: "no drivers",
-			want: false,
+			want: CSICameraDriverNone,
 		},
 	}
 
@@ -113,13 +113,13 @@ func TestHasNativeCSICameraDriver(t *testing.T) {
 			if tt.camxSocket {
 				require.NoError(t, os.WriteFile(socketPath, nil, 0o644))
 			}
-			assert.Equal(t, tt.want, hasNativeCSICameraDriver(driversDir, socketPath))
+			assert.Equal(t, tt.want, detectCSICameraDriver(driversDir, socketPath))
 		})
 	}
 }
 
-func TestHasNativeCSICameraDriverMissingDriversDir(t *testing.T) {
-	assert.False(t, hasNativeCSICameraDriver(filepath.Join(t.TempDir(), "missing"), filepath.Join(t.TempDir(), "le_cam_socket")))
+func TestDetectCSICameraDriverMissingDriversDir(t *testing.T) {
+	assert.Equal(t, CSICameraDriverNone, detectCSICameraDriver(filepath.Join(t.TempDir(), "missing"), filepath.Join(t.TempDir(), "le_cam_socket")))
 }
 
 func TestContainsVirtualDevice(t *testing.T) {

--- a/internal/orchestrator/peripherals/devices_test.go
+++ b/internal/orchestrator/peripherals/devices_test.go
@@ -6,6 +6,8 @@
 package peripherals
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,6 +65,61 @@ func TestExtractIndexFromVideoDeviceName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHasNativeCSICameraDriver(t *testing.T) {
+	tests := []struct {
+		name       string
+		drivers    []string
+		camxSocket bool
+		want       bool
+	}{
+		{
+			name:    "camss driver present",
+			drivers: []string{"qcom-camss"},
+			want:    true,
+		},
+		{
+			name:       "camx drivers with socket",
+			drivers:    []string{"cam_sync", "cam_smmu", "other-driver"},
+			camxSocket: true,
+			want:       true,
+		},
+		{
+			name:       "camx drivers without socket",
+			drivers:    []string{"cam_sync", "cam_smmu"},
+			camxSocket: false,
+			want:       false,
+		},
+		{
+			name:       "socket without camx drivers",
+			drivers:    []string{"other-driver"},
+			camxSocket: true,
+			want:       false,
+		},
+		{
+			name: "no drivers",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driversDir := t.TempDir()
+			for _, d := range tt.drivers {
+				require.NoError(t, os.Mkdir(filepath.Join(driversDir, d), 0o755))
+			}
+			socketPath := filepath.Join(t.TempDir(), "le_cam_socket")
+			if tt.camxSocket {
+				require.NoError(t, os.WriteFile(socketPath, nil, 0o644))
+			}
+			assert.Equal(t, tt.want, hasNativeCSICameraDriver(driversDir, socketPath))
+		})
+	}
+}
+
+func TestHasNativeCSICameraDriverMissingDriversDir(t *testing.T) {
+	assert.False(t, hasNativeCSICameraDriver(filepath.Join(t.TempDir(), "missing"), filepath.Join(t.TempDir(), "le_cam_socket")))
 }
 
 func TestContainsVirtualDevice(t *testing.T) {

--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -30,6 +30,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/peripherals"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
@@ -346,6 +347,14 @@ func generateMainComposeFile(
 			Source: p.String(),
 			Target: p.String(),
 		})
+	}
+
+	// camx CSI cameras are accessed through the cam_server socket and a host userspace library
+	if peripherals.DetectCSICameraDriver() == peripherals.CSICameraDriverCamx {
+		volumes = append(volumes,
+			volume{Type: "bind", Source: "/run/cam_server", Target: "/run/cam_server"},
+			volume{Type: "bind", Source: "/usr/lib/libcamera_metadata.so.0.1.0", Target: "/usr/lib/libcamera_metadata.so.0.1.0"},
+		)
 	}
 
 	volumes = addLedControl(platform, volumes)

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -34,6 +34,13 @@ type Platform struct {
 	} `json:"-"`
 }
 
+// HasNativeCSICameraSupport reports if the board has built-in MIPI-CSI interfaces,
+// available without any additional carrier/hat.
+// Derived from BoardName so it stays consistent with platform.json overrides.
+func (p Platform) HasNativeCSICameraSupport() bool {
+	return p.BoardName == "ventunoq"
+}
+
 func GetPlatform(dir *paths.Path) Platform {
 	compatible := devicetree.LoadCompatible()
 	slog.Debug("detected platform", "compatible", compatible)


### PR DESCRIPTION
### Motivation

This PR allows to detect built-in CSI camera support on the VentunoQ board and allow the python-apps-base to use them.

### Change description

We have:
1. Introduced a check that detects whether the system has the qcom-camss or qcom-camx driver available;
2. Added a conditional bind mount that covers the qcom-camx case and allows the python-apps-base to access the qcom-camera-server socket on the host.

Note: we're currently also mounting a host lib (/usr/lib/libcamera_metadata.so.0.1.0) due to camera server limitations but future versions won't require it. We'll remove it as soon as it will be updated.

### Additional Notes

This PR complements https://github.com/bcmi-labs/arduino-deb-packages/pull/94 and https://github.com/arduino/app-bricks-py/pull/363.

### Reviewer checklist

- [x] PR addresses a single concern.
- [x] PR title and description are properly filled.
- [x] Changes will be merged in `main`.
- [x] Changes are covered by tests.
- [x] Logging is meaningful in case of troubleshooting.
