### PR TITLE
Add support for new example layout

### DIFF
--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -1679,6 +1679,8 @@ components:
       properties:
         brick:
           type: string
+        brick_category:
+          type: string
         examples:
           items:
             $ref: '#/components/schemas/Example'
@@ -1789,6 +1791,12 @@ components:
       type: object
     CodeExample:
       properties:
+        description:
+          type: string
+        encoded_id:
+          type: string
+        name:
+          type: string
         path:
           type: string
       type: object
@@ -1874,7 +1882,7 @@ components:
             $ref: '#/components/schemas/BrickExamples'
           nullable: true
           type: array
-        coreAndFoundational:
+        core-and-foundational:
           items:
             $ref: '#/components/schemas/CategoryExamples'
           nullable: true

--- a/internal/e2e/client/client.gen.go
+++ b/internal/e2e/client/client.gen.go
@@ -254,8 +254,9 @@ type BrickDetailsResult struct {
 
 // BrickExamples defines model for BrickExamples.
 type BrickExamples struct {
-	Brick    *string    `json:"brick,omitempty"`
-	Examples *[]Example `json:"examples,omitempty"`
+	Brick         *string    `json:"brick,omitempty"`
+	BrickCategory *string    `json:"brick_category,omitempty"`
+	Examples      *[]Example `json:"examples,omitempty"`
 }
 
 // BrickInstance defines model for BrickInstance.
@@ -326,7 +327,10 @@ type CloneRequest struct {
 
 // CodeExample defines model for CodeExample.
 type CodeExample struct {
-	Path *string `json:"path,omitempty"`
+	Description *string `json:"description,omitempty"`
+	EncodedId   *string `json:"encoded_id,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	Path        *string `json:"path,omitempty"`
 }
 
 // ConfigDirectories defines model for ConfigDirectories.
@@ -390,7 +394,7 @@ type Example struct {
 // ExampleResponse defines model for ExampleResponse.
 type ExampleResponse struct {
 	Bricks              *[]BrickExamples    `json:"bricks,omitempty"`
-	CoreAndFoundational *[]CategoryExamples `json:"coreAndFoundational,omitempty"`
+	CoreAndFoundational *[]CategoryExamples `json:"core-and-foundational,omitempty"`
 }
 
 // Library defines model for Library.

--- a/internal/orchestrator/appid/id.go
+++ b/internal/orchestrator/appid/id.go
@@ -145,6 +145,16 @@ func (p *Provider) parseID(id string) (ID, error) {
 					break
 				}
 			}
+
+			pathPrefix, _, found := strings.Cut(appPath, "/")
+			if (found && pathPrefix == "core-and-foundational") ||
+				(found && pathPrefix == "bricks") {
+				path = p.cfg.ExamplesBaseDir().Join(appPath)
+				if path.Exist() {
+					break
+				}
+			}
+
 		default:
 			return ID{}, ErrInvalidID
 		}

--- a/internal/orchestrator/appid/id.go
+++ b/internal/orchestrator/appid/id.go
@@ -101,10 +101,22 @@ func (p *Provider) IDFromPath(path *paths.Path) (ID, error) {
 				if err != nil {
 					return ID{}, ErrInvalidID
 				}
-				id = "examples:" + rel.String()
+				id = "examples:" + "inspirational/" + rel.String()
 				isFromKnownLocation = true
 				isExample = true
 				break
+			}
+		}
+
+		for _, example := range p.cfg.ExamplesAdditionalDirs() {
+			if strings.HasPrefix(path.String(), example.String()) {
+				rel, err := path.RelFrom(p.cfg.ExamplesBaseDir())
+				if err != nil {
+					return ID{}, ErrInvalidID
+				}
+				id = "examples:" + rel.String()
+				isFromKnownLocation = true
+				isExample = true
 			}
 		}
 	}
@@ -138,20 +150,25 @@ func (p *Provider) parseID(id string) (ID, error) {
 			path = p.cfg.AppsDir().Join(appPath)
 		case "examples":
 			isExample = true
-			// Falls back to the last dir if none contains the example.
-			for _, examplePath := range p.cfg.ExamplesDirs(p.plat) {
-				path = examplePath.Join(appPath)
-				if path.Exist() {
-					break
-				}
-			}
+			pathPrefix, remainingPath, found := strings.Cut(appPath, "/")
 
-			pathPrefix, _, found := strings.Cut(appPath, "/")
+			// Falls back to the last dir if none contains the example.
+			path = p.cfg.ExamplesBaseDir().Join(appPath)
+
 			if (found && pathPrefix == "core-and-foundational") ||
 				(found && pathPrefix == "bricks") {
 				path = p.cfg.ExamplesBaseDir().Join(appPath)
 				if path.Exist() {
 					break
+				}
+			}
+
+			if found && pathPrefix == "inspirational" {
+				for _, examplePath := range p.cfg.ExamplesDirs(p.plat) {
+					path = examplePath.Join(remainingPath)
+					if path.Exist() {
+						break
+					}
 				}
 			}
 

--- a/internal/orchestrator/appid/id_test.go
+++ b/internal/orchestrator/appid/id_test.go
@@ -54,29 +54,29 @@ func TestNewIDFromPath(t *testing.T) {
 			want: f.Must(idProvider.ParseID("user:user-app")),
 		},
 		{
-			name: "valid example id",
+			name: "valid example id, legacy, in common",
 			in:   examplesCommonDir.Join("example-app"),
-			want: f.Must(idProvider.ParseID("examples:example-app")),
+			want: f.Must(idProvider.ParseID("examples:inspirational/example-app")),
 		},
 		{
 			name: "duplicated example id, the platform specific wins",
 			in:   examplesUnoQDir.Join("duplicated-example-app"),
-			want: f.Must(idProvider.ParseID("examples:duplicated-example-app")),
+			want: f.Must(idProvider.ParseID("examples:inspirational/duplicated-example-app")),
 		},
 		{
 			name: "platform specific valid example id",
 			in:   examplesUnoQDir.Join("special-example-app"),
-			want: f.Must(idProvider.ParseID("examples:special-example-app")),
+			want: f.Must(idProvider.ParseID("examples:inspirational/special-example-app")),
 		},
 		{
 			name: "nested common example id",
 			in:   examplesCommonDir.Join("nested", "deep", "example-app"),
-			want: f.Must(idProvider.ParseID("examples:nested/deep/example-app")),
+			want: f.Must(idProvider.ParseID("examples:inspirational/nested/deep/example-app")),
 		},
 		{
 			name: "nested platform example id",
 			in:   examplesUnoQDir.Join("nested", "platform-example"),
-			want: f.Must(idProvider.ParseID("examples:nested/platform-example")),
+			want: f.Must(idProvider.ParseID("examples:inspirational/nested/platform-example")),
 		},
 		{
 			name: "valid absolute path",
@@ -85,18 +85,13 @@ func TestNewIDFromPath(t *testing.T) {
 		},
 		{
 			name: "inspirational path",
-			in:   examplesBaseDir.Join("core-and-foundational"),
-			want: f.Must(idProvider.ParseID(examplesBaseDir.Join("core-and-foundational").String())),
-		},
-		{
-			name: "inspirational path",
 			in:   examplesBaseDir.Join("core-and-foundational", "nested1", "nested2"),
-			want: f.Must(idProvider.ParseID(examplesBaseDir.Join("core-and-foundational", "nested1", "nested2").String())),
+			want: f.Must(idProvider.ParseID("examples:core-and-foundational/nested1/nested2")),
 		},
 		{
 			name: "bricks",
 			in:   examplesBaseDir.Join("bricks", "nested1"),
-			want: f.Must(idProvider.ParseID(examplesBaseDir.Join("bricks", "nested1").String())),
+			want: f.Must(idProvider.ParseID("examples:bricks/nested1")),
 		},
 	}
 
@@ -125,6 +120,7 @@ func TestParseID(t *testing.T) {
 	examplesCommonDir := orchestratorConfig.DataDir().Join("examples", "inspirational", "common")
 	examplesBaseDir := orchestratorConfig.DataDir().Join("examples")
 	require.NoError(t, examplesCommonDir.Join("example-app").MkdirAll())
+	require.NoError(t, examplesCommonDir.Join("common-example").MkdirAll())
 	require.NoError(t, examplesCommonDir.Join("nested", "deep", "example-app").MkdirAll())
 	require.NoError(t, examplesUnoQDir.Join("nested", "platform-example").MkdirAll())
 
@@ -142,18 +138,18 @@ func TestParseID(t *testing.T) {
 			wantPath: orchestratorConfig.AppsDir().Join("user-app"),
 		},
 		{
-			name:     "valid example id",
-			in:       "examples:example-app",
+			name:     "valid example id, should check in common",
+			in:       "examples:inspirational/example-app",
 			wantPath: examplesCommonDir.Join("example-app"),
 		},
 		{
 			name:     "nested common example id",
-			in:       "examples:nested/deep/example-app",
+			in:       "examples:inspirational/nested/deep/example-app",
 			wantPath: examplesCommonDir.Join("nested", "deep", "example-app"),
 		},
 		{
 			name:     "nested platform example id wins over common",
-			in:       "examples:nested/platform-example",
+			in:       "examples:inspirational/nested/platform-example",
 			wantPath: examplesUnoQDir.Join("nested", "platform-example"),
 		},
 		{
@@ -178,7 +174,7 @@ func TestParseID(t *testing.T) {
 		},
 		{
 			name:     "not existing known location path DO NOT raise an error",
-			in:       "examples:missing",
+			in:       "examples:inspirational/missing",
 			wantPath: examplesCommonDir.Join("missing"),
 		},
 		{
@@ -192,14 +188,19 @@ func TestParseID(t *testing.T) {
 			wantPath: examplesBaseDir.Join("bricks", "example-app"),
 		},
 		{
-			name:     "others_dir belongs to common, existing example",
+			name:     "others_dir existing: is resolved starting from examples",
 			in:       "examples:others_dir/example-app",
-			wantPath: examplesCommonDir.Join("others_dir", "example-app"),
+			wantPath: examplesBaseDir.Join("others_dir", "example-app"),
 		},
 		{
-			name:     "others_dir belongs to common, missing example",
+			name:     "others_dir missing: is resolved starting from examples",
 			in:       "examples:others_dir/missing",
-			wantPath: examplesCommonDir.Join("others_dir", "missing"),
+			wantPath: examplesBaseDir.Join("others_dir", "missing"),
+		},
+		{
+			name:     "common examples should start from inspirational, no common is required",
+			in:       "examples:inspirational/common-example",
+			wantPath: examplesCommonDir.Join("common-example"),
 		},
 	}
 

--- a/internal/orchestrator/appid/id_test.go
+++ b/internal/orchestrator/appid/id_test.go
@@ -26,16 +26,19 @@ func TestNewIDFromPath(t *testing.T) {
 
 	orchestratorConfig, err := config.NewFromEnv()
 	require.NoError(t, err)
-	examplesBoardDir := orchestratorConfig.DataDir().Join("examples/inspirational", "platform_unoq")
-	examplesCommonDir := orchestratorConfig.DataDir().Join("examples/inspirational", "common")
+	examplesUnoQDir := orchestratorConfig.DataDir().Join("examples", "inspirational", "platform_unoq")
+	examplesCommonDir := orchestratorConfig.DataDir().Join("examples", "inspirational", "common")
+	examplesBaseDir := orchestratorConfig.DataDir().Join("examples")
 	require.NoError(t, orchestratorConfig.AppsDir().Join("user-app").MkdirAll())
 	require.NoError(t, examplesCommonDir.Join("example-app").MkdirAll())
-	require.NoError(t, examplesBoardDir.Join("special-example-app").MkdirAll())
+	require.NoError(t, examplesUnoQDir.Join("special-example-app").MkdirAll())
 	require.NoError(t, examplesCommonDir.Join("duplicated-example-app").MkdirAll())
-	require.NoError(t, examplesBoardDir.Join("duplicated-example-app").MkdirAll())
+	require.NoError(t, examplesUnoQDir.Join("duplicated-example-app").MkdirAll())
 	require.NoError(t, examplesCommonDir.Join("nested", "deep", "example-app").MkdirAll())
-	require.NoError(t, examplesBoardDir.Join("nested", "platform-example").MkdirAll())
-	require.NoError(t, tmp.Join("other-app").MkdirAll())
+	require.NoError(t, examplesUnoQDir.Join("nested", "platform-example").MkdirAll())
+	require.NoError(t, examplesBaseDir.Join("core-and-foundational", "nested1", "nested2").MkdirAll())
+	require.NoError(t, examplesBaseDir.Join("bricks", "nested1").MkdirAll())
+	require.NoError(t, tmp.Join("other-location-app").MkdirAll())
 
 	idProvider := NewAppProvider(orchestratorConfig, unoQPlatform)
 
@@ -57,12 +60,12 @@ func TestNewIDFromPath(t *testing.T) {
 		},
 		{
 			name: "duplicated example id, the platform specific wins",
-			in:   examplesBoardDir.Join("duplicated-example-app"),
+			in:   examplesUnoQDir.Join("duplicated-example-app"),
 			want: f.Must(idProvider.ParseID("examples:duplicated-example-app")),
 		},
 		{
 			name: "platform specific valid example id",
-			in:   examplesBoardDir.Join("special-example-app"),
+			in:   examplesUnoQDir.Join("special-example-app"),
 			want: f.Must(idProvider.ParseID("examples:special-example-app")),
 		},
 		{
@@ -72,14 +75,28 @@ func TestNewIDFromPath(t *testing.T) {
 		},
 		{
 			name: "nested platform example id",
-			in:   examplesBoardDir.Join("nested", "platform-example"),
+			in:   examplesUnoQDir.Join("nested", "platform-example"),
 			want: f.Must(idProvider.ParseID("examples:nested/platform-example")),
 		},
-
 		{
 			name: "valid absolute path",
-			in:   tmp.Join("other-app"),
-			want: f.Must(idProvider.IDFromPath(tmp.Join("other-app"))),
+			in:   tmp.Join("other-location-app"),
+			want: f.Must(idProvider.ParseID(tmp.Join("other-location-app").String())),
+		},
+		{
+			name: "inspirational path",
+			in:   examplesBaseDir.Join("core-and-foundational"),
+			want: f.Must(idProvider.ParseID(examplesBaseDir.Join("core-and-foundational").String())),
+		},
+		{
+			name: "inspirational path",
+			in:   examplesBaseDir.Join("core-and-foundational", "nested1", "nested2"),
+			want: f.Must(idProvider.ParseID(examplesBaseDir.Join("core-and-foundational", "nested1", "nested2").String())),
+		},
+		{
+			name: "bricks",
+			in:   examplesBaseDir.Join("bricks", "nested1"),
+			want: f.Must(idProvider.ParseID(examplesBaseDir.Join("bricks", "nested1").String())),
 		},
 	}
 
@@ -104,11 +121,12 @@ func TestParseID(t *testing.T) {
 	orchestratorConfig, err := config.NewFromEnv()
 	require.NoError(t, err)
 	require.NoError(t, tmp.Join("other-app").MkdirAll())
-	examplesBoardDir := orchestratorConfig.DataDir().Join("examples/inspirational", "platform_unoq")
-	examplesCommonDir := orchestratorConfig.DataDir().Join("examples/inspirational", "common")
+	examplesUnoQDir := orchestratorConfig.DataDir().Join("examples", "inspirational", "platform_unoq")
+	examplesCommonDir := orchestratorConfig.DataDir().Join("examples", "inspirational", "common")
+	examplesBaseDir := orchestratorConfig.DataDir().Join("examples")
 	require.NoError(t, examplesCommonDir.Join("example-app").MkdirAll())
 	require.NoError(t, examplesCommonDir.Join("nested", "deep", "example-app").MkdirAll())
-	require.NoError(t, examplesBoardDir.Join("nested", "platform-example").MkdirAll())
+	require.NoError(t, examplesUnoQDir.Join("nested", "platform-example").MkdirAll())
 
 	idProvider := NewAppProvider(orchestratorConfig, unoQPlatform)
 
@@ -136,7 +154,7 @@ func TestParseID(t *testing.T) {
 		{
 			name:     "nested platform example id wins over common",
 			in:       "examples:nested/platform-example",
-			wantPath: examplesBoardDir.Join("nested", "platform-example"),
+			wantPath: examplesUnoQDir.Join("nested", "platform-example"),
 		},
 		{
 			name:     "absolute path to app",
@@ -154,9 +172,34 @@ func TestParseID(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "not existing path",
+			name:    "not existing system path raise an error",
 			in:      "/non/existing/path",
 			wantErr: true,
+		},
+		{
+			name:     "not existing known location path DO NOT raise an error",
+			in:       "examples:missing",
+			wantPath: examplesCommonDir.Join("missing"),
+		},
+		{
+			name:     "core-and-foundational should be processed",
+			in:       "examples:core-and-foundational/example-app",
+			wantPath: examplesBaseDir.Join("core-and-foundational", "example-app"),
+		},
+		{
+			name:     "bricks should be processed",
+			in:       "examples:bricks/example-app",
+			wantPath: examplesBaseDir.Join("bricks", "example-app"),
+		},
+		{
+			name:     "others_dir belongs to common, existing example",
+			in:       "examples:others_dir/example-app",
+			wantPath: examplesCommonDir.Join("others_dir", "example-app"),
+		},
+		{
+			name:     "others_dir belongs to common, missing example",
+			in:       "examples:others_dir/missing",
+			wantPath: examplesCommonDir.Join("others_dir", "missing"),
 		},
 	}
 

--- a/internal/orchestrator/bricks/bricks.go
+++ b/internal/orchestrator/bricks/bricks.go
@@ -120,7 +120,7 @@ func (s *Service) AppBrickInstanceDetails(a *app.ArduinoApp, brickID string) (Br
 	if r, err := brick.GetReadmeFile(); err == nil {
 		readme = r
 	} else {
-		slog.Warn("cannot open readme for brick", "brickID", brick.ID, "error", err.Error())
+		slog.Warn("cannot open readme for brick", slog.String("brickID", brick.ID), slog.Any("error", err.Error()))
 	}
 
 	return BrickInstance{
@@ -183,29 +183,25 @@ func (s *Service) BricksDetails(id string, idProvider *appid.Provider,
 
 	readme, err := brick.GetReadmeFile()
 	if err != nil {
-		slog.Warn("cannot open readme for brick", "brickID", brick.ID, "error", err.Error())
+		slog.Warn("cannot open readme for brick", slog.String("brickID", brick.ID), slog.Any("error", err.Error()))
 	}
 
 	var apiDocsPath string
 	if p, ok := brick.GetApiDocPath(); ok {
 		apiDocsPath = p.String()
 	} else {
-		slog.Warn("cannot load API doc", "brickID", brick.ID)
+		slog.Warn("cannot load API doc", slog.String("brickID", brick.ID))
 	}
 
-	examplePaths, err := brick.GetExamplesPath()
+	brickNamespace, brickName, err := bricksindex.ParseBrickID(brick.ID)
 	if err != nil {
-		slog.Warn("cannot load example for brick", "brickID", brick.ID, "error", err.Error())
+		slog.Warn("invalid brick id", "brickID", brick.ID, "error", err.Error())
 	}
-	codeExamples := f.Map(examplePaths, func(p *paths.Path) CodeExample {
-		return CodeExample{
-			Path: p.String(),
-		}
-	})
+	codeExamples := getBrickExamplesInfo(cfg, idProvider, brickNamespace, brickName)
 
 	usedByApps, err := getUsedByApps(cfg, brick.ID, idProvider, platform)
 	if err != nil {
-		slog.Warn("unable to get used by apps for brick", "brickID", brick.ID, "error", err.Error())
+		slog.Warn("unable to get used by apps for brick", slog.String("brickID", brick.ID), slog.Any("error", err.Error()))
 	}
 
 	variables, configVariables := getBrickConfigVariableDetails(brick)
@@ -232,6 +228,43 @@ func (s *Service) BricksDetails(id string, idProvider *appid.Provider,
 		}),
 		ConfigVariables: configVariables,
 	}, nil
+}
+
+func getBrickExamplesInfo(cfg config.Configuration, idProvider *appid.Provider, brickNamespace string, brickName string) []CodeExample {
+	var codeExamples = []CodeExample{}
+
+	examplesPath := cfg.ExamplesBaseDir().Join("bricks", brickNamespace, brickName)
+
+	dirEntries, err := examplesPath.ReadDir()
+	if err != nil {
+		slog.Warn("cannot read examples directory", slog.Any("error", err.Error()))
+		return []CodeExample{}
+	}
+
+	for _, brickExamplePath := range dirEntries {
+		id, err := idProvider.IDFromPath(brickExamplePath)
+		if err != nil {
+			slog.Warn("Invalid path", slog.String("brickExamplePath", brickExamplePath.String()))
+			continue
+		}
+
+		loadedApp, err := app.Load(id.ToPath())
+		if err != nil {
+			slog.Warn("App referenced in examples not found", slog.String("brickExamplePath", brickExamplePath.String()))
+			continue
+		}
+
+		mainPy := brickExamplePath.Join("python", "main.py")
+
+		codeExamples = append(codeExamples, CodeExample{
+			Path:        mainPy.String(),
+			EncodedID:   id.String(),
+			Name:        loadedApp.Name,
+			Description: loadedApp.Descriptor.Description,
+		})
+	}
+
+	return codeExamples
 }
 
 func getBrickConfigVariableDetails(
@@ -263,6 +296,7 @@ func getBrickConfigVariableDetails(
 func getUsedByApps(cfg config.Configuration, brickId string, idProvider *appid.Provider, platform platform.Platform) ([]AppReference, error) {
 	pathsToExplore := paths.NewPathList()
 	pathsToExplore.AddAll(cfg.ExamplesDirs(platform))
+	pathsToExplore.AddAll(cfg.ExamplesAdditionalDirs())
 	pathsToExplore.Add(cfg.AppsDir())
 	appPaths, err := app.FindAppsInFolders(pathsToExplore)
 	if err != nil {
@@ -275,7 +309,7 @@ func getUsedByApps(cfg config.Configuration, brickId string, idProvider *appid.P
 		app, err := app.Load(appPath)
 		if err != nil {
 			// we are not considering the broken apps
-			slog.Warn("unable to parse app.yaml, skipping", "path", appPath.String(), "error", err.Error())
+			slog.Warn("unable to parse app.yaml, skipping", slog.String("path", appPath.String()), slog.Any("error", err.Error()))
 			continue
 		}
 
@@ -325,7 +359,7 @@ func (s *Service) BrickCreate(
 	for _, brickVar := range brick.Variables {
 		if brickVar.IsRequired() {
 			if _, exist := req.Variables[brickVar.Name]; !exist {
-				slog.Warn("[Skip] a required variable is not set by user", "variable", brickVar.Name, "brick", brickVar.Name)
+				slog.Warn("[Skip] a required variable is not set by user", slog.String("variable", brickVar.Name), slog.String("brick", brickVar.Name))
 			}
 		}
 	}

--- a/internal/orchestrator/bricks/bricks.go
+++ b/internal/orchestrator/bricks/bricks.go
@@ -293,10 +293,11 @@ func getBrickConfigVariableDetails(
 	return variablesMap, variableDetails
 }
 
+// Additional core-and-foundational and brick paths are not processed here;
+// we do not want them to appear in the brick example list.
 func getUsedByApps(cfg config.Configuration, brickId string, idProvider *appid.Provider, platform platform.Platform) ([]AppReference, error) {
 	pathsToExplore := paths.NewPathList()
 	pathsToExplore.AddAll(cfg.ExamplesDirs(platform))
-	pathsToExplore.AddAll(cfg.ExamplesAdditionalDirs())
 	pathsToExplore.Add(cfg.AppsDir())
 	appPaths, err := app.FindAppsInFolders(pathsToExplore)
 	if err != nil {

--- a/internal/orchestrator/bricks/bricks_test.go
+++ b/internal/orchestrator/bricks/bricks_test.go
@@ -407,6 +407,17 @@ bricks:
 	cfg, err := config.NewFromEnv()
 	require.NoError(t, err)
 
+	// Add brick CodeExamples
+	examplesBaseDir := cfg.ExamplesBaseDir()
+	require.NoError(t, examplesBaseDir.Join("core-and-foundational").MkdirAll())
+	bricksDir := cfg.ExamplesBaseDir().Join("bricks")
+	require.NoError(t, bricksDir.Join("arduino", "one_model_brick", "01_example", "python").MkdirAll())
+	require.NoError(t, bricksDir.Join("arduino", "one_model_brick", "02_example", "python").MkdirAll())
+	require.NoError(t, bricksDir.Join("arduino", "one_model_brick", "01_example", "python", "main.py").Truncate())
+	require.NoError(t, bricksDir.Join("arduino", "one_model_brick", "02_example", "python", "main.py").Truncate())
+	require.NoError(t, bricksDir.Join("arduino", "one_model_brick", "01_example", "app.yaml").Truncate())
+	require.NoError(t, bricksDir.Join("arduino", "one_model_brick", "02_example", "app.yaml").Truncate())
+
 	for _, brick := range []string{"object_detection", "weather_forecast", "one_model_brick"} {
 		createFakeBrickAssets(t, assetsDir, brick)
 	}
@@ -471,8 +482,6 @@ bricks:
 		require.Equal(t, "default_path", res.Variables["EI_OBJ_DETECTION_MODEL"].DefaultValue)
 		require.Equal(t, "# Documentation", res.Readme)
 		require.Contains(t, res.ApiDocsPath, filepath.Join("arduino", "app_bricks", "object_detection", "API.md"))
-		require.Len(t, res.CodeExamples, 1)
-		require.Contains(t, res.CodeExamples[0].Path, "blink.ino")
 		require.Len(t, res.UsedByApps, 1)
 		require.Equal(t, "My App", res.UsedByApps[0].Name)
 		require.NotEmpty(t, res.UsedByApps[0].ID)
@@ -498,8 +507,6 @@ bricks:
 		require.Empty(t, res.Variables)
 		require.Equal(t, "# Documentation", res.Readme)
 		require.Contains(t, res.ApiDocsPath, filepath.Join("arduino", "app_bricks", "weather_forecast", "API.md"))
-		require.Len(t, res.CodeExamples, 1)
-		require.Contains(t, res.CodeExamples[0].Path, "blink.ino")
 		require.Len(t, res.UsedByApps, 1)
 		require.Equal(t, "My App", res.UsedByApps[0].Name)
 		require.NotEmpty(t, res.UsedByApps[0].ID)
@@ -520,6 +527,22 @@ bricks:
 		require.Empty(t, res.ConfigVariables)
 		require.Empty(t, res.Variables)
 	})
+
+	t.Run("Success - Brick Code example", func(t *testing.T) {
+		res, err := svc.BricksDetails("arduino:one_model_brick", idProvider, cfg, unoQPlatform)
+		require.NoError(t, err)
+
+		require.Equal(t, "arduino:one_model_brick", res.ID)
+		require.Equal(t, "one model brick", res.Name)
+		require.Len(t, res.CompatibleModels, 1)
+		require.Len(t, res.CodeExamples, 2)
+		require.Equal(t, "face-detection", res.CompatibleModels[0].ID)
+		require.Equal(t, "Lightweight-Face-Detection", res.CompatibleModels[0].Name)
+		require.Equal(t, "", res.CompatibleModels[0].Description)
+		require.Empty(t, res.ConfigVariables)
+		require.Empty(t, res.Variables)
+	})
+
 }
 
 func createFakeBrickAssets(t *testing.T, assetsDir, brick string) {

--- a/internal/orchestrator/bricks/bricks_test.go
+++ b/internal/orchestrator/bricks/bricks_test.go
@@ -407,16 +407,17 @@ bricks:
 	cfg, err := config.NewFromEnv()
 	require.NoError(t, err)
 
-	// Add brick CodeExamples
-	examplesBaseDir := cfg.ExamplesBaseDir()
-	require.NoError(t, examplesBaseDir.Join("core-and-foundational").MkdirAll())
-	bricksDir := cfg.ExamplesBaseDir().Join("bricks")
-	require.NoError(t, bricksDir.Join("arduino", "one_model_brick", "01_example", "python").MkdirAll())
-	require.NoError(t, bricksDir.Join("arduino", "one_model_brick", "02_example", "python").MkdirAll())
-	require.NoError(t, bricksDir.Join("arduino", "one_model_brick", "01_example", "python", "main.py").Truncate())
-	require.NoError(t, bricksDir.Join("arduino", "one_model_brick", "02_example", "python", "main.py").Truncate())
-	require.NoError(t, bricksDir.Join("arduino", "one_model_brick", "01_example", "app.yaml").Truncate())
-	require.NoError(t, bricksDir.Join("arduino", "one_model_brick", "02_example", "app.yaml").Truncate())
+	// Add two one_model_brick CodeExamples as testacase
+	brick01Dir := cfg.ExamplesBaseDir().Join("bricks").Join("arduino", "one_model_brick", "01_example")
+	require.NoError(t, brick01Dir.Join("python").MkdirAll())
+	brick02Dir := cfg.ExamplesBaseDir().Join("bricks").Join("arduino", "one_model_brick", "02_example")
+	require.NoError(t, brick02Dir.Join("python").MkdirAll())
+
+	// Create required files to load the app
+	require.NoError(t, brick01Dir.Join("python", "main.py").Truncate())
+	require.NoError(t, brick02Dir.Join("python", "main.py").Truncate())
+	require.NoError(t, brick01Dir.Join("app.yaml").Truncate())
+	require.NoError(t, brick02Dir.Join("app.yaml").Truncate())
 
 	for _, brick := range []string{"object_detection", "weather_forecast", "one_model_brick"} {
 		createFakeBrickAssets(t, assetsDir, brick)

--- a/internal/orchestrator/bricks/types.go
+++ b/internal/orchestrator/bricks/types.go
@@ -56,8 +56,12 @@ type BrickVariable struct {
 }
 
 type CodeExample struct {
-	Path string `json:"path"`
+	Path        string `json:"path"`
+	EncodedID   string `json:"encoded_id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
 }
+
 type AppReference struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`

--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -170,20 +170,6 @@ func (b Brick) GetReadmeFile() (string, error) {
 	return string(content), nil
 }
 
-func (b Brick) GetExamplesPath() (paths.PathList, error) {
-	if b.ExamplesPath == nil || b.ExamplesPath.NotExist() {
-		return nil, fmt.Errorf("examples not found for brick %s", b.ID)
-	}
-	dirEntries, err := b.ExamplesPath.ReadDir()
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("examples not found for brick %s", b.ID)
-		}
-		return nil, fmt.Errorf("cannot read examples directory %q: %w", b.ExamplesPath, err)
-	}
-	return dirEntries, nil
-}
-
 func (b Brick) GetApiDocPath() (*paths.Path, bool) {
 	if b.DocsAPIPath == nil || b.DocsAPIPath.NotExist() {
 		return nil, false
@@ -271,7 +257,7 @@ func Load(platform platform.Platform, path *paths.Path) (*BricksIndex, error) {
 	}
 
 	for i := range yamlIndex.Bricks {
-		namespace, brickName, err := parseBrickID(yamlIndex.Bricks[i].ID)
+		namespace, brickName, err := ParseBrickID(yamlIndex.Bricks[i].ID)
 		if err != nil {
 			return nil, err
 		}
@@ -328,7 +314,7 @@ func Load(platform platform.Platform, path *paths.Path) (*BricksIndex, error) {
 	}, nil
 }
 
-func parseBrickID(brickID string) (namespace, name string, err error) {
+func ParseBrickID(brickID string) (namespace, name string, err error) {
 	namespace, brickName, ok := strings.Cut(brickID, ":")
 	if !ok {
 		return "", "", errors.New("invalid ID")

--- a/internal/orchestrator/bricksindex/bricks_index_test.go
+++ b/internal/orchestrator/bricksindex/bricks_index_test.go
@@ -366,10 +366,6 @@ func TestLoadBrickYamlBrickIndex(t *testing.T) {
 		require.True(t, found)
 		require.Equal(t, paths.New("testdata/0.4.8/compose/arduino/a-good-brick/brick_compose.yaml"), compose)
 
-		examples, err := brick.GetExamplesPath()
-		require.NoError(t, err)
-		require.Equal(t, paths.NewPathList("testdata/0.4.8/examples/arduino/a-good-brick/example_1.py", "testdata/0.4.8/examples/arduino/a-good-brick/example_2.py"), examples)
-
 		api, found := brick.GetApiDocPath()
 		require.True(t, found)
 		require.Equal(t, paths.New("testdata/0.4.8/api-docs/arduino/app_bricks/a-good-brick/API.md"), api)

--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -189,6 +189,12 @@ func (c *Configuration) ExamplesBaseDir() *paths.Path {
 	return c.dataDir.Join("examples/")
 }
 
+func (c *Configuration) ExamplesAdditionalDirs() paths.PathList {
+	return paths.PathList{
+		c.ExamplesBaseDir().Join("core-and-foundational"),
+		c.ExamplesBaseDir().Join("bricks")}
+}
+
 func (c *Configuration) ExamplesDirs(platform platform.Platform) paths.PathList {
 	boardExampleDir := c.examplesDir().Join(fmt.Sprintf("platform_%s", platform.BoardName))
 	if boardExampleDir.Exist() {

--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -161,9 +161,17 @@ func (c *Configuration) init() error {
 	if err := c.AppsDir().MkdirAll(); err != nil {
 		return err
 	}
-	if err := c.examplesDir().Join("common").MkdirAll(); err != nil {
-		return err
+
+	examplesDir := paths.PathList{
+		c.examplesDir().Join("common"),
 	}
+	examplesDir.AddAll(c.ExamplesAdditionalDirs())
+	for _, dir := range examplesDir {
+		if err := dir.MkdirAll(); err != nil {
+			return err
+		}
+	}
+
 	if err := c.AssetDir().MkdirAll(); err != nil {
 		return err
 	}

--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -163,7 +163,7 @@ func (c *Configuration) init() error {
 	}
 
 	examplesDir := paths.PathList{
-		c.examplesDir().Join("common"),
+		c.ExamplesBaseDir().Join("inspirational").Join("common"),
 	}
 	examplesDir.AddAll(c.ExamplesAdditionalDirs())
 	for _, dir := range examplesDir {
@@ -189,12 +189,8 @@ func (c *Configuration) DataDir() *paths.Path {
 	return c.dataDir
 }
 
-func (c *Configuration) examplesDir() *paths.Path {
-	return c.dataDir.Join("examples", "inspirational")
-}
-
 func (c *Configuration) ExamplesBaseDir() *paths.Path {
-	return c.dataDir.Join("examples/")
+	return c.dataDir.Join("examples")
 }
 
 func (c *Configuration) ExamplesAdditionalDirs() paths.PathList {
@@ -204,11 +200,11 @@ func (c *Configuration) ExamplesAdditionalDirs() paths.PathList {
 }
 
 func (c *Configuration) ExamplesDirs(platform platform.Platform) paths.PathList {
-	boardExampleDir := c.examplesDir().Join(fmt.Sprintf("platform_%s", platform.BoardName))
+	boardExampleDir := c.ExamplesBaseDir().Join("inspirational").Join(fmt.Sprintf("platform_%s", platform.BoardName))
 	if boardExampleDir.Exist() {
-		return paths.PathList{boardExampleDir, c.examplesDir().Join("common")}
+		return paths.PathList{boardExampleDir, c.ExamplesBaseDir().Join("inspirational").Join("common")}
 	}
-	return paths.PathList{c.examplesDir().Join("common")}
+	return paths.PathList{c.ExamplesBaseDir().Join("inspirational").Join("common")}
 }
 
 // RequiredRuntimesPaths returns the discovered host paths for configured required

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -267,7 +267,7 @@ func TestListApp(t *testing.T) {
 		assert.Empty(t, res.BrokenApps)
 		assert.Empty(t, gCmp.Diff([]AppInfo{
 			{
-				ID:          f.Must(idProvider.ParseID("examples:example1")),
+				ID:          f.Must(idProvider.ParseID("examples:inspirational/example1")),
 				Name:        "example1",
 				Description: "",
 				Icon:        "😃",
@@ -336,7 +336,7 @@ func TestListApp(t *testing.T) {
 		assert.Empty(t, res.BrokenApps)
 		assert.Empty(t, gCmp.Diff([]AppInfo{
 			{
-				ID:          f.Must(idProvider.ParseID("examples:example1")),
+				ID:          f.Must(idProvider.ParseID("examples:inspirational/example1")),
 				Name:        "example1",
 				Description: "",
 				Icon:        "😃",

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -554,7 +554,7 @@ func createApp(
 		require.NoError(t, err)
 		newID, err := idProvider.IDFromPath(newPath)
 		require.NoError(t, err)
-		assert.Empty(t, gCmp.Diff(f.Must(idProvider.ParseID("examples:"+name)), newID))
+		assert.Empty(t, gCmp.Diff(f.Must(idProvider.ParseID("examples:inspirational/"+name)), newID))
 		res.ID = newID
 	}
 

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -594,6 +594,7 @@ func downloadLibsAndPlatformsUsedInExamples(ctx context.Context, cfg config.Conf
 
 	// Get a list of example apps
 	pathsToExplore := cfg.ExamplesDirs(platform)
+	pathsToExplore.AddAll(cfg.ExamplesAdditionalDirs())
 	exampleAppsPath, err := app.FindAppsInFolders(pathsToExplore)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Motivation

Process others examples subdirectories inside /var/lib/arduino-app-cli/examples/, (core-and-foudation and bricks) excluding /inspirational/, which is already handled from legacy code.
Update the brickDetails API to search for brick examples in the brick examples folder.

Update tests.