### PR TITLE
fix: check volumes before mount

### DIFF
--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -386,7 +386,7 @@ func generateMainComposeFile(
 	mainAppCompose.Services = &mainService{
 		Main: service{
 			Image:             pythonImage,
-			Volumes:           volumes,
+			Volumes:           filterNotExistingVolume(volumes),
 			Ports:             slices.Collect(maps.Keys(ports)),
 			DeviceCgroupRules: deviceCgroupsRules,
 			Entrypoint:        "/run.sh",
@@ -436,6 +436,19 @@ func generateMainComposeFile(
 
 	// Done!
 	return nil
+}
+
+func filterNotExistingVolume(volumes []volume) []volume {
+	return slices.DeleteFunc(volumes, func(v volume) bool {
+		if v.Type != "bind" {
+			return false
+		}
+		if !paths.New(v.Source).Exist() {
+			slog.Debug("Skipping volume mount because source does not exist", slog.String("source", v.Source), slog.String("target", v.Target))
+			return true
+		}
+		return false
+	})
 }
 
 // Resolve supplementary group IDs on the host dynamically

--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -386,7 +386,7 @@ func generateMainComposeFile(
 	mainAppCompose.Services = &mainService{
 		Main: service{
 			Image:             pythonImage,
-			Volumes:           filterNotExistingVolume(volumes),
+			Volumes:           filterNotExistingVolumes(volumes),
 			Ports:             slices.Collect(maps.Keys(ports)),
 			DeviceCgroupRules: deviceCgroupsRules,
 			Entrypoint:        "/run.sh",
@@ -438,7 +438,7 @@ func generateMainComposeFile(
 	return nil
 }
 
-func filterNotExistingVolume(volumes []volume) []volume {
+func filterNotExistingVolumes(volumes []volume) []volume {
 	return slices.DeleteFunc(volumes, func(v volume) bool {
 		if v.Type != "bind" {
 			return false


### PR DESCRIPTION
### Motivation

A missing pipewire socket, `/run/user/1000/pipewire-0`, will prevent the app from starting.

### Change description

Add a check that verifies that all mounted paths exist.

### Additional Notes

Error before the patch:
```
Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /run/user/1000/pipewire-0
```
### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
