### PR TITLE
fix(dockerhelper): fail when a bind mount is not usable by the container

### DIFF
--- a/internal/api/handlers/ai_models.go
+++ b/internal/api/handlers/ai_models.go
@@ -179,8 +179,10 @@ func HandleInstallModel(dockerClient command.Cli, modelsIndex *modelsindex.Model
 
 		model, err := modelsIndex.GetModelByID(r.Context(), id)
 		if err != nil {
+			// Forward the reason, as HandlerModelByID does: it names the model
+			// and the path that could not be used, which the caller needs.
 			slog.Error("unable to get model by ID", slog.String("error", err.Error()))
-			render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{Details: "unable to get model by ID"})
+			render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{Details: err.Error()})
 			return
 		}
 		if model == nil {

--- a/internal/dockerhelper/dockerhelper.go
+++ b/internal/dockerhelper/dockerhelper.go
@@ -16,8 +16,11 @@ import (
 	"log/slog"
 	"os"
 	"os/user"
+	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -54,12 +57,8 @@ func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
 	stderrTail := &tailBuffer{}
 	stderr := io.MultiWriter(opts.Stderr, stderrTail)
 
-	for _, bind := range opts.Binds {
-		hostPath, _, _ := strings.Cut(bind, ":")
-		if err := os.MkdirAll(hostPath, 0775); err != nil {
-			slog.Warn("cannot pre-create bind mount directory", "path", hostPath, "err", err)
-			continue
-		}
+	if err := ensureBindDirs(opts.Binds); err != nil {
+		return err
 	}
 
 	launchStart := time.Now()
@@ -225,6 +224,64 @@ func ensureImage(ctx context.Context, cli client.APIClient, img string) error {
 		return fmt.Errorf("image pull read: %w", err)
 	}
 	return nil
+}
+
+// ensureBindDirs makes sure every host bind path exists and is writable by the
+// user the container runs as, which getCurrentUser reports.
+//
+// Docker creates a missing bind path itself, as root. The container runs as the
+// invoking user, so it is then handed a mount it cannot write to and fails deep
+// inside the handler script. Reporting that here, against the path that is
+// actually wrong, beats letting it surface as a traceback from the container.
+func ensureBindDirs(binds []string) error {
+	for _, bind := range binds {
+		hostPath, mountSpec, found := strings.Cut(bind, ":")
+		if !found || hostPath == "" {
+			return fmt.Errorf("malformed bind mount %q", bind)
+		}
+
+		if err := os.MkdirAll(hostPath, 0775); err != nil {
+			return fmt.Errorf("cannot create bind mount directory %q (%s): %w",
+				hostPath, describePath(filepath.Dir(hostPath)), err)
+		}
+
+		// A read-only mount only has to be readable.
+		if isReadOnlyBind(mountSpec) {
+			continue
+		}
+
+		if err := syscall.Access(hostPath, wOK); err != nil {
+			return fmt.Errorf("bind mount directory %q is not writable by the container user %s (%s): %w",
+				hostPath, getCurrentUser(), describePath(hostPath), err)
+		}
+	}
+	return nil
+}
+
+// wOK is access(2)'s write-permission bit.
+const wOK = 0x2
+
+// isReadOnlyBind reports whether a bind's "container[:options]" half marks it
+// read-only.
+func isReadOnlyBind(mountSpec string) bool {
+	_, options, found := strings.Cut(mountSpec, ":")
+	if !found {
+		return false
+	}
+	return slices.Contains(strings.Split(options, ","), "ro")
+}
+
+// describePath renders a path's ownership and mode for an error message, which
+// is what tells the reader whether a stray root-owned directory is the problem.
+func describePath(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "cannot stat"
+	}
+	if st, ok := info.Sys().(*syscall.Stat_t); ok {
+		return fmt.Sprintf("owned by %d:%d, mode %04o", st.Uid, st.Gid, info.Mode().Perm())
+	}
+	return fmt.Sprintf("mode %04o", info.Mode().Perm())
 }
 
 func getCurrentUser() string {

--- a/internal/dockerhelper/dockerhelper_test.go
+++ b/internal/dockerhelper/dockerhelper_test.go
@@ -1,0 +1,100 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dockerhelper
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureBindDirs(t *testing.T) {
+	t.Run("creates a missing bind directory", func(t *testing.T) {
+		root := t.TempDir()
+		hostPath := filepath.Join(root, "models", "llamacpp")
+
+		require.NoError(t, ensureBindDirs([]string{hostPath + ":/models"}))
+		info, err := os.Stat(hostPath)
+		require.NoError(t, err)
+		assert.True(t, info.IsDir())
+	})
+
+	t.Run("accepts an existing writable directory", func(t *testing.T) {
+		hostPath := t.TempDir()
+		require.NoError(t, ensureBindDirs([]string{hostPath + ":/models"}))
+	})
+
+	// The regression: the daemon used to log a warning and carry on, leaving
+	// Docker to create the path as root and the container unable to write to it.
+	t.Run("refuses a directory it cannot create", func(t *testing.T) {
+		requireNotRoot(t)
+		root := t.TempDir()
+		parent := filepath.Join(root, "models")
+		require.NoError(t, os.Mkdir(parent, 0o555))
+		t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+		err := ensureBindDirs([]string{filepath.Join(parent, "llamacpp") + ":/models"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot create bind mount directory")
+		assert.Contains(t, err.Error(), "owned by")
+	})
+
+	t.Run("refuses an existing directory it cannot write to", func(t *testing.T) {
+		requireNotRoot(t)
+		hostPath := t.TempDir()
+		require.NoError(t, os.Chmod(hostPath, 0o555))
+		t.Cleanup(func() { _ = os.Chmod(hostPath, 0o755) })
+
+		err := ensureBindDirs([]string{hostPath + ":/models"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is not writable by the container user")
+	})
+
+	t.Run("allows an unwritable directory when the mount is read-only", func(t *testing.T) {
+		requireNotRoot(t)
+		hostPath := t.TempDir()
+		require.NoError(t, os.Chmod(hostPath, 0o555))
+		t.Cleanup(func() { _ = os.Chmod(hostPath, 0o755) })
+
+		require.NoError(t, ensureBindDirs([]string{hostPath + ":/models:ro"}))
+	})
+
+	t.Run("rejects a malformed bind", func(t *testing.T) {
+		for _, bind := range []string{"", "/no-container-path", ":/models"} {
+			err := ensureBindDirs([]string{bind})
+			require.Error(t, err, "bind %q should be rejected", bind)
+			assert.Contains(t, err.Error(), "malformed bind mount")
+		}
+	})
+}
+
+func TestIsReadOnlyBind(t *testing.T) {
+	for _, tc := range []struct {
+		mountSpec string
+		want      bool
+	}{
+		{"/models", false},
+		{"/models:ro", true},
+		{"/models:rw", false},
+		{"/models:ro,z", true},
+		{"/models:z,ro", true},
+		{"/models:rox", false},
+	} {
+		assert.Equal(t, tc.want, isReadOnlyBind(tc.mountSpec), "mountSpec %q", tc.mountSpec)
+	}
+}
+
+// requireNotRoot skips a test that depends on permission checks having teeth,
+// since root bypasses them.
+func requireNotRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: permission checks do not apply")
+	}
+}

--- a/internal/orchestrator/modelsindex/modelsindex_test.go
+++ b/internal/orchestrator/modelsindex/modelsindex_test.go
@@ -162,7 +162,7 @@ func TestModelsIndex(t *testing.T) {
 			cli := newFakeDockerClient(func(image string, cmd []string) (string, int) {
 				return "{\"event\":\"info\",\"downloading\":false}\n", 0
 			})
-			modelsIndex, err := Load(platform.GetPlatform(nil), paths.New("testdata"), paths.New("testdata/models"), nil, cli, config.Configuration{})
+			modelsIndex, err := Load(platform.GetPlatform(nil), paths.New("testdata"), paths.New(t.TempDir()), nil, cli, config.Configuration{})
 			require.NoError(t, err)
 
 			model, err := modelsIndex.GetModelByID(t.Context(), "a-model-not-preloaded-with-handler")
@@ -183,7 +183,7 @@ func TestModelsIndex(t *testing.T) {
 			cli := newFakeDockerClient(func(image string, cmd []string) (string, int) {
 				return "{\"event\":\"info\",\"downloading\":true}\n", 0
 			})
-			modelsIndex, err := Load(platform.GetPlatform(nil), paths.New("testdata"), paths.New("testdata/models"), nil, cli, config.Configuration{})
+			modelsIndex, err := Load(platform.GetPlatform(nil), paths.New("testdata"), paths.New(t.TempDir()), nil, cli, config.Configuration{})
 			require.NoError(t, err)
 
 			model, err := modelsIndex.GetModelByID(t.Context(), "a-model-not-preloaded-with-handler")
@@ -204,7 +204,7 @@ func TestModelsIndex(t *testing.T) {
 			cli := newFakeDockerClient(func(image string, cmd []string) (string, int) {
 				return "{\"event\":\"error\",\"description\":\"model not found\"}\n", 1
 			})
-			modelsIndex, err := Load(platform.GetPlatform(nil), paths.New("testdata"), paths.New("testdata/models"), nil, cli, config.Configuration{})
+			modelsIndex, err := Load(platform.GetPlatform(nil), paths.New("testdata"), paths.New(t.TempDir()), nil, cli, config.Configuration{})
 			require.NoError(t, err)
 
 			model, err := modelsIndex.GetModelByID(t.Context(), "a-model-not-preloaded-with-handler")

--- a/internal/orchestrator/modelsindex/testdata/models-handlers.yaml
+++ b/internal/orchestrator/modelsindex/testdata/models-handlers.yaml
@@ -1,14 +1,14 @@
 listing:
   image: test-registry/models-downloader:test
   volumes:
-    - ${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}:/models
+    - ${MODELS_PATH}:/models
   command: ["/app/list_models.sh"]
 handlers:
   - my-handler:
       description: "Handler for models from my"
       image: test-registry/models-downloader:test
       volumes:
-        - ${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}/${models_repository}:/models
+        - ${MODELS_PATH}/${models_repository}:/models
       actions:
         - download:
             command: ["/app/my/my_model_downloader.sh"]


### PR DESCRIPTION
> **Stacked on #581** — base is `fix/model-download-error-reporting`, so only the last commit belongs to this PR. Retarget to `main` once #581 merges.

Follow-up to #523. #581 makes a failed download report *what* went wrong; this stops the daemon causing one class of failure at all.

## The problem

`Run` pre-creates each bind mount's host directory and swallowed the error when it could not:

```go
if err := os.MkdirAll(hostPath, 0775); err != nil {
    slog.Warn("cannot pre-create bind mount directory", "path", hostPath, "err", err)
    continue                      // ← proceeds into a known-broken state
}
```

That pre-creation is the only thing preventing Docker from creating the path, and Docker runs as root. So when it fails:

1. the daemon (uid 1000) cannot create `<models>/<repo>` → `EACCES` → warned at a level the shipped unit filters out, then ignored
2. Docker creates the bind path itself, **root-owned `755`**
3. the container runs as the invoking user and cannot write to its own `/models`
4. the script dies with `PermissionError: [Errno 13] Permission denied: '/models/unsloth'`

The user is shown a path *inside the container* for a host problem, and step 2 leaves a root-owned directory that keeps failing until someone chowns it.

## The change

`ensureBindDirs` creates the directory, verifies it is writable by the user the container runs as, and returns an error naming the path, its owner and its mode. Read-only mounts only need to be readable.

`HandleInstallModel` now forwards the error from `GetModelByID` instead of replacing it with the fixed string `"unable to get model by ID"` — otherwise the diagnostic never reaches the caller. `HandlerModelByID` already forwarded `err.Error()`; the two were inconsistent.

## A stale fixture this uncovered

The new check failed three existing tests, for a real reason. `testdata/models-handlers.yaml` used `${ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR}`, which `loadHandlers` never puts in `configEnv` — only `DOCKER_REGISTRY_BASE`, `BOARD_NAME` and `MODELS_PATH`. Unset variables substitute to the empty string, so every bind in those tests resolved to `/`. They had been mounting the filesystem root. The same tests passed `paths.New("testdata/models")`, a directory that does not exist in the repo.

The fixture now uses `${MODELS_PATH}` as the shipped handlers do, and those tests get a real `t.TempDir()`.

Separately: `ResolveVars`' comment claims unknown variables are left unchanged, but compose-go substitutes `""` and returns no error, so any typo in a handler's `volumes` silently produces a wrong bind. Not addressed here.

## Testing

`dockerhelper_test.go` covers create-missing, exists-writable, cannot-create, exists-unwritable, read-only-unwritable and malformed binds, plus `:ro` parsing; permission cases skip under root. Validated on a UNO Q — evidence below.

`go build`, `go vet`, `gofmt` clean; `go test ./internal/...` passes except the pre-existing Docker-dependent `TestRemoveImage`.

## For reviewers

This makes a previously silent condition fatal. A board whose `/var/lib/arduino-app-cli/models` is already root-owned — the state the old code kept producing — will now fail loudly on listing and install instead of obscurely later. Intended, but a conscious call. The `chown` in `DEBIAN/postinst` only runs at install time, so an affected board needs `chown -R arduino:arduino /var/lib/arduino-app-cli` or a reinstall.
