### PR TITLE
Remove deprecated require_container field from Brick struct

### DIFF
--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -113,14 +113,12 @@ func (r *RequiresServices) UnmarshalYAML(node ast.Node) error {
 }
 
 type Brick struct {
-	ID              string   `yaml:"id"`
-	Name            string   `yaml:"name"`
-	Description     string   `yaml:"description"`
-	SupportedBoards []string `yaml:"supported_boards,omitempty"`
-	Category        string   `yaml:"category,omitempty"`
-	RequiresDisplay string   `yaml:"requires_display,omitempty"`
-	// Deprecated : the field `require_container` is deprecated, you can remove it from the brick config. It will be ignored if present.
-	RequireContainer            bool                      `yaml:"require_container"` // Deprecated
+	ID                          string                    `yaml:"id"`
+	Name                        string                    `yaml:"name"`
+	Description                 string                    `yaml:"description"`
+	SupportedBoards             []string                  `yaml:"supported_boards,omitempty"`
+	Category                    string                    `yaml:"category,omitempty"`
+	RequiresDisplay             string                    `yaml:"requires_display,omitempty"`
 	Variables                   []BrickVariable           `yaml:"variables,omitempty"`
 	Ports                       []string                  `yaml:"ports,omitempty"`
 	ModelName                   string                    `yaml:"model_name,omitempty"`
@@ -260,9 +258,6 @@ func Load(platform platform.Platform, path *paths.Path) (*BricksIndex, error) {
 		namespace, brickName, err := ParseBrickID(yamlIndex.Bricks[i].ID)
 		if err != nil {
 			return nil, err
-		}
-		if yamlIndex.Bricks[i].RequireContainer {
-			slog.Warn("the field `require_container` is deprecated. You can remove it from the brick config", "brick_id", yamlIndex.Bricks[i].ID)
 		}
 		yamlIndex.Bricks[i].Source = "Arduino"
 		yamlIndex.Bricks[i].FullPath = path

--- a/internal/orchestrator/bricksindex/bricks_index_test.go
+++ b/internal/orchestrator/bricksindex/bricks_index_test.go
@@ -195,7 +195,6 @@ func TestBricksIndexYAMLFormats(t *testing.T) {
 					Description:               "A test brick",
 					Category:                  "",
 					RequiresDisplay:           "",
-					RequireContainer:          false,
 					RequiredDevices:           nil,
 					Variables:                 nil,
 					Ports:                     nil,


### PR DESCRIPTION
### Motivation

Companion PR https://github.com/arduino/app-bricks-py/pull/381/

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
