### PR TITLE
Restore --bricks support in app new

### DIFF
--- a/cmd/arduino-app-cli/app/new.go
+++ b/cmd/arduino-app-cli/app/new.go
@@ -84,7 +84,7 @@ func createHandler(
 			Description: description,
 			Bricks:      bricks,
 			SkipSketch:  noSketch,
-		}, servicelocator.GetAppIDProvider(), cfg)
+		}, servicelocator.GetBricksIndex(), servicelocator.GetAppIDProvider(), cfg)
 		if err != nil {
 			feedback.Fatal(err.Error(), feedback.ErrGeneric)
 			return nil

--- a/cmd/arduino-app-cli/app/new.go
+++ b/cmd/arduino-app-cli/app/new.go
@@ -32,7 +32,7 @@ func newCreateCmd(cfg config.Configuration) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cobra.MinimumNArgs(1)
 			name := args[0]
-			return createHandler(cfg, name, icon, description, noSketch, fromApp)
+			return createHandler(cfg, name, icon, description, bricks, noSketch, fromApp)
 		},
 	}
 
@@ -45,7 +45,15 @@ func newCreateCmd(cfg config.Configuration) *cobra.Command {
 	return cmd
 }
 
-func createHandler(cfg config.Configuration, name string, icon string, description string, noSketch bool, fromApp string) error {
+func createHandler(
+	cfg config.Configuration,
+	name string,
+	icon string,
+	description string,
+	bricks []string,
+	noSketch bool,
+	fromApp string,
+) error {
 	if fromApp != "" {
 		id, err := servicelocator.GetAppIDProvider().ParseID(fromApp)
 		if err != nil {
@@ -74,6 +82,7 @@ func createHandler(cfg config.Configuration, name string, icon string, descripti
 			Name:        name,
 			Icon:        icon,
 			Description: description,
+			Bricks:      bricks,
 			SkipSketch:  noSketch,
 		}, servicelocator.GetAppIDProvider(), cfg)
 		if err != nil {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -68,7 +68,7 @@ func NewHTTPRouter(
 	mux.Handle("DELETE /v1/models/{modelID}", handlers.HandlerDeleteModelByID(dockerClient, cfg, modelsIndex, bricksIndex, idProvider, platform))
 
 	mux.Handle("GET /v1/apps", handlers.HandleAppList(dockerClient, idProvider, bricksIndex, cfg, platform))
-	mux.Handle("POST /v1/apps", handlers.HandleAppCreate(idProvider, cfg))
+	mux.Handle("POST /v1/apps", handlers.HandleAppCreate(bricksIndex, idProvider, cfg))
 	mux.Handle("GET /v1/apps/events", handlers.HandlerAppStatus(dockerClient, idProvider, bricksIndex, cfg, platform))
 	mux.Handle("GET /v1/apps/{appID}", handlers.HandleAppDetails(dockerClient, bricksIndex, idProvider, cfg))
 	mux.Handle("PATCH /v1/apps/{appID}", handlers.HandleAppDetailsEdits(dockerClient, bricksIndex, idProvider, cfg))

--- a/internal/api/handlers/app_create.go
+++ b/internal/api/handlers/app_create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
@@ -27,6 +28,7 @@ type CreateAppRequest struct {
 }
 
 func HandleAppCreate(
+	bricksIndex *bricksindex.BricksIndex,
 	idProvider *appid.Provider,
 	cfg config.Configuration,
 ) http.HandlerFunc {
@@ -52,6 +54,7 @@ func HandleAppCreate(
 				Description: req.Description,
 				SkipSketch:  skipSketch,
 			},
+			bricksIndex,
 			idProvider,
 			cfg,
 		)

--- a/internal/orchestrator/app/generator/app_generator_test.go
+++ b/internal/orchestrator/app/generator/app_generator_test.go
@@ -63,6 +63,21 @@ func TestGenerateApp(t *testing.T) {
 	}
 }
 
+func TestGenerateAppWithBricks(t *testing.T) {
+	tempDir := paths.New(t.TempDir())
+	descriptor := app.AppDescriptor{
+		Name: "test app with bricks",
+		Bricks: []app.Brick{
+			{ID: "arduino:air_quality_monitoring"},
+			{ID: "arduino:object_detection"},
+		},
+	}
+
+	require.NoError(t, GenerateApp(tempDir, descriptor, true))
+	generated := f.Must(app.Load(tempDir))
+	require.Equal(t, descriptor.Bricks, generated.Descriptor.Bricks)
+}
+
 func compareFolders(t *testing.T, actualPath, goldenPath *paths.Path) {
 	t.Helper()
 

--- a/internal/orchestrator/app/generator/app_template/app.yaml.template
+++ b/internal/orchestrator/app/generator/app_template/app.yaml.template
@@ -12,4 +12,11 @@ icon: {{ .Icon }}
 ports: [{{ joinInts .Ports }}]
 
 # A list of bricks used by this application.
+{{- if .Bricks }}
+bricks:
+{{- range .Bricks }}
+  - {{ printf "%q" .ID }}
+{{- end }}
+{{- else }}
 bricks: []
+{{- end }}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -745,11 +745,20 @@ type CreateAppResponse struct {
 
 func CreateApp(
 	req CreateAppRequest,
+	bricksIndex *bricksindex.BricksIndex,
 	idProvider *appid.Provider,
 	cfg config.Configuration,
 ) (CreateAppResponse, error) {
 	if req.Name == "" {
 		return CreateAppResponse{}, fmt.Errorf("app name cannot be empty")
+	}
+
+	appBricks := make([]app.Brick, 0, len(req.Bricks))
+	for _, id := range req.Bricks {
+		if _, found := bricksIndex.FindBrickByID(id); !found {
+			return CreateAppResponse{}, fmt.Errorf("%w: brick %q not found", ErrBadRequest, id)
+		}
+		appBricks = append(appBricks, app.Brick{ID: id})
 	}
 
 	basePath, appExists := findAppPathByName(req.Name, cfg)
@@ -761,10 +770,8 @@ func CreateApp(
 		Name:        appName,
 		Description: req.Description,
 		Ports:       []int{},
-		Bricks: f.Map(req.Bricks, func(id string) app.Brick {
-			return app.Brick{ID: id}
-		}),
-		Icon: req.Icon, // TODO: not sure if icon will exists for bricks
+		Bricks:      appBricks,
+		Icon:        req.Icon,
 	}
 	if err := newApp.IsValid(); err != nil {
 		return CreateAppResponse{}, fmt.Errorf("%w: %v", app.ErrInvalidApp, err)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -735,6 +735,7 @@ type CreateAppRequest struct {
 	Name        string
 	Icon        string
 	Description string
+	Bricks      []string
 	SkipSketch  bool
 }
 
@@ -760,7 +761,10 @@ func CreateApp(
 		Name:        appName,
 		Description: req.Description,
 		Ports:       []int{},
-		Icon:        req.Icon, // TODO: not sure if icon will exists for bricks
+		Bricks: f.Map(req.Bricks, func(id string) app.Brick {
+			return app.Brick{ID: id}
+		}),
+		Icon: req.Icon, // TODO: not sure if icon will exists for bricks
 	}
 	if err := newApp.IsValid(); err != nil {
 		return CreateAppResponse{}, fmt.Errorf("%w: %v", app.ErrInvalidApp, err)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -35,7 +35,7 @@ func TestCloneApp(t *testing.T) {
 
 	originalAppID := f.Must(idProvider.ParseID("user:original-app"))
 	originalAppPath := originalAppID.ToPath()
-	r, err := CreateApp(CreateAppRequest{Name: "original-app"}, idProvider, cfg)
+	r, err := CreateApp(CreateAppRequest{Name: "original-app"}, &bricksindex.BricksIndex{}, idProvider, cfg)
 	require.NoError(t, err)
 	require.Equal(t, originalAppID, r.ID)
 	require.DirExists(t, originalAppPath.String())
@@ -154,7 +154,7 @@ func TestEditApp(t *testing.T) {
 	idProvider := appid.NewAppProvider(cfg, unoQPlatform)
 
 	t.Run("with default", func(t *testing.T) {
-		_, err := CreateApp(CreateAppRequest{Name: "app-default"}, idProvider, cfg)
+		_, err := CreateApp(CreateAppRequest{Name: "app-default"}, &bricksindex.BricksIndex{}, idProvider, cfg)
 		require.NoError(t, err)
 		appDir := cfg.AppsDir().Join("app-default")
 
@@ -192,7 +192,7 @@ func TestEditApp(t *testing.T) {
 
 	t.Run("with name", func(t *testing.T) {
 		originalAppName := "original-name"
-		_, err := CreateApp(CreateAppRequest{Name: originalAppName}, idProvider, cfg)
+		_, err := CreateApp(CreateAppRequest{Name: originalAppName}, &bricksindex.BricksIndex{}, idProvider, cfg)
 		require.NoError(t, err)
 		appDir := cfg.AppsDir().Join(originalAppName)
 		userApp := f.Must(app.Load(appDir))
@@ -207,7 +207,7 @@ func TestEditApp(t *testing.T) {
 
 		t.Run("already existing name", func(t *testing.T) {
 			existingAppName := "existing-name"
-			_, err := CreateApp(CreateAppRequest{Name: existingAppName}, idProvider, cfg)
+			_, err := CreateApp(CreateAppRequest{Name: existingAppName}, &bricksindex.BricksIndex{}, idProvider, cfg)
 			require.NoError(t, err)
 			appDir := cfg.AppsDir().Join(existingAppName)
 			existingApp := f.Must(app.Load(appDir))
@@ -219,7 +219,7 @@ func TestEditApp(t *testing.T) {
 
 	t.Run("with icon and description", func(t *testing.T) {
 		commonAppName := "common-app"
-		_, err := CreateApp(CreateAppRequest{Name: commonAppName}, idProvider, cfg)
+		_, err := CreateApp(CreateAppRequest{Name: commonAppName}, &bricksindex.BricksIndex{}, idProvider, cfg)
 		require.NoError(t, err)
 		commonAppDir := cfg.AppsDir().Join(commonAppName)
 		commonApp := f.Must(app.Load(commonAppDir))
@@ -551,7 +551,7 @@ func createApp(
 	res, err := CreateApp(CreateAppRequest{
 		Name: name,
 		Icon: "😃",
-	}, idProvider, cfg)
+	}, &bricksindex.BricksIndex{}, idProvider, cfg)
 	require.NoError(t, err)
 	require.Empty(t, gCmp.Diff(f.Must(idProvider.ParseID("user:"+name)), res.ID))
 	if isExample {


### PR DESCRIPTION
## Motivation

The `app new --bricks` flag is still exposed but its values are dropped before app generation, so every generated `app.yaml` contains an empty `bricks` list.

## Change description

- thread the CLI brick IDs through `createHandler` and `CreateAppRequest`
- populate the generated `AppDescriptor` with those brick IDs
- render brick IDs in `app.yaml` while preserving `bricks: []` for the default case
- add a round-trip regression test for multiple brick IDs

The IDs are quoted in the template so unusual but valid values remain valid YAML.

## Testing

- `go test ./internal/orchestrator/app/generator`
- `go test ./internal/orchestrator -run 'TestCreateApp|Test.*App' -count=1`

Closes #568
