### PR TITLE
fix: custom brick import in main.py

### DIFF
--- a/internal/orchestrator/app/generator/brick_template/README.md.template
+++ b/internal/orchestrator/app/generator/brick_template/README.md.template
@@ -2,43 +2,18 @@
 
 Your Brick **{{ .Name }}** is ready!
 
-Custom Bricks are modular components that add reusable functionality to your app.
+You can find the brick implementation inside `bricks/{{ .ID }}/__init__.py`.
 
 ## How to use it
 
-Write your Python class inside `bricks/{{ .ID }}/__init__.py` and add the `@brick` decorator.
-```python
-# bricks/{{ .ID }}/__init__.py
-from arduino.app_utils import brick, Logger
-import time
+You can import and use your Brick in your main application code:
 
-logger = Logger("GreeterBrick")
-
-@brick
-class Greeter:
-    def __init__(self, name="World"):
-        self.name = name
-
-    def start(self):
-        logger.info("Starting Greeter")
-
-    def stop(self):
-        logger.info("Stopping Greeter")
-
-    # This is a non-blocking method that will be called repeatedly
-    def loop(self):
-        logger.info(f"Hello, {self.name}!")
-        time.sleep(1)
-
-```
-
-You can then import and use your Brick in your main application code:
 ```python
 # python/main.py
 from arduino.app_utils import App
-from greeter import Greeter
+from {{ .ID }} import Greeter
 
-g = Greeter()
+greet = Greeter()
 
 App.run()
 ```
@@ -58,7 +33,7 @@ When `App.run()` is executed, the framework automatically manages the applicatio
 
 ## What's in the brick folder
 
-your brick is created under the `bricks/{{ .ID }}` folder that contains the following files:
+Your brick is created under the `bricks/{{ .ID }}` folder that contains the following files:
 - `__init__.py` Your core Python code. This is what gets imported.
 - `brick_config.yaml` Brick identity, variables, and configuration
 - `brick_compose.yaml` A Docker Compose file for adding custom containers (if your Brick requires external services like a database).
@@ -72,8 +47,8 @@ For example, to add a configuration variable called `YOUR_NAME` to your Brick, d
 id: {{ .ID }}
 name: {{ .Name }}
 variables:
-    - name: YOUR_NAME
-     description: A name to greet
+  - name: YOUR_NAME
+    description: A name to greet
 ```
 Note: Variables defined in this file are automatically injected into your Brick as environment variables at runtime.
 
@@ -86,5 +61,6 @@ name = os.getenv("YOUR_NAME")
 
 ## Next
 
-Replace this README with your Brick's docs: what it does, inputs, outputs, and a usage example.
-[See Documentation on Docs](https://docs.arduino.cc/software/app-lab/bricks/about-bricks/)
+Replace this README with your Brick's documentation: what it does, inputs, outputs, and usage examples.
+
+See [Bricks Documentation](https://docs.arduino.cc/software/app-lab/bricks/about-bricks/)

--- a/internal/orchestrator/app/generator/brick_template/__init__.py
+++ b/internal/orchestrator/app/generator/brick_template/__init__.py
@@ -1,1 +1,20 @@
-# put your python code here
+from arduino.app_utils import brick, Logger
+import time
+
+logger = Logger("GreeterBrick")
+
+@brick
+class Greeter:
+    def __init__(self, name="World"):
+        self.name = name
+
+    def start(self):
+        logger.info("Starting Greeter")
+
+    def stop(self):
+        logger.info("Stopping Greeter")
+
+    # This is a non-blocking method that will be called repeatedly
+    def loop(self):
+        logger.info(f"Hello, {self.name}!")
+        time.sleep(1)

--- a/internal/orchestrator/app/generator/brick_template/__init__.py
+++ b/internal/orchestrator/app/generator/brick_template/__init__.py
@@ -3,6 +3,7 @@ import time
 
 logger = Logger("GreeterBrick")
 
+
 @brick
 class Greeter:
     def __init__(self, name="World"):

--- a/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/README.md
+++ b/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/README.md
@@ -2,43 +2,18 @@
 
 Your Brick **a-brick-name** is ready!
 
-Custom Bricks are modular components that add reusable functionality to your app.
+You can find the brick implementation inside `bricks/my-brick/__init__.py`.
 
 ## How to use it
 
-Write your Python class inside `bricks/my-brick/__init__.py` and add the `@brick` decorator.
-```python
-# bricks/my-brick/__init__.py
-from arduino.app_utils import brick, Logger
-import time
+You can import and use your Brick in your main application code:
 
-logger = Logger("GreeterBrick")
-
-@brick
-class Greeter:
-    def __init__(self, name="World"):
-        self.name = name
-
-    def start(self):
-        logger.info("Starting Greeter")
-
-    def stop(self):
-        logger.info("Stopping Greeter")
-
-    # This is a non-blocking method that will be called repeatedly
-    def loop(self):
-        logger.info(f"Hello, {self.name}!")
-        time.sleep(1)
-
-```
-
-You can then import and use your Brick in your main application code:
 ```python
 # python/main.py
 from arduino.app_utils import App
-from greeter import Greeter
+from my-brick import Greeter
 
-g = Greeter()
+greet = Greeter()
 
 App.run()
 ```
@@ -58,7 +33,7 @@ When `App.run()` is executed, the framework automatically manages the applicatio
 
 ## What's in the brick folder
 
-your brick is created under the `bricks/my-brick` folder that contains the following files:
+Your brick is created under the `bricks/my-brick` folder that contains the following files:
 - `__init__.py` Your core Python code. This is what gets imported.
 - `brick_config.yaml` Brick identity, variables, and configuration
 - `brick_compose.yaml` A Docker Compose file for adding custom containers (if your Brick requires external services like a database).
@@ -72,8 +47,8 @@ For example, to add a configuration variable called `YOUR_NAME` to your Brick, d
 id: my-brick
 name: a-brick-name
 variables:
-    - name: YOUR_NAME
-     description: A name to greet
+  - name: YOUR_NAME
+    description: A name to greet
 ```
 Note: Variables defined in this file are automatically injected into your Brick as environment variables at runtime.
 
@@ -86,5 +61,6 @@ name = os.getenv("YOUR_NAME")
 
 ## Next
 
-Replace this README with your Brick's docs: what it does, inputs, outputs, and a usage example.
-[See Documentation on Docs](https://docs.arduino.cc/software/app-lab/bricks/about-bricks/)
+Replace this README with your Brick's documentation: what it does, inputs, outputs, and usage examples.
+
+See [Bricks Documentation](https://docs.arduino.cc/software/app-lab/bricks/about-bricks/)

--- a/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/__init__.py
+++ b/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/__init__.py
@@ -1,1 +1,20 @@
-# put your python code here
+from arduino.app_utils import brick, Logger
+import time
+
+logger = Logger("GreeterBrick")
+
+@brick
+class Greeter:
+    def __init__(self, name="World"):
+        self.name = name
+
+    def start(self):
+        logger.info("Starting Greeter")
+
+    def stop(self):
+        logger.info("Stopping Greeter")
+
+    # This is a non-blocking method that will be called repeatedly
+    def loop(self):
+        logger.info(f"Hello, {self.name}!")
+        time.sleep(1)

--- a/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/__init__.py
+++ b/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/__init__.py
@@ -3,6 +3,7 @@ import time
 
 logger = Logger("GreeterBrick")
 
+
 @brick
 class Greeter:
     def __init__(self, name="World"):


### PR DESCRIPTION
### Motivation
Wrong import of a custom brick in the `main.py` 

### Change description

- fix the import
- write the initial python class into `__init__.py` when a custom brick is created.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
