### PR TITLE
Enable pipewire via adb shell

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -167,7 +167,7 @@ func StartApp(
 
 	// We start PW for any platform or addon in order to be consistend with Network and SBC mode.
 	if err := pipewire.EnsurePipewireRunning(ctx, cfg); err != nil {
-		return fmt.Errorf("failed to enable audio service linger: %w", err)
+		slog.Warn("failed to enable audio service linger", slog.String("error", err.Error()))
 	}
 
 	if err := setLedsToUserControlledMode(platform); err != nil {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -165,10 +165,9 @@ func StartApp(
 
 	cb(StreamMessage{data: fmt.Sprintf("Starting app %q", appToStart.Name)})
 
-	if needsAudioDevices(requiredClasses) && devices.HasCarrierSoundDevice {
-		if err := pipewire.EnsurePipewireRunning(ctx, cfg); err != nil {
-			return fmt.Errorf("failed to enable audio service linger: %w", err)
-		}
+	// We start PW for any platform or addon in order to be consistend with Network and SBC mode.
+	if err := pipewire.EnsurePipewireRunning(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to enable audio service linger: %w", err)
 	}
 
 	if err := setLedsToUserControlledMode(platform); err != nil {


### PR DESCRIPTION
### Motivation
In order to let PW be able to start up in USB mode for VENTUNO Q, we need to add it to the start up cases