### PR TITLE
refactor: update the new pipewire utility

### DIFF
--- a/docs/user-documentation.md
+++ b/docs/user-documentation.md
@@ -51,6 +51,7 @@ Examples of the `assets` and the builtin `examples` stored under the `ARDUINO_AP
 │       └── ...
 ├── bootloader_burned.flag
 ├── default.app               # Default App
+├── pipewire_linger.timestamp # PipeWire linger record
 ├── properties.msgpack        # Variable values
 ├── examples                  # Built-in App examples
 │   ├── air-quality-monitoring

--- a/internal/orchestrator/pipewire/linger.go
+++ b/internal/orchestrator/pipewire/linger.go
@@ -21,37 +21,101 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
 )
 
-func setOwner(ownerPath string, lingerMtime time.Time) error {
-	if err := os.MkdirAll(filepath.Dir(ownerPath), 0700); err != nil {
-		return err
+// enableLingering enables lingering for the current user if not already enabled, and saves the mtime of the linger file to the configuration directory.
+func enableLingering(ctx context.Context, cfg config.Configuration) error {
+	user, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("get current user: %w", err)
 	}
-	return fatomic.WriteFile(ownerPath, []byte(lingerMtime.Format(time.RFC3339Nano)), 0600)
+
+	alreadyOn, err := runShowLingerCommand(ctx, user.Username)
+	if err != nil {
+		return fmt.Errorf("check linger: %w", err)
+	}
+	if alreadyOn {
+		return nil
+	}
+
+	err = runEnableLingerCommand(ctx, user.Username)
+	if err != nil {
+		return fmt.Errorf("enable linger: %w", err)
+	}
+	mtime, err := getLingerFileMtime(user.Username)
+	if err != nil {
+		return fmt.Errorf("read linger state: %w", err)
+	}
+
+	return saveLingerRecord(cfg, mtime)
 }
 
-func isSetbyApp(ownerPath string) (owned bool, recordedMtime time.Time, err error) {
-	data, err := os.ReadFile(ownerPath)
+func stopLingering(ctx context.Context, cfg config.Configuration) error {
+	owned, recordedMtime, err := readLingerRecord(cfg)
+	if err != nil {
+		return fmt.Errorf("check linger ownership: %w", err)
+	}
+	if !owned {
+		return nil
+	}
+
+	user, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("get current user: %w", err)
+	}
+
+	currentMtime, err := getLingerFileMtime(user.Username)
+	if err != nil {
+		return fmt.Errorf("read linger state: %w", err)
+	}
+
+	if currentMtime.Equal(recordedMtime) {
+		err := runDisableLingerCommand(ctx, user.Username)
+		if err != nil {
+			return fmt.Errorf("disable linger: %w", err)
+		}
+		slog.Debug("linger disabled", slog.String("username", user.Username))
+	}
+
+	return clearLingerRecord(cfg)
+}
+
+func lingerRecordPath(cfg config.Configuration) *paths.Path {
+	return cfg.DataDir().Join("pipewire_linger.timestamp")
+}
+
+func saveLingerRecord(cfg config.Configuration, lingerMtime time.Time) error {
+	p := lingerRecordPath(cfg)
+	if err := p.Parent().MkdirAll(); err != nil {
+		return err
+	}
+	return fatomic.WriteFile(p.String(), []byte(lingerMtime.Format(time.RFC3339Nano)), 0600)
+}
+
+func readLingerRecord(cfg config.Configuration) (bool, time.Time, error) {
+	data, err := lingerRecordPath(cfg).ReadFile()
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, time.Time{}, nil
 		}
 		return false, time.Time{}, err
 	}
-	t, err := time.Parse(time.RFC3339Nano, string(data))
-	if err != nil {
+
+	if t, err := time.Parse(time.RFC3339Nano, string(data)); err != nil {
 		return false, time.Time{}, fmt.Errorf("parse recorded linger mtime: %w", err)
+	} else {
+		return true, t, nil
 	}
-	return true, t, nil
 }
 
-func clearOwner(ownerPath string) error {
-	err := os.Remove(ownerPath)
+func clearLingerRecord(cfg config.Configuration) error {
+	err := lingerRecordPath(cfg).Remove()
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return nil
 }
 
-func lingerFileMtime(username string) (time.Time, error) {
+// getLingerFileMtime returns the mtime of the linger file for the given username, or zero time if the file does not exist.
+func getLingerFileMtime(username string) (time.Time, error) {
 	info, err := os.Stat(filepath.Join("/var/lib/systemd/linger", username))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -62,66 +126,7 @@ func lingerFileMtime(username string) (time.Time, error) {
 	return info.ModTime(), nil
 }
 
-func runEnableLingerCmd(ctx context.Context, cfg config.Configuration) error {
-	user, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("get current user: %w", err)
-	}
-
-	alreadyOn, err := showLinger(ctx, user.Username)
-	if err != nil {
-		return fmt.Errorf("check linger: %w", err)
-	}
-	if alreadyOn {
-		return nil
-	}
-
-	err = enableLinger(ctx, user.Username)
-	if err != nil {
-		return fmt.Errorf("enable linger: %w", err)
-	}
-	mtime, err := lingerFileMtime(user.Username)
-	if err != nil {
-		return fmt.Errorf("read linger state: %w", err)
-	}
-
-	ownerPath := cfg.DataDir().Join("pipewire").Join(fmt.Sprintf("linger-owner-%s", user.Username)).String()
-	return setOwner(ownerPath, mtime)
-}
-
-func StopIfNotNeeded(ctx context.Context, cfg config.Configuration) error {
-
-	user, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("get current user: %w", err)
-	}
-
-	ownerPath := cfg.DataDir().Join("pipewire").Join(fmt.Sprintf("linger-owner-%s", user.Username)).String()
-	owned, recordedMtime, err := isSetbyApp(ownerPath)
-	if err != nil {
-		return fmt.Errorf("check linger ownership: %w", err)
-	}
-	if !owned {
-		return nil
-	}
-
-	currentMtime, err := lingerFileMtime(user.Username)
-	if err != nil {
-		return fmt.Errorf("read linger state: %w", err)
-	}
-
-	if currentMtime.Equal(recordedMtime) {
-		err := disableLinger(ctx, user.Username)
-		if err != nil {
-			return fmt.Errorf("disable linger: %w", err)
-		}
-		slog.Debug("linger disabled", slog.String("username", user.Username))
-	}
-
-	return clearOwner(ownerPath)
-}
-
-func enableLinger(ctx context.Context, username string) error {
+func runEnableLingerCommand(ctx context.Context, username string) error {
 	cmdArgs := []string{"loginctl", "enable-linger", username}
 	cmd, err := paths.NewProcess(nil, cmdArgs...)
 	if err != nil {
@@ -134,7 +139,7 @@ func enableLinger(ctx context.Context, username string) error {
 	return nil
 }
 
-func disableLinger(ctx context.Context, username string) error {
+func runDisableLingerCommand(ctx context.Context, username string) error {
 	cmdArgs := []string{"loginctl", "disable-linger", username}
 	cmd, err := paths.NewProcess(nil, cmdArgs...)
 	if err != nil {
@@ -147,7 +152,7 @@ func disableLinger(ctx context.Context, username string) error {
 	return nil
 }
 
-func showLinger(ctx context.Context, username string) (bool, error) {
+func runShowLingerCommand(ctx context.Context, username string) (bool, error) {
 	cmdArgs := []string{"loginctl", "show-user", username, "-p", "Linger", "--value"}
 	cmd, err := paths.NewProcess(nil, cmdArgs...)
 	if err != nil {

--- a/internal/orchestrator/pipewire/pipewire.go
+++ b/internal/orchestrator/pipewire/pipewire.go
@@ -26,20 +26,17 @@ const (
 	userManagerDialInterval = 500 * time.Millisecond
 )
 
-var pipewireUnits = []string{"pipewire.socket", "pipewire-pulse.socket", "wireplumber.service"}
-
-// EnsurePipewireRunning waits for the current user's systemd --user manager to come
-// up — brought up by EnableLinger, which callers are expected to have called
-// first — and starts the PipeWire units on it.
+// EnsurePipewireRunning starts the PipeWire units (pipewire, pipewire-pulse and
+// wireplumber) for the current user, enabling lingering first so that logind
+// brings up the user's systemd --user manager and keeps it running.
 func EnsurePipewireRunning(ctx context.Context, cfg config.Configuration) error {
-
-	if err := runEnableLingerCmd(ctx, cfg); err != nil {
+	if err := enableLingering(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to enable audio service linger: %w", err)
 	}
 
 	var lastErr error
-	for i := 0; i < userManagerDialAttempts; i++ {
-		if _, err := runSystemctlUser(ctx, pipewireUnits...); err == nil {
+	for range userManagerDialAttempts {
+		if _, err := runStartPipewireUnitsCommand(ctx); err == nil {
 			return nil
 		} else {
 			lastErr = err
@@ -54,17 +51,32 @@ func EnsurePipewireRunning(ctx context.Context, cfg config.Configuration) error 
 	return fmt.Errorf("wait for user systemd manager: %w", lastErr)
 }
 
-func runSystemctlUser(ctx context.Context, args ...string) (string, error) {
-	cmdArgs := append([]string{"systemctl", "--user", "start"}, args...)
-	cmdEnv := append(os.Environ(), fmt.Sprintf("XDG_RUNTIME_DIR=/run/user/%d", os.Getuid()))
-	cmd, err := paths.NewProcess(cmdEnv, cmdArgs...)
+// StopIfNotNeeded tears down the PipeWire units for the current user, but only
+// if EnsurePipewireRunning was the one that started them. It does so by
+// disabling lingering, letting logind shut down the user's systemd --user
+// manager and the PipeWire units running on it.
+func StopIfNotNeeded(ctx context.Context, cfg config.Configuration) error {
+	return stopLingering(ctx, cfg)
+}
+
+func runStartPipewireUnitsCommand(ctx context.Context) (string, error) {
+	env := []string{fmt.Sprintf("XDG_RUNTIME_DIR=/run/user/%d", os.Getuid())}
+	cmd, err := paths.NewProcess(env,
+		"systemctl",
+		"--user",
+		"start",
+		"pipewire.socket",
+		"pipewire-pulse.socket",
+		"wireplumber.service",
+	)
 	if err != nil {
-		return "", fmt.Errorf("create process %q: %w", strings.Join(cmdArgs, " "), err)
+		return "", fmt.Errorf("create process start pipewire: %w", err)
 	}
 
 	out, err := cmd.RunAndCaptureCombinedOutput(ctx)
 	if err != nil {
-		return string(out), fmt.Errorf("%s: %w: %s", strings.Join(cmdArgs, " "), err, strings.TrimSpace(string(out)))
+		return string(out), fmt.Errorf("%s: %w: %s", strings.Join(cmd.GetArgs(), " "), err, strings.TrimSpace(string(out)))
 	}
+
 	return string(out), nil
 }


### PR DESCRIPTION
### Motivation

Refactoring the pipewire module.

### Change description

1. Use the conventional function name `run*Command` for wrapping external command execution
2. Remove the username in the record file (the CLI cannot be executed with a user different from 1000)
3. Rename the record file to `pipewire_linger.timestamp`
4. Update doc comments and other function names

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
