### PR TITLE
bump brick version to 0.12.0rc6

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,7 +9,7 @@ vars:
   GOIMPORTS_VERSION: v0.42.0
   DPRINT_VERSION: 0.48.0
   EXAMPLE_VERSION: "0.12.0rc1"
-  RUNNER_VERSION: "0.12.0rc3"
+  RUNNER_VERSION: "0.12.0rc6"
   VERSION: # if version is not passed we hack the semver by encoding the commit as pre-release
     sh: echo "${VERSION:-0.0.0-$(git rev-parse --short HEAD)}"
 

--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -22,7 +22,7 @@ import (
 )
 
 // runnerVersion do not edit, this is generate with `task bump:runner-version`
-var RunnerVersion = "0.12.0rc3"
+var RunnerVersion = "0.12.0rc6"
 
 type Configuration struct {
 	appsDir                          *paths.Path


### PR DESCRIPTION
### Motivation

<!-- Why this pull request? -->

### Change description

1. RUNNER_VERSION: "0.12.0rc5" to  RUNNER_VERSION: "0.12.0rc6"
2. task bump:runner-version  

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
