### PR TITLE
fix(pkg/board): escape shell expansion in path names

### DIFF
--- a/pkg/board/remote/adb/adb.go
+++ b/pkg/board/remote/adb/adb.go
@@ -17,7 +17,6 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -151,7 +150,7 @@ func (a *ADBConnection) ForwardKillAll(ctx context.Context) error {
 }
 
 func (a *ADBConnection) List(path string) ([]remote.FileInfo, error) {
-	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "ls", "-laQ", strconv.Quote(path))
+	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "ls", "-laQ", remote.ShellQuote(path))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +169,7 @@ func (a *ADBConnection) List(path string) ([]remote.FileInfo, error) {
 }
 
 func (a *ADBConnection) Stats(p string) (remote.FileInfo, error) {
-	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "file", "-L", strconv.Quote(p))
+	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "file", "-L", remote.ShellQuote(p))
 	if err != nil {
 		return remote.FileInfo{}, err
 	}
@@ -210,15 +209,15 @@ func (a *ADBConnection) Stats(p string) (remote.FileInfo, error) {
 }
 
 func (a *ADBConnection) ReadFile(path string) (io.ReadCloser, error) {
-	return adbReadFile(a, strconv.Quote(path))
+	return adbReadFile(a, remote.ShellQuote(path))
 }
 
 func (a *ADBConnection) WriteFile(r io.Reader, path string) error {
-	return adbWriteFile(a, r, strconv.Quote(path))
+	return adbWriteFile(a, r, remote.ShellQuote(path))
 }
 
 func (a *ADBConnection) MkDirAll(path string) error {
-	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "install", "-o", username, "-g", username, "-m", "755", "-d", strconv.Quote(path))
+	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "install", "-o", username, "-g", username, "-m", "755", "-d", remote.ShellQuote(path))
 	if err != nil {
 		return err
 	}
@@ -230,7 +229,7 @@ func (a *ADBConnection) MkDirAll(path string) error {
 }
 
 func (a *ADBConnection) Remove(path string) error {
-	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "rm", "-r", strconv.Quote(path))
+	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "rm", "-r", remote.ShellQuote(path))
 	if err != nil {
 		return err
 	}
@@ -316,7 +315,7 @@ func (a *ADBCommand) Interactive() (io.WriteCloser, io.Reader, io.Reader, remote
 	}, nil
 }
 
-func (a *ADBConnection) Push(ctx context.Context, local, remote string) error {
+func (a *ADBConnection) Push(ctx context.Context, local, remotePath string) error {
 	isDirLocal := func() bool {
 		if info, err := os.Stat(local); err == nil {
 			return info.IsDir()
@@ -324,7 +323,7 @@ func (a *ADBConnection) Push(ctx context.Context, local, remote string) error {
 		return false
 	}
 	isDirRemote := func() bool {
-		if info, err := a.Stats(remote); err == nil {
+		if info, err := a.Stats(remotePath); err == nil {
 			return info.IsDir
 		}
 		return false
@@ -338,27 +337,27 @@ func (a *ADBConnection) Push(ctx context.Context, local, remote string) error {
 
 	if isDirLocal() {
 		// ensure the remote directory exists before pushing, otherwise empty directory push will not work.
-		if err := a.MkDirAll(remote); err != nil {
-			return fmt.Errorf("failed to create remote directory %q: %w", remote, err)
+		if err := a.MkDirAll(remotePath); err != nil {
+			return fmt.Errorf("failed to create remote directory %q: %w", remotePath, err)
 		}
 		// force directory override by adding a dot at the end of the local path.
 		local = addDotLocal(local)
 	} else if isDirRemote() {
-		return fmt.Errorf("cannot push file %q to directory %q", local, remote)
+		return fmt.Errorf("cannot push file %q to directory %q", local, remotePath)
 	}
 
-	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "push", local, remote)
+	cmd, err := paths.NewProcess(nil, a.adbPath, "-s", a.host, "push", local, remotePath)
 	if err != nil {
 		return err
 	}
 	stdout, err := cmd.RunAndCaptureCombinedOutput(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to push file from %q to %q: %w: %s", local, remote, err, string(stdout))
+		return fmt.Errorf("failed to push file from %q to %q: %w: %s", local, remotePath, err, string(stdout))
 	}
 
-	if cmd, err = paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "chmod", "-R", "u+wr", strconv.Quote(remote)); err == nil {
+	if cmd, err = paths.NewProcess(nil, a.adbPath, "-s", a.host, "shell", "chmod", "-R", "u+wr", remote.ShellQuote(remotePath)); err == nil {
 		if stdout, err = cmd.RunAndCaptureCombinedOutput(ctx); err != nil {
-			slog.Warn("failed to set permissions for remote path", "path", remote, "error", err, "output", string(stdout))
+			slog.Warn("failed to set permissions for remote path", "path", remotePath, "error", err, "output", string(stdout))
 		}
 	}
 

--- a/pkg/board/remote/remote.go
+++ b/pkg/board/remote/remote.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 )
 
 var ErrPortAvailable = fmt.Errorf("port is not available")
@@ -73,4 +74,12 @@ func (w WithCloser) Close() error {
 		return w.CloseFun()
 	}
 	return nil
+}
+
+// ShellQuote quotes s so it can be safely used as a single argument in a POSIX
+// shell command. It wraps the value in single quotes, which prevents the shell
+// from interpreting special characters such as '$', backticks or backslashes.
+// Any embedded single quote is escaped using the standard '\” idiom.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/pkg/board/remote/remote_test.go
+++ b/pkg/board/remote/remote_test.go
@@ -735,7 +735,7 @@ func TestShellQuoteNoExpansion(t *testing.T) {
 	inputs := []string{"$$$$$$", "$HOME", "$(echo pwned)", "`echo pwned`", "a'b$c"}
 	for _, in := range inputs {
 		t.Run(in, func(t *testing.T) {
-			out, err := exec.Command("/bin/sh", "-c", "printf %s "+remote.ShellQuote(in)).Output()
+			out, err := exec.Command("/bin/sh", "-c", "printf %s "+remote.ShellQuote(in)).Output() // nolint:gosec
 			require.NoError(t, err)
 			assert.Equal(t, in, string(out))
 		})

--- a/pkg/board/remote/remote_test.go
+++ b/pkg/board/remote/remote_test.go
@@ -11,8 +11,10 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -62,6 +64,8 @@ func TestRemoteFS(t *testing.T) {
 		"testdir/testfile with spaces.txt",
 		"testdir with space/testfile.txt",
 		"testdir with space/testfile with spaces.txt",
+		"test$dir/test$file.txt",
+		"test$dir/file$$$$$$.txt",
 	}
 
 	dirs := func() []string {
@@ -693,6 +697,47 @@ func TestRemoteTransferBehavioralCheck(t *testing.T) {
 					}
 				})
 			}
+		})
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "/tmp/file.txt", "'/tmp/file.txt'"},
+		{"empty", "", "''"},
+		{"dollars", "$$$$$$", "'$$$$$$'"},
+		{"variable", "$HOME/file", "'$HOME/file'"},
+		{"command substitution", "$(rm -rf /)", "'$(rm -rf /)'"},
+		{"backtick", "`whoami`", "'`whoami`'"},
+		{"space", "my file", "'my file'"},
+		{"single quote", "it's", `'it'\''s'`},
+		{"backslash", `a\b`, `'a\b'`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, remote.ShellQuote(tt.in))
+		})
+	}
+}
+
+// TestShellQuoteNoExpansion verifies that a POSIX shell treats the quoted value
+// as a single, literal argument, without performing any '$'/backtick expansion.
+func TestShellQuoteNoExpansion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell not available on Windows")
+	}
+
+	inputs := []string{"$$$$$$", "$HOME", "$(echo pwned)", "`echo pwned`", "a'b$c"}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			out, err := exec.Command("/bin/sh", "-c", "printf %s "+remote.ShellQuote(in)).Output()
+			require.NoError(t, err)
+			assert.Equal(t, in, string(out))
 		})
 	}
 }

--- a/pkg/board/remote/ssh/scp.go
+++ b/pkg/board/remote/ssh/scp.go
@@ -14,6 +14,8 @@ import (
 	"path/filepath"
 
 	"golang.org/x/crypto/ssh"
+
+	remotepkg "github.com/arduino/arduino-app-cli/pkg/board/remote"
 )
 
 type ScpClient struct {
@@ -43,7 +45,7 @@ func (c *ScpClient) PushDir(ctx context.Context, fsys fs.FS, name, remote string
 	}
 	defer w.Close()
 
-	cmd := fmt.Sprintf("%s -rt %q", remoteBinary, remote)
+	cmd := fmt.Sprintf("%s -rt %s", remoteBinary, remotepkg.ShellQuote(remote))
 	if err := session.Start(cmd); err != nil {
 		return err
 	}
@@ -77,7 +79,7 @@ func (c *ScpClient) PushFile(ctx context.Context, local, remote string) error {
 	}
 	defer w.Close()
 
-	cmd := fmt.Sprintf("%s -t %q", remoteBinary, remote)
+	cmd := fmt.Sprintf("%s -t %s", remoteBinary, remotepkg.ShellQuote(remote))
 	if err := session.Start(cmd); err != nil {
 		return err
 	}

--- a/pkg/board/remote/ssh/ssh.go
+++ b/pkg/board/remote/ssh/ssh.go
@@ -160,7 +160,7 @@ func (a *SSHConnection) List(path string) ([]remote.FileInfo, error) {
 	}
 	defer session.Close()
 
-	cmd := fmt.Sprintf("ls -laQ %q", path)
+	cmd := fmt.Sprintf("ls -laQ %s", remote.ShellQuote(path))
 	output, err := session.Output(cmd)
 	if err != nil {
 		return nil, err
@@ -176,7 +176,7 @@ func (a *SSHConnection) MkDirAll(path string) error {
 	}
 	defer session.Close()
 
-	cmd := fmt.Sprintf("mkdir -p %q", path)
+	cmd := fmt.Sprintf("mkdir -p %s", remote.ShellQuote(path))
 	if err := session.Run(cmd); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
@@ -191,7 +191,7 @@ func (a *SSHConnection) WriteFile(r io.Reader, path string) error {
 	}
 	defer session.Close()
 
-	cmd := fmt.Sprintf("cat > %q", path)
+	cmd := fmt.Sprintf("cat > %s", remote.ShellQuote(path))
 	session.Stdin = r
 
 	if err := session.Run(cmd); err != nil {
@@ -207,7 +207,7 @@ func (a *SSHConnection) ReadFile(path string) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	cmd := fmt.Sprintf("cat %q", path)
+	cmd := fmt.Sprintf("cat %s", remote.ShellQuote(path))
 	output, err := session.StdoutPipe()
 	if err != nil {
 		return nil, err
@@ -230,7 +230,7 @@ func (a *SSHConnection) Remove(path string) error {
 	}
 	defer session.Close()
 
-	cmd := fmt.Sprintf("rm -rf %q", path)
+	cmd := fmt.Sprintf("rm -rf %s", remote.ShellQuote(path))
 	if err := session.Run(cmd); err != nil {
 		return fmt.Errorf("failed to remove file: %w", err)
 	}
@@ -245,7 +245,7 @@ func (a *SSHConnection) Stats(p string) (remote.FileInfo, error) {
 	}
 	defer session.Close()
 
-	cmd := fmt.Sprintf("file -L %q", p)
+	cmd := fmt.Sprintf("file -L %s", remote.ShellQuote(p))
 	output, err := session.Output(cmd)
 	if err != nil {
 		return remote.FileInfo{}, err


### PR DESCRIPTION
### Motivation

Improve escaping of shell expansion, in particular in the case where the user was adding a `$` in the file path.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
