### PR TITLE
Create valid Docker Compose file in generated custom Brick

### DIFF
--- a/internal/orchestrator/app/generator/brick_template/brick_compose.yaml
+++ b/internal/orchestrator/app/generator/brick_template/brick_compose.yaml
@@ -1,2 +1,2 @@
-services:
 # Optional: containers services
+services: {}

--- a/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/brick_compose.yaml
+++ b/internal/orchestrator/app/generator/testdata/app-with-brick.golden/bricks/my-brick/brick_compose.yaml
@@ -1,2 +1,2 @@
-services:
 # Optional: containers services
+services: {}


### PR DESCRIPTION
### Motivation

When the user adds a custom Brick to their App, it is populated with some minimal demonstration code, which is intended to be a fully functional Brick (https://github.com/arduino/arduino-app-cli/pull/580). This includes a Docker Compose file.

The generated Compose file contains a `services` key. Previously this key had an empty value. It is mandatory for the type of this key to be a mapping. If the user instead left the file as generated, the incorrect type caused an error:

```
$ arduino-app-cli app logs user:hascustombrick

services must be a mapping
```

### Change description

Make the generated Brick valid by setting the value of the `services` key in the Docker Compose file to an empty mapping.

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
