### PR TITLE
fix(ci): create the release in a single job to avoid losing artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,19 +5,20 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
 
-env:
-  PROJECT_NAME: "arduino-app-cli"
-  GITHUB_TOKEN: ${{ secrets.ARDUINOBOT_TOKEN }}
-  GITHUB_USERNAME: ArduinoBot
-
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-22.04]
         arch: [amd64, arm64]
 
     runs-on: ${{ matrix.os }}
+
+    env:
+      PROJECT_NAME: "arduino-app-cli"
+      GITHUB_TOKEN: ${{ secrets.ARDUINOBOT_TOKEN }}
+      GITHUB_USERNAME: ArduinoBot
 
     steps:
       - name: Set env vars
@@ -43,11 +44,44 @@ jobs:
         run: |
           go tool task build-deb VERSION=${TAG_VERSION} ARCH=${{ matrix.arch }} RELEASE="true"
 
+      - name: Upload deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb-${{ matrix.arch }}
+          path: build/*.deb
+          if-no-files-found: error
+          retention-days: 1
+
+  release:
+    needs: build
+    if: ${{ needs.build.result == 'success' }}
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Download deb artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: deb-*
+          path: dist
+          merge-multiple: true
+
+      - name: Verify artifacts
+        run: |
+          ls -la dist/
+          amd64_count=$(find dist -maxdepth 1 -name '*_amd64.deb' | wc -l)
+          arm64_count=$(find dist -maxdepth 1 -name '*_arm64.deb' | wc -l)
+          if [ "${amd64_count}" -ne 1 ] || [ "${arm64_count}" -ne 1 ]; then
+            echo "::error::expected exactly one *_amd64.deb and one *_arm64.deb in dist/, found ${amd64_count} amd64 and ${arm64_count} arm64"
+            exit 1
+          fi
+
       - name: Create Github Release and upload artifacts
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
           prerelease: true
-          artifacts: build/*.deb
+          artifacts: dist/*.deb
           allowUpdates: true
+          artifactErrorsFailBuild: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -53,6 +55,8 @@ jobs:
           retention-days: 1
 
   release:
+    permissions:
+      contents: write
     needs: build
     if: ${{ needs.build.result == 'success' }}
 


### PR DESCRIPTION
### Motivation

Both matrix jobs (amd64 and arm64) were calling `ncipollo/release-action`
on the same release at the same time. This is a race condition.

In release  [(tag v0.13.0-rc.9)](https://github.com/arduino/arduino-app-cli/actions/runs/31184266799) it went wrong: only the amd64 .deb was
uploaded, the arm64 one was lost. Both jobs were still green, because the
action only logs a warning when an upload fails and `artifactErrorsFailBuild`
is not set.

The race also created two release objects for the same tag. Because of this,
re-running the arm64 job does not help: the update call fails with
`422 already_exists` on `tag_name`.

### Change description

Split the workflow in two phases:

- `build` (matrix): builds the .deb and uploads it with `upload-artifact`,
  using `if-no-files-found: error`.
- `release` (single job, `needs: build`): downloads all the .deb files,
  checks that both architectures are there, and creates the release once.

Also added `artifactErrorsFailBuild: true`, so a failed upload makes the
job red instead of passing silently.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
