### PR TITLE
fix(models): surface download failures instead of losing them

### DIFF
--- a/internal/api/handlers/ai_models.go
+++ b/internal/api/handlers/ai_models.go
@@ -222,9 +222,23 @@ func HandleInstallModel(dockerClient command.Cli, modelsIndex *modelsindex.Model
 				sseStream.Send(render.SSEEvent{Type: "progress", Data: &progress{Name: model.ID, Current: e.GetProgress().Current, Total: e.GetProgress().Total, Progress: progressValue}})
 
 			case modelsindex.ErrorType:
-				sseStream.Send(render.SSEEvent{Type: "error", Data: e.GetError()})
+				// Same payload shape as every other error on this stream: a bare
+				// string here reads as an empty code and message to a client
+				// decoding SSEErrorData, i.e. an error banner with no text.
+				slog.Error("model download handler reported an error",
+					slog.String("model", model.ID), slog.String("error", e.GetError()))
+				sseStream.SendError(render.SSEErrorData{
+					Code:    render.InternalServiceErr,
+					Message: e.GetError(),
+				})
 			case modelsindex.DoneType:
 				sseStream.Send(render.SSEEvent{Type: "done", Data: e.GetDone()})
+			default:
+				// A message with no populated field, e.g. an error event whose
+				// description was empty. Dropping it silently is what made a
+				// failed download look like nothing at all.
+				slog.Warn("unhandled message from model download handler",
+					slog.String("model", model.ID))
 			}
 		}
 

--- a/internal/api/handlers/ai_models.go
+++ b/internal/api/handlers/ai_models.go
@@ -230,6 +230,10 @@ func HandleInstallModel(dockerClient command.Cli, modelsIndex *modelsindex.Model
 
 		err = modelsIndex.Download(r.Context(), dockerClient.Client(), *model, plat, installResponse)
 		if err != nil {
+			// Also log it: the SSE event only reaches a client that is still
+			// listening, and the container is gone by now, so without this the
+			// reason cannot be recovered after the fact.
+			slog.Error("model download failed", slog.String("model", model.ID), slog.String("error", err.Error()))
 			if errors.Is(err, modelsindex.ErrInsufficientStorage) {
 				sseStream.SendError(render.SSEErrorData{
 					Code:    "insufficient_storage",

--- a/internal/dockerhelper/dockerhelper.go
+++ b/internal/dockerhelper/dockerhelper.go
@@ -93,7 +93,11 @@ func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
 
 	slog.Debug("creating container", "id", resp.ID, "image", opts.Image, "cmd", opts.Cmd, "env", opts.Env, "binds", opts.Binds)
 
-	statusCh, errCh := cli.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
+	// NextExit, not NotRunning: the container has been created but not started
+	// yet, and a created container already satisfies "not running", so
+	// NotRunning returns immediately with StatusCode 0 and every failing
+	// container looks like a success.
+	statusCh, errCh := cli.ContainerWait(ctx, resp.ID, container.WaitConditionNextExit)
 
 	attachResp, err := cli.ContainerAttach(ctx, resp.ID, container.AttachOptions{
 		Stream: true,

--- a/internal/dockerhelper/dockerhelper.go
+++ b/internal/dockerhelper/dockerhelper.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/user"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -45,6 +46,13 @@ func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
 	if opts.Stderr == nil {
 		opts.Stderr = io.Discard
 	}
+
+	// Always keep the tail of stderr, whatever the caller does with it: it is
+	// the only place where a handler script reports *why* it failed, and the
+	// container is removed on exit (AutoRemove) with logging disabled, so it
+	// cannot be recovered afterwards.
+	stderrTail := &tailBuffer{}
+	stderr := io.MultiWriter(opts.Stderr, stderrTail)
 
 	for _, bind := range opts.Binds {
 		hostPath, _, _ := strings.Cut(bind, ":")
@@ -119,7 +127,7 @@ func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
 	// Read output in a goroutine so it doesn't block waiting for the container.
 	g, _ := errgroup.WithContext(ctx)
 	g.Go(func() error {
-		_, err := stdcopy.StdCopy(opts.Stdout, opts.Stderr, attachResp.Reader)
+		_, err := stdcopy.StdCopy(opts.Stdout, stderr, attachResp.Reader)
 		return err
 	})
 
@@ -140,6 +148,12 @@ func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
 	// Wait for StdCopy to finish draining output.
 	_ = g.Wait()
 
+	// Attach the container's own diagnostics to the error, now that stderr has
+	// been fully drained.
+	if exitErr, ok := errors.AsType[*ExitError](runErr); ok {
+		exitErr.Stderr = stderrTail.String()
+	}
+
 	return cmp.Or(ctx.Err(), runErr)
 }
 
@@ -148,16 +162,48 @@ func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
 // a simple boolean check.
 type ExitError struct {
 	Code int64
+	// Stderr holds the tail of what the container wrote to stderr, which is
+	// usually the only description of what actually went wrong.
+	Stderr string
 }
 
 func (e *ExitError) Error() string {
-	return fmt.Sprintf("container exited with status %d", e.Code)
+	if e.Stderr == "" {
+		return fmt.Sprintf("container exited with status %d", e.Code)
+	}
+	return fmt.Sprintf("container exited with status %d: %s", e.Code, e.Stderr)
 }
 
 // IsExitError reports whether err (or any error wrapped by it) is an *ExitError.
 func IsExitError(err error) bool {
 	_, ok := errors.AsType[*ExitError](err)
 	return ok
+}
+
+// maxStderrTail caps how much of a container's stderr is kept for the error
+// message. Errors travel to the UI over SSE, so this stays small.
+const maxStderrTail = 2048
+
+// tailBuffer is an io.Writer retaining only the last maxStderrTail bytes.
+type tailBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (t *tailBuffer) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.buf = append(t.buf, p...)
+	if len(t.buf) > maxStderrTail {
+		t.buf = t.buf[len(t.buf)-maxStderrTail:]
+	}
+	return len(p), nil
+}
+
+func (t *tailBuffer) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return strings.TrimSpace(string(t.buf))
 }
 
 func ensureImage(ctx context.Context, cli client.APIClient, img string) error {

--- a/internal/orchestrator/modelsindex/models_index.go
+++ b/internal/orchestrator/modelsindex/models_index.go
@@ -284,6 +284,10 @@ func (m *ModelsIndex) modelInstalled(ctx context.Context, model AIModel, cli cli
 
 	switch out.Event {
 	case "error":
+		// Not an error for the caller: the handler reports "error" both when the
+		// model is genuinely absent and when it could not look. Keep the reason
+		// so the two are distinguishable in the logs.
+		slog.Debug("model check reported an error", "model", model.ID, "description", out.Description)
 		return false, nil
 	case "info":
 		return !out.Downloading, nil

--- a/internal/render/sse.go
+++ b/internal/render/sse.go
@@ -51,6 +51,11 @@ type SSEStream struct {
 	messageCh         chan SSEEvent
 	isClosing         atomic.Bool
 
+	// drainingCh is closed as soon as loop() stops reading messageCh. Senders
+	// select on it so that a Send issued after the client disconnected is
+	// dropped instead of blocking forever on the unbuffered channel.
+	drainingCh chan struct{}
+
 	shutdownFn context.CancelFunc
 	stoppedCh  chan struct{}
 	ctx        context.Context
@@ -81,6 +86,7 @@ func NewSSEStream(ctx context.Context, w http.ResponseWriter) (*SSEStream, error
 		heartbeatInterval: 30 * time.Second,
 		messageCh:         make(chan SSEEvent),
 		isClosing:         atomic.Bool{},
+		drainingCh:        make(chan struct{}),
 		shutdownFn:        cancel,
 		stoppedCh:         make(chan struct{}),
 		ctx:               ctx,
@@ -93,6 +99,10 @@ func NewSSEStream(ctx context.Context, w http.ResponseWriter) (*SSEStream, error
 
 func (s *SSEStream) loop() {
 	defer func() {
+		// Stop accepting events before anything else: from here on nothing
+		// reads messageCh, so a concurrent Send must not be allowed to block.
+		close(s.drainingCh)
+
 		// This is kept for backward compatibility. We should remove this in the future.
 		_ = s.send(SSEEvent{Type: "error", Data: SSEErrorData{Code: "SERVER_CLOSED"}})
 
@@ -129,7 +139,11 @@ func (s *SSEStream) Send(event SSEEvent) {
 		slog.Debug("SSE stream is closing, ignoring event", slog.String("event", event.Type))
 		return
 	}
-	s.messageCh <- event
+	select {
+	case s.messageCh <- event:
+	case <-s.drainingCh:
+		slog.Debug("SSE stream is no longer draining, dropping event", slog.String("event", event.Type))
+	}
 }
 
 func (s *SSEStream) SendError(event SSEErrorData) {
@@ -137,7 +151,11 @@ func (s *SSEStream) SendError(event SSEErrorData) {
 		slog.Debug("SSE stream is closing, ignoring event", slog.String("event", "error"))
 		return
 	}
-	s.messageCh <- SSEEvent{Type: "error", Data: event}
+	select {
+	case s.messageCh <- SSEEvent{Type: "error", Data: event}:
+	case <-s.drainingCh:
+		slog.Debug("SSE stream is no longer draining, dropping event", slog.String("event", "error"))
+	}
 }
 
 func (s *SSEStream) Close() {

--- a/internal/render/sse_test.go
+++ b/internal/render/sse_test.go
@@ -1,0 +1,90 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package render
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSendDoesNotBlockAfterClientDisconnect covers the deadlock that made a
+// failed model download wedge the daemon until it was restarted: once the
+// client goes away the stream stops draining messageCh, and a Send from the
+// docker output goroutine blocked on it forever, so the handler never returned
+// and its deferred Close was never reached.
+func TestSendDoesNotBlockAfterClientDisconnect(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		send func(s *SSEStream)
+	}{
+		{"Send", func(s *SSEStream) { s.Send(SSEEvent{Type: "progress", Data: "1%"}) }},
+		{"SendError", func(s *SSEStream) { s.SendError(SSEErrorData{Code: InternalServiceErr, Message: "boom"}) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			w := &syncResponseWriter{header: http.Header{}}
+
+			stream, err := NewSSEStream(ctx, w)
+			require.NoError(t, err)
+
+			// The client disconnects: this is what cancels the request context.
+			cancel()
+
+			// loop() writes the farewell events on its way out, so their arrival
+			// means it has stopped reading messageCh.
+			require.Eventually(t, func() bool {
+				return strings.Contains(w.String(), "SERVER_CLOSED")
+			}, 2*time.Second, time.Millisecond, "stream never stopped")
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				tc.send(stream)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("send blocked after the client disconnected")
+			}
+		})
+	}
+}
+
+// syncResponseWriter is a minimal http.ResponseWriter satisfying the sseFlusher
+// interface, safe to read while the stream goroutine writes to it.
+type syncResponseWriter struct {
+	mu     sync.Mutex
+	buf    bytes.Buffer
+	header http.Header
+}
+
+func (w *syncResponseWriter) Header() http.Header { return w.header }
+
+func (w *syncResponseWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *syncResponseWriter) WriteHeader(int) {}
+
+func (w *syncResponseWriter) Flush() {}
+
+func (w *syncResponseWriter) SetWriteDeadline(time.Time) error { return nil }
+
+func (w *syncResponseWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -195,7 +195,9 @@ func (b *Manager) broadcast(event Event) {
 	defer b.mu.RUnlock()
 
 	if event.Type == ErrorEvent {
-		slog.Error("An error occurred", slog.Any("event", event))
+		// Log the error itself: Event's fields are unexported, so logging the
+		// struct prints the error as a bare pointer address.
+		slog.Error("An error occurred", slog.Any("error", event.GetError()))
 	}
 	for ch := range b.subs {
 		select {


### PR DESCRIPTION
Fixes #523.

A failed model download reported nothing usable, and aborting one wedged the daemon until it was restarted.

## Root cause

`dockerhelper.Run` called `ContainerWait` with `WaitConditionNotRunning` **before** starting the container. A created-but-not-started container already satisfies "not running", so the wait returned immediately with `StatusCode: 0` and `Run()` reported success however the container actually exited.

Every handler failure therefore looked like a success: no error returned, nothing logged, the model left `not-installed`. It also made `ExitError` and `IsExitError` unreachable in practice. Fix is `WaitConditionNextExit`.

Two further losses sat on top of it:

- **stderr was discarded.** Handlers print JSON progress on stdout and real diagnostics on stderr, and every call site passed `Stderr: io.Discard`. With `LogConfig{Type: "none"}` and `AutoRemove: true` there is no `docker logs` fallback either. Now teed into a bounded 2 KiB buffer and attached to `ExitError.Stderr`.
- **`update.go` logged the error as a pointer.** `update.Event`'s fields are unexported, so `slog.Any("event", event)` cannot reach `.Error()` and printed `err:0x710f24f7d7a0`. Now logs `event.GetError()`.

## The SSE deadlock

`messageCh` is unbuffered. `loop()` stops reading it when the request context is cancelled — a closed browser tab — but never sets `isClosing`, so the next `Send` blocks forever. That `Send` runs inline on the docker output path, so `StdCopy` blocks, `g.Wait()` never returns, the handler never returns, and its deferred `Close()` — the only thing that sets `isClosing` — never runs.

Senders now select on a `drainingCh` closed as soon as `loop()` stops reading.

## Changes

| File | Change |
|---|---|
| `internal/dockerhelper/dockerhelper.go` | `WaitConditionNextExit`; tee stderr into `ExitError.Stderr` |
| `internal/render/sse.go` | `drainingCh`; `Send`/`SendError` select on it |
| `internal/orchestrator/modelsindex/models_index.go` | Restore the log line saying why a model check returned `error` (dropped in #515) |
| `internal/update/update.go` | Log `event.GetError()` |

## Testing

`internal/render/sse_test.go` regression-tests the deadlock using only the exported API, so it compiles against `main` — and against `main` it hangs and fails. Clean under `-race`.

No unit test for the wait-condition bug: a fake `client.APIClient` returns whatever it is programmed to return, so it would assert the mock rather than Docker's semantics. Verified against a real daemon on a UNO Q instead — before/after evidence in the comment below.

`go build ./...`, `go vet`, `gofmt` clean. `go test ./internal/...` passes except `TestRemoveImage`, which needs a live Docker daemon and fails identically on `main`.

## Out of scope

- No post-download verification: a handler that fails but exits 0 still yields a silent success.
- No failure state in the API — `status` stays `installed`/`not-installed`. `DownloadingStatus` exists but is unassigned.
- No retry/cancel surface; `PUT /v1/models/{modelID}` is absent from the OpenAPI spec; no `model install` CLI (#527).
- The swallowed bind-mount `MkdirAll` error (#583), `_ = g.Wait()` discarding the `StdCopy` error, and `ResolveVars` substituting unset variables with `""`.
