### PR TITLE
fix: carrier sound device is not a general sound device

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -159,7 +159,7 @@ func StartApp(
 
 	// TODO Pipewire is started if a media-carrier is present we should check also if it's required by the app.
 	if devices.HasCarrierSoundDevice {
-		if err := pipewire.EnsurePipewireRunning(ctx); err != nil {
+		if err := pipewire.EnsurePipewireRunning(ctx, cfg); err != nil {
 			return fmt.Errorf("failed to enable audio service linger: %w", err)
 		}
 	}

--- a/internal/orchestrator/peripherals/devices.go
+++ b/internal/orchestrator/peripherals/devices.go
@@ -179,7 +179,7 @@ func HasCarrierDevices(carriers []linuxconfig.Carrier, devices AvailableDevices)
 
 	for _, c := range carriers {
 		if c.CarrierName == "media-carrier" {
-			devices.HasSoundDevice = true
+			devices.HasCarrierSoundDevice = true
 			if slices.ContainsFunc(c.EnabledDevices(), func(d linuxconfig.Device) bool { return strings.Contains(d.Device, "camera") }) {
 				devices.HasCSICameraDevice = true
 				return devices

--- a/internal/orchestrator/pipewire/linger.go
+++ b/internal/orchestrator/pipewire/linger.go
@@ -150,6 +150,9 @@ func showLinger(ctx context.Context, username string) (bool, error) {
 
 	out, err := cmd.RunAndCaptureCombinedOutput(ctx)
 	if err != nil {
+		if strings.Contains(string(out), "is not logged in or lingering") {
+			return false, nil
+		}
 		return false, fmt.Errorf("%s: %w: %s", strings.Join(cmdArgs, " "), err, strings.TrimSpace(string(out)))
 	}
 	return strings.TrimSpace(string(out)) == "yes", nil

--- a/internal/orchestrator/pipewire/linger.go
+++ b/internal/orchestrator/pipewire/linger.go
@@ -59,7 +59,7 @@ func systemdLingerTimestamp(ctx context.Context, username string) (string, error
 	return strings.TrimSpace(string(out)), nil
 }
 
-func EnableLinger(ctx context.Context, cfg config.Configuration) error {
+func runEnableLingerCmd(ctx context.Context, cfg config.Configuration) error {
 	user, err := user.Current()
 	if err != nil {
 		return fmt.Errorf("get current user: %w", err)

--- a/internal/orchestrator/pipewire/pipewire.go
+++ b/internal/orchestrator/pipewire/pipewire.go
@@ -16,8 +16,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
 	"github.com/arduino/go-paths-helper"
+
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
 )
 
 const (

--- a/internal/orchestrator/pipewire/pipewire.go
+++ b/internal/orchestrator/pipewire/pipewire.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
 	"github.com/arduino/go-paths-helper"
 )
 
@@ -29,7 +30,12 @@ var pipewireUnits = []string{"pipewire.socket", "pipewire-pulse.socket", "wirepl
 // EnsurePipewireRunning waits for the current user's systemd --user manager to come
 // up — brought up by EnableLinger, which callers are expected to have called
 // first — and starts the PipeWire units on it.
-func EnsurePipewireRunning(ctx context.Context) error {
+func EnsurePipewireRunning(ctx context.Context, cfg config.Configuration) error {
+
+	if err := runEnableLingerCmd(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to enable audio service linger: %w", err)
+	}
+
 	var lastErr error
 	for i := 0; i < userManagerDialAttempts; i++ {
 		if _, err := runSystemctlUser(ctx, pipewireUnits...); err == nil {


### PR DESCRIPTION
### Motivation
If a media-carrier is present, we need to check the actual sound device present, not the general one


