### PR TITLE
Use system init data in upgrade progress info

### DIFF
--- a/cmd/arduino-app-cli/system/system_helper.go
+++ b/cmd/arduino-app-cli/system/system_helper.go
@@ -6,88 +6,28 @@
 package system
 
 import (
-	"fmt"
-
 	"github.com/arduino/arduino-app-cli/cmd/feedback"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 )
 
-const (
-	initLogEventType      = "log"
-	initProgressEventType = "progress"
-)
-
-var _ feedback.Result = (*initResult)(nil)
-
-type initResult struct {
-	Type    string `json:"type"`
-	Source  string `json:"source,omitempty"`
-	Message string `json:"message,omitempty"`
-	Label   string `json:"label,omitempty"`
-	Current int64  `json:"current,omitempty"`
-	Total   int64  `json:"total,omitempty"`
-	Percent int    `json:"percent,omitempty"`
-}
-
-// Data implements feedback.Result.
-func (e *initResult) Data() any {
-	return e
-}
-
-// String implements feedback.Result.
-func (e *initResult) String() string {
-	if e.Type == initProgressEventType {
-		return fmt.Sprintf("%s: %d%%", e.Label, e.Percent)
-	}
-	return e.Message
-}
-
-func fromInitEvent(e orchestrator.InitEvent) *initResult {
-	switch e.Type {
-	case orchestrator.InitLogEvent:
-		return &initResult{
-			Type:    initLogEventType,
-			Source:  string(e.Source),
-			Message: e.Message,
-		}
-	case orchestrator.InitProgressEvent:
-		p := e.Progress
-		return &initResult{
-			Type:    initProgressEventType,
-			Source:  string(e.Source),
-			Label:   p.Label,
-			Current: p.Curr,
-			Total:   p.Total,
-			Percent: percent(p.Curr, p.Total),
-		}
-	default:
-		return nil
-	}
-}
-
-func percent(curr, total int64) int {
-	if total <= 0 {
-		return 0
-	}
-	return int(float64(curr) / float64(total) * 100)
-}
+var _ feedback.Result = (*orchestrator.InitResult)(nil)
 
 func newInitEventCallback(printEvent func(feedback.Result)) orchestrator.InitEventCallback {
-	return throttleProgress(func(e *initResult) {
+	return throttleProgress(func(e *orchestrator.InitResult) {
 		printEvent(e)
 	})
 }
 
 // throttleProgress drops the progress events that would render the same
 // percentage twice in a row for a given label.
-func throttleProgress(next func(*initResult)) orchestrator.InitEventCallback {
+func throttleProgress(next func(*orchestrator.InitResult)) orchestrator.InitEventCallback {
 	lastPct := map[string]int{}
 	return func(event orchestrator.InitEvent) {
-		e := fromInitEvent(event)
+		e := orchestrator.NewInitResult(event)
 		if e == nil {
 			return
 		}
-		if e.Type == initProgressEventType {
+		if e.Type == orchestrator.InitResultProgress {
 			if e.Total <= 0 {
 				return
 			}

--- a/cmd/arduino-app-cli/system/system_test.go
+++ b/cmd/arduino-app-cli/system/system_test.go
@@ -25,8 +25,8 @@ func TestThrottleProgress(t *testing.T) {
 		return orchestrator.InitEvent{Type: orchestrator.InitLogEvent, Message: msg}
 	}
 
-	var got []initResult
-	cb := throttleProgress(func(e *initResult) {
+	var got []orchestrator.InitResult
+	cb := throttleProgress(func(e *orchestrator.InitResult) {
 		got = append(got, *e)
 	})
 
@@ -41,13 +41,13 @@ func TestThrottleProgress(t *testing.T) {
 	cb(progress("other", 5, 100)) // 5%  -> forwarded (different label tracked separately)
 	cb(logEvt("done"))            //     -> forwarded
 
-	want := []initResult{
-		*fromInitEvent(progress("img", 0, 100)),
-		*fromInitEvent(progress("img", 4, 100)),
-		*fromInitEvent(logEvt("hello")),
-		*fromInitEvent(progress("img", 5, 100)),
-		*fromInitEvent(progress("other", 5, 100)),
-		*fromInitEvent(logEvt("done")),
+	want := []orchestrator.InitResult{
+		*orchestrator.NewInitResult(progress("img", 0, 100)),
+		*orchestrator.NewInitResult(progress("img", 4, 100)),
+		*orchestrator.NewInitResult(logEvt("hello")),
+		*orchestrator.NewInitResult(progress("img", 5, 100)),
+		*orchestrator.NewInitResult(progress("other", 5, 100)),
+		*orchestrator.NewInitResult(logEvt("done")),
 	}
 
 	if len(got) != len(want) {
@@ -114,7 +114,7 @@ func TestInitEventJSON(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Each event must serialize to a single line, so that the JSON output
 			// is a stream of JSON lines, one object per event.
-			d, err := json.Marshal(fromInitEvent(tt.event).Data())
+			d, err := json.Marshal(orchestrator.NewInitResult(tt.event).Data())
 			if err != nil {
 				t.Fatalf("Marshal() error = %v", err)
 			}
@@ -150,7 +150,7 @@ func TestInitEventString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := fromInitEvent(tt.event).String(); got != tt.want {
+			if got := orchestrator.NewInitResult(tt.event).String(); got != tt.want {
 				t.Errorf("String() = %q, want %q", got, tt.want)
 			}
 		})

--- a/internal/orchestrator/init_result.go
+++ b/internal/orchestrator/init_result.go
@@ -13,14 +13,6 @@ const (
 	InitResultProgress = "progress"
 )
 
-// InitResult is the serializable form of an InitEvent: it is what the
-// `system init` command writes, one JSON object per line, when asked for the
-// json-lines output format.
-//
-// It is a contract, not just a rendering: the update process runs `system init`
-// as a subprocess and reads these lines back to follow the progress of the
-// docker images download, so the field names are part of an interface between
-// the two.
 type InitResult struct {
 	Type    string `json:"type"`
 	Source  string `json:"source,omitempty"`

--- a/internal/orchestrator/init_result.go
+++ b/internal/orchestrator/init_result.go
@@ -15,8 +15,8 @@ const (
 )
 
 type InitResult struct {
-	Type    InitResultType `json:"type"`
-	Source  string         `json:"source,omitempty"`
+	Type    InitResultType  `json:"type"`
+	Source  InitEventSource `json:"source,omitempty"`
 	Message string         `json:"message,omitempty"`
 	Label   string         `json:"label,omitempty"`
 	Current int64          `json:"current,omitempty"`
@@ -44,14 +44,14 @@ func NewInitResult(e InitEvent) *InitResult {
 	case InitLogEvent:
 		return &InitResult{
 			Type:    InitResultLog,
-			Source:  string(e.Source),
+			Source:  e.Source,
 			Message: e.Message,
 		}
 	case InitProgressEvent:
 		p := e.Progress
 		return &InitResult{
 			Type:    InitResultProgress,
-			Source:  string(e.Source),
+			Source:  e.Source,
 			Label:   p.Label,
 			Current: p.Curr,
 			Total:   p.Total,

--- a/internal/orchestrator/init_result.go
+++ b/internal/orchestrator/init_result.go
@@ -17,11 +17,11 @@ const (
 type InitResult struct {
 	Type    InitResultType  `json:"type"`
 	Source  InitEventSource `json:"source,omitempty"`
-	Message string         `json:"message,omitempty"`
-	Label   string         `json:"label,omitempty"`
-	Current int64          `json:"current,omitempty"`
-	Total   int64          `json:"total,omitempty"`
-	Percent int            `json:"percent,omitempty"`
+	Message string          `json:"message,omitempty"`
+	Label   string          `json:"label,omitempty"`
+	Current int64           `json:"current,omitempty"`
+	Total   int64           `json:"total,omitempty"`
+	Percent int             `json:"percent,omitempty"`
 }
 
 // Data implements feedback.Result.

--- a/internal/orchestrator/init_result.go
+++ b/internal/orchestrator/init_result.go
@@ -1,0 +1,77 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package orchestrator
+
+import "fmt"
+
+// Types of an InitResult.
+const (
+	InitResultLog      = "log"
+	InitResultProgress = "progress"
+)
+
+// InitResult is the serializable form of an InitEvent: it is what the
+// `system init` command writes, one JSON object per line, when asked for the
+// json-lines output format.
+//
+// It is a contract, not just a rendering: the update process runs `system init`
+// as a subprocess and reads these lines back to follow the progress of the
+// docker images download, so the field names are part of an interface between
+// the two.
+type InitResult struct {
+	Type    string `json:"type"`
+	Source  string `json:"source,omitempty"`
+	Message string `json:"message,omitempty"`
+	Label   string `json:"label,omitempty"`
+	Current int64  `json:"current,omitempty"`
+	Total   int64  `json:"total,omitempty"`
+	Percent int    `json:"percent,omitempty"`
+}
+
+// Data implements feedback.Result.
+func (e *InitResult) Data() any {
+	return e
+}
+
+// String implements feedback.Result.
+func (e *InitResult) String() string {
+	if e.Type == InitResultProgress {
+		return fmt.Sprintf("%s: %d%%", e.Label, e.Percent)
+	}
+	return e.Message
+}
+
+// NewInitResult converts an event into its serializable form, and reports nil
+// for the event types that have none.
+func NewInitResult(e InitEvent) *InitResult {
+	switch e.Type {
+	case InitLogEvent:
+		return &InitResult{
+			Type:    InitResultLog,
+			Source:  string(e.Source),
+			Message: e.Message,
+		}
+	case InitProgressEvent:
+		p := e.Progress
+		return &InitResult{
+			Type:    InitResultProgress,
+			Source:  string(e.Source),
+			Label:   p.Label,
+			Current: p.Curr,
+			Total:   p.Total,
+			Percent: initPercent(p.Curr, p.Total),
+		}
+	default:
+		return nil
+	}
+}
+
+func initPercent(curr, total int64) int {
+	if total <= 0 {
+		return 0
+	}
+	return int(float64(curr) / float64(total) * 100)
+}

--- a/internal/orchestrator/init_result.go
+++ b/internal/orchestrator/init_result.go
@@ -7,20 +7,21 @@ package orchestrator
 
 import "fmt"
 
-// Types of an InitResult.
+type InitResultType string
+
 const (
-	InitResultLog      = "log"
-	InitResultProgress = "progress"
+	InitResultLog      InitResultType = "log"
+	InitResultProgress InitResultType = "progress"
 )
 
 type InitResult struct {
-	Type    string `json:"type"`
-	Source  string `json:"source,omitempty"`
-	Message string `json:"message,omitempty"`
-	Label   string `json:"label,omitempty"`
-	Current int64  `json:"current,omitempty"`
-	Total   int64  `json:"total,omitempty"`
-	Percent int    `json:"percent,omitempty"`
+	Type    InitResultType `json:"type"`
+	Source  string         `json:"source,omitempty"`
+	Message string         `json:"message,omitempty"`
+	Label   string         `json:"label,omitempty"`
+	Current int64          `json:"current,omitempty"`
+	Total   int64          `json:"total,omitempty"`
+	Percent int            `json:"percent,omitempty"`
 }
 
 // Data implements feedback.Result.

--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -8,6 +8,7 @@ package apt
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"iter"
@@ -63,6 +64,17 @@ func (s *Service) ListUpgradablePackages(ctx context.Context, matcher func(updat
 
 const selfPackageName = "arduino-app-cli"
 
+// Progress milestones on a local 0-100 scale: the Manager rescales them to the
+// slice of the whole update process this updater is responsible for. Most of the
+// scale is reserved to the docker images download, by far the longest step.
+const (
+	aptUpgradeProgress       float32 = 0.0
+	aptCacheCleanProgress    float32 = 25.0
+	imagesDownloadProgress   float32 = 30.0
+	imagesCleanupProgress    float32 = 90.0
+	upgradeCompletedProgress float32 = 100.0
+)
+
 // UpgradePackages upgrades the specified packages using the `apt-get upgrade` command.
 // It publishes events to subscribers during the upgrade process.
 // It returns an error if the upgrade is already in progress or if the upgrade command fails.
@@ -92,17 +104,6 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 		}
 	}()
 
-	// Progress milestones on a local 0-100 scale: the Manager rescales them to the
-	// slice of the whole update process this updater is responsible for. Most of
-	// the scale is reserved to the docker images download, by far the longest step.
-	const (
-		aptUpgradeProgress       float32 = 0.0
-		aptCacheCleanProgress    float32 = 25.0
-		imagesDownloadProgress   float32 = 30.0
-		imagesCleanupProgress    float32 = 90.0
-		upgradeCompletedProgress float32 = 100.0
-	)
-
 	names := f.Map(packages, func(pkg update.PackageInfo) string {
 		return pkg.Name
 	})
@@ -125,7 +126,26 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 		eventCB(update.NewDataEvent(update.UpgradeLineEvent, line))
 	}
 	eventCB(update.NewProgressEvent("docker images download", imagesDownloadProgress))
-	for line, err := range runSystemInit(ctx) {
+
+	// Of the two sources reporting a progress, only docker can be trusted: it is
+	// the fraction of the bytes of every image, and the total is known before the
+	// download starts. The arduino one is per file, out of an unknown number of
+	// them, so it is only logged.
+	//
+	// The last value is kept because the whole command is run again when it fails:
+	// the second run restarts from zero, and the progress must not follow it back.
+	lastImagesProgress := imagesDownloadProgress
+	handleInitResult := func(result orchestrator.InitResult) {
+		if result.Type == orchestrator.InitResultProgress && result.Source == string(orchestrator.InitSourceDocker) {
+			if value := imagesDownloadBand(result.Percent); value > lastImagesProgress {
+				lastImagesProgress = value
+				eventCB(update.NewProgressEvent("docker images download", value))
+			}
+		}
+		eventCB(update.NewDataEvent(update.UpgradeLineEvent, result.String()))
+	}
+
+	for result, err := range runSystemInit(ctx) {
 		if err != nil {
 			// In case of errors, including "out of disk space" erros, do a cleanup and then retry once.
 
@@ -141,14 +161,14 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 
 			// Try again to pull the docker containers.
 			eventCB(update.NewDataEvent(update.UpgradeLineEvent, "Pulling the latest docker images (again) ..."))
-			for line, err := range runSystemInit(ctx) {
+			for result, err := range runSystemInit(ctx) {
 				if err != nil {
 					return fmt.Errorf("error pulling docker images: %w", err)
 				}
-				eventCB(update.NewDataEvent(update.UpgradeLineEvent, line))
+				handleInitResult(result)
 			}
 		} else {
-			eventCB(update.NewDataEvent(update.UpgradeLineEvent, line))
+			handleInitResult(result)
 		}
 	}
 	eventCB(update.NewProgressEvent("docker images cleanup", imagesCleanupProgress))
@@ -257,16 +277,19 @@ func runAptCleanCommand(ctx context.Context) iter.Seq2[string, error] {
 	}
 }
 
-func runSystemInit(ctx context.Context) iter.Seq2[string, error] {
-	return func(yield func(string, error) bool) {
-		cmd, err := paths.NewProcess(nil, "arduino-app-cli", "system", "init")
+func runSystemInit(ctx context.Context) iter.Seq2[orchestrator.InitResult, error] {
+	return func(yield func(orchestrator.InitResult, error) bool) {
+		// The json-lines format is what makes the progress of the images download
+		// readable from here. The binary being invoked is the one apt has just
+		// upgraded, so it is never older than this code.
+		cmd, err := paths.NewProcess(nil, "arduino-app-cli", "system", "init", "--format", "json-lines")
 		if err != nil {
-			_ = yield("", err)
+			_ = yield(orchestrator.InitResult{}, err)
 			return
 		}
 
 		stdout := orchestrator.NewCallbackWriter(func(line string) {
-			if !yield(line, nil) {
+			if !yield(parseSystemInitLine(line), nil) {
 				if err := cmd.Kill(); err != nil {
 					slog.Error("Failed to kill 'arduino-app-cli system init' command", slog.String("error", err.Error()))
 				}
@@ -276,10 +299,30 @@ func runSystemInit(ctx context.Context) iter.Seq2[string, error] {
 		cmd.RedirectStdoutTo(stdout)
 
 		if err = cmd.RunWithinContext(ctx); err != nil {
-			_ = yield("", err)
+			_ = yield(orchestrator.InitResult{}, err)
 			return
 		}
 	}
+}
+
+// parseSystemInitLine turns a line written by `system init` into an event.
+// Standard error is redirected to the same stream and is not structured, so
+// anything that does not parse as an event is reported as a log line, to make
+// sure nothing the command has to say gets dropped.
+func parseSystemInitLine(line string) orchestrator.InitResult {
+	var result orchestrator.InitResult
+	if err := json.Unmarshal([]byte(line), &result); err != nil || result.Type == "" {
+		return orchestrator.InitResult{Type: orchestrator.InitResultLog, Message: line}
+	}
+	return result
+}
+
+// imagesDownloadBand maps the 0-100 percentage reported by `system init` onto the
+// band of the local scale reserved to the images download. The percentage comes
+// from another process, so it is clamped rather than trusted.
+func imagesDownloadBand(percentage int) float32 {
+	percentage = min(max(percentage, 0), 100)
+	return imagesDownloadProgress + float32(percentage)/100.0*(imagesCleanupProgress-imagesDownloadProgress)
 }
 
 // Remove all stopped containers

--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -131,9 +131,6 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 	// the fraction of the bytes of every image, and the total is known before the
 	// download starts. The arduino one is per file, out of an unknown number of
 	// them, so it is only logged.
-	//
-	// The last value is kept because the whole command is run again when it fails:
-	// the second run restarts from zero, and the progress must not follow it back.
 	lastImagesProgress := imagesDownloadProgress
 	handleInitResult := func(result orchestrator.InitResult) {
 		if result.Type == orchestrator.InitResultProgress && result.Source == string(orchestrator.InitSourceDocker) {
@@ -279,9 +276,6 @@ func runAptCleanCommand(ctx context.Context) iter.Seq2[string, error] {
 
 func runSystemInit(ctx context.Context) iter.Seq2[orchestrator.InitResult, error] {
 	return func(yield func(orchestrator.InitResult, error) bool) {
-		// The json-lines format is what makes the progress of the images download
-		// readable from here. The binary being invoked is the one apt has just
-		// upgraded, so it is never older than this code.
 		cmd, err := paths.NewProcess(nil, "arduino-app-cli", "system", "init", "--format", "json-lines")
 		if err != nil {
 			_ = yield(orchestrator.InitResult{}, err)
@@ -305,10 +299,6 @@ func runSystemInit(ctx context.Context) iter.Seq2[orchestrator.InitResult, error
 	}
 }
 
-// parseSystemInitLine turns a line written by `system init` into an event.
-// Standard error is redirected to the same stream and is not structured, so
-// anything that does not parse as an event is reported as a log line, to make
-// sure nothing the command has to say gets dropped.
 func parseSystemInitLine(line string) orchestrator.InitResult {
 	var result orchestrator.InitResult
 	if err := json.Unmarshal([]byte(line), &result); err != nil || result.Type == "" {

--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -133,7 +133,7 @@ func (s *Service) UpgradePackages(ctx context.Context, packages []update.Package
 	// them, so it is only logged.
 	lastImagesProgress := imagesDownloadProgress
 	handleInitResult := func(result orchestrator.InitResult) {
-		if result.Type == orchestrator.InitResultProgress && result.Source == string(orchestrator.InitSourceDocker) {
+		if result.Type == orchestrator.InitResultProgress && result.Source == orchestrator.InitSourceDocker {
 			if value := imagesDownloadBand(result.Percent); value > lastImagesProgress {
 				lastImagesProgress = value
 				eventCB(update.NewProgressEvent("docker images download", value))

--- a/internal/update/apt/service_test.go
+++ b/internal/update/apt/service_test.go
@@ -118,7 +118,7 @@ func TestParseSystemInitLine(t *testing.T) {
 			input: `{"type":"progress","source":"docker","label":"arduino/app:1.0","current":50,"total":100,"percent":50}`,
 			expected: orchestrator.InitResult{
 				Type:    orchestrator.InitResultProgress,
-				Source:  "docker",
+				Source:  orchestrator.InitSourceDocker,
 				Label:   "arduino/app:1.0",
 				Current: 50,
 				Total:   100,
@@ -130,7 +130,7 @@ func TestParseSystemInitLine(t *testing.T) {
 			input: `{"type":"log","source":"docker","message":"pulling images"}`,
 			expected: orchestrator.InitResult{
 				Type:    orchestrator.InitResultLog,
-				Source:  "docker",
+				Source:  orchestrator.InitSourceDocker,
 				Message: "pulling images",
 			},
 		},

--- a/internal/update/apt/service_test.go
+++ b/internal/update/apt/service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/update"
 )
 
@@ -104,4 +105,67 @@ containerd.io/focal 1.7.27-1 amd64 [upgradable from: 1.7.25-1]
 			})
 		}
 	})
+}
+
+func TestParseSystemInitLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected orchestrator.InitResult
+	}{
+		{
+			name:  "progress event",
+			input: `{"type":"progress","source":"docker","label":"arduino/app:1.0","current":50,"total":100,"percent":50}`,
+			expected: orchestrator.InitResult{
+				Type:    orchestrator.InitResultProgress,
+				Source:  "docker",
+				Label:   "arduino/app:1.0",
+				Current: 50,
+				Total:   100,
+				Percent: 50,
+			},
+		},
+		{
+			name:  "log event",
+			input: `{"type":"log","source":"docker","message":"pulling images"}`,
+			expected: orchestrator.InitResult{
+				Type:    orchestrator.InitResultLog,
+				Source:  "docker",
+				Message: "pulling images",
+			},
+		},
+		{
+			// Standard error is redirected to the same stream and is not structured.
+			name:     "line that is not json",
+			input:    "time=2026-08-05 level=WARN msg=something happened",
+			expected: orchestrator.InitResult{Type: orchestrator.InitResultLog, Message: "time=2026-08-05 level=WARN msg=something happened"},
+		},
+		{
+			name:     "json without a type",
+			input:    `{"message":"orphan"}`,
+			expected: orchestrator.InitResult{Type: orchestrator.InitResultLog, Message: `{"message":"orphan"}`},
+		},
+		{
+			name:     "empty line",
+			input:    "",
+			expected: orchestrator.InitResult{Type: orchestrator.InitResultLog, Message: ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, parseSystemInitLine(tt.input))
+		})
+	}
+}
+
+func TestImagesDownloadBand(t *testing.T) {
+	require.Equal(t, imagesDownloadProgress, imagesDownloadBand(0))
+	require.Equal(t, imagesCleanupProgress, imagesDownloadBand(100))
+	require.Equal(t, float32(60), imagesDownloadBand(50))
+
+	// The percentage comes from another process: out of range values must not push
+	// the progress outside of the band.
+	require.Equal(t, imagesDownloadProgress, imagesDownloadBand(-10))
+	require.Equal(t, imagesCleanupProgress, imagesDownloadBand(300))
 }


### PR DESCRIPTION
### Motivation

- Progress bar froze at 44% during the Docker image download
- That is the longest step of the update: no feedback for minutes

### Change description

- `system init` is now called with `--format json-lines`
- Its JSON payload moved to `internal/orchestrator` (`InitResult`): shared contract between the two processes(init and update)
- The update process parses each line back into `InitResult`
- Only `source: docker` progress is used
- `source: arduino` progress is per file on an unknown total, so it is only logged
- The 0-100 percent of `system init` is mapped into the local 30-90 band of `system update`, and clamped
- Progress never goes back: in case of init failure, it will restart from the last percentage reached
- Lines that are not valid JSON (stderr) fall back to log lines
- Tests on the line parser and on the band mapping

### Additional Notes

tested manually on UnoQ

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
