### PR TITLE
Assign current user to arduino-router group on install

### DIFF
--- a/debian/arduino-app-cli/DEBIAN/preinst
+++ b/debian/arduino-app-cli/DEBIAN/preinst
@@ -49,3 +49,12 @@ if [ "$1" = "upgrade" ]; then
     # remove it to cleanup stale files
     rm -rf /home/arduino/.local/share/arduino-app-cli/examples
 fi
+
+# Add the system user to the arduino-router group.
+# If the group does not exist, create it first.
+if ! getent group arduino-router >/dev/null; then
+    groupadd --system arduino-router || true
+fi
+if id -u "$username" >/dev/null 2>&1; then
+    usermod -a -G arduino-router "$username" || true
+fi


### PR DESCRIPTION
### Motivation

In upcoming versions of `arduino-router` the Unix socket permissions will be lowered.

### Change description

Assign the `arduino` user to the `arduino-router` group to allow seamless integration with the new lowered permissions.

### Additional Notes

It goes in pair with https://github.com/arduino/arduino-router/pull/65/changes.

### Reviewer checklist

- [X] PR addresses a single concern.
- [X] PR title and description are properly filled.
- [X] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
