### PR TITLE
fix(models): refuse a second download into the same directory

### DIFF
--- a/internal/api/handlers/ai_models.go
+++ b/internal/api/handlers/ai_models.go
@@ -194,6 +194,15 @@ func HandleInstallModel(dockerClient command.Cli, modelsIndex *modelsindex.Model
 			return
 		}
 
+		// Claimed before the stream is opened so a duplicate request gets a
+		// plain 409 rather than an error inside an SSE body.
+		release, acquired := modelsIndex.AcquireDownload(*model, plat)
+		if !acquired {
+			render.EncodeResponse(w, http.StatusConflict, models.ErrorResponse{Details: fmt.Sprintf("model %q is already being downloaded", id)})
+			return
+		}
+		defer release()
+
 		sseStream, err := render.NewSSEStream(r.Context(), w)
 		if err != nil {
 			slog.Error("unable to create SSE stream", slog.String("error", err.Error()))

--- a/internal/orchestrator/modelsindex/download_lock_test.go
+++ b/internal/orchestrator/modelsindex/download_lock_test.go
@@ -1,0 +1,106 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package modelsindex
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arduino/arduino-app-cli/internal/platform"
+)
+
+func modelWithVars(id, repo, dir string) AIModel {
+	return AIModel{
+		ID: id,
+		Deployment: &ModelDeployment{
+			Handler: "hf-handler",
+			Variables: []map[string]PlatformDeploymentConfig{
+				{"unoq": {Variables: map[string]string{
+					"models_repository": repo,
+					"model_directory":   dir,
+				}}},
+			},
+		},
+	}
+}
+
+func TestAcquireDownload(t *testing.T) {
+	plat := platform.Platform{BoardName: "unoq"}
+
+	t.Run("a second download of the same model is refused", func(t *testing.T) {
+		idx := &ModelsIndex{}
+		model := modelWithVars("llamacpp:Qwen3.5-0.8B-Q4_0", "llamacpp", "unsloth/Qwen3.5-0.8B-GGUF")
+
+		release, ok := idx.AcquireDownload(model, plat)
+		require.True(t, ok)
+
+		_, ok = idx.AcquireDownload(model, plat)
+		assert.False(t, ok, "the second download should be refused")
+
+		release()
+		_, ok = idx.AcquireDownload(model, plat)
+		assert.True(t, ok, "releasing should allow a retry")
+	})
+
+	// Every quantization of one repo is written into the same directory, so
+	// two different models can still collide.
+	t.Run("models sharing a repository directory collide", func(t *testing.T) {
+		idx := &ModelsIndex{}
+		q4 := modelWithVars("llamacpp:Qwen3.5-0.8B-Q4_0", "llamacpp", "unsloth/Qwen3.5-0.8B-GGUF")
+		q8 := modelWithVars("llamacpp:Qwen3.5-0.8B-Q8_0", "llamacpp", "unsloth/Qwen3.5-0.8B-GGUF")
+
+		_, ok := idx.AcquireDownload(q4, plat)
+		require.True(t, ok)
+		_, ok = idx.AcquireDownload(q8, plat)
+		assert.False(t, ok, "same directory, so it must be refused")
+	})
+
+	t.Run("models in different directories are independent", func(t *testing.T) {
+		idx := &ModelsIndex{}
+		a := modelWithVars("a", "llamacpp", "unsloth/Qwen3.5-0.8B-GGUF")
+		b := modelWithVars("b", "llamacpp", "google/gemma-3-1b-it-GGUF")
+
+		_, ok := idx.AcquireDownload(a, plat)
+		require.True(t, ok)
+		_, ok = idx.AcquireDownload(b, plat)
+		assert.True(t, ok)
+	})
+
+	t.Run("falls back to the model ID without deployment variables", func(t *testing.T) {
+		idx := &ModelsIndex{}
+		model := AIModel{ID: "custom-model"}
+
+		_, ok := idx.AcquireDownload(model, plat)
+		require.True(t, ok)
+		_, ok = idx.AcquireDownload(model, plat)
+		assert.False(t, ok)
+	})
+
+	t.Run("exactly one of many concurrent callers wins", func(t *testing.T) {
+		idx := &ModelsIndex{}
+		model := modelWithVars("m", "llamacpp", "unsloth/Qwen3.5-0.8B-GGUF")
+
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		won := 0
+		for range 20 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if _, ok := idx.AcquireDownload(model, plat); ok {
+					mu.Lock()
+					won++
+					mu.Unlock()
+				}
+			}()
+		}
+		wg.Wait()
+		assert.Equal(t, 1, won)
+	})
+}

--- a/internal/orchestrator/modelsindex/models_index.go
+++ b/internal/orchestrator/modelsindex/models_index.go
@@ -16,6 +16,7 @@ import (
 	"maps"
 	"slices"
 	"strconv"
+	"sync"
 	"syscall"
 
 	"github.com/docker/cli/cli/command"
@@ -120,6 +121,53 @@ type ModelsIndex struct {
 	Handlers        *HandlersIndex
 	cli             client.APIClient
 	plat            platform.Platform
+
+	mu          sync.Mutex
+	downloading map[string]struct{}
+}
+
+// AcquireDownload reserves the directory a model downloads into, returning a
+// release function and true, or false if a download into it is already running.
+//
+// The handler script cannot tell a live download from an interrupted one: it
+// treats the ".download" marker as stale, removes the directory and starts
+// over. A second run therefore deletes the first run's partial files while it
+// is still reading them, and both fail with ENOENT. Overlapping runs have to be
+// prevented here because the container cannot detect them itself.
+func (m *ModelsIndex) AcquireDownload(model AIModel, plat platform.Platform) (release func(), ok bool) {
+	key := downloadKey(model, plat)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, busy := m.downloading[key]; busy {
+		return nil, false
+	}
+	if m.downloading == nil {
+		m.downloading = make(map[string]struct{})
+	}
+	m.downloading[key] = struct{}{}
+
+	return func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		delete(m.downloading, key)
+	}, true
+}
+
+// downloadKey identifies the directory a model's download writes into. Models
+// sharing a repository share that directory - every quantization of one Hugging
+// Face repo lands in the same folder - so the directory, not the model ID, is
+// what must not be written to twice at once.
+func downloadKey(model AIModel, plat platform.Platform) string {
+	if model.Deployment == nil {
+		return model.ID
+	}
+	vars := model.Deployment.VariablesForPlatform(plat.BoardName)
+	repo, dir := vars["models_repository"], vars["model_directory"]
+	if repo == "" && dir == "" {
+		return model.ID
+	}
+	return repo + "/" + dir
 }
 
 func (m *ModelsIndex) GetModels(ctx context.Context) []AIModel {


### PR DESCRIPTION
> **Stacked on #583** (which is stacked on #581). Only the last commit belongs here. Retarget to `main` once the other two merge.

Fixes the cause behind the "download sticks at ~20%, container vanishes, no error" report. #581 and #583 make such a failure visible; this one stops it happening.

## Cause

Nothing prevents two installs of the same model running at once, and the handler script cannot detect the overlap. `hf_downloader.py` treats the `.download` marker as a stale attempt:

```python
# Per-repo ".download" marker: present => prior run killed mid-download,
# wipe and retry; absent but dir exists => already complete.
marker = Path(output_dir) / ".download"
if marker.is_file():
    emit_json_info(f"Removing incomplete previous download: {repo_id}")
    remove_model_dir(output_dir, args.output_dir)
```

The marker means "in progress **or** interrupted" — its own docstring says so — and those cannot be told apart from inside the container. So a second run deletes the first run's files while it is still reading them, and both die:

```
Download failed: [Errno 2] No such file or directory:
'/models/unsloth/Qwen3.5-0.8B-GGUF/.cache/huggingface/download/Mg3yf...'
```

Overlap comes from anything issuing a second install: a double click, the UI re-issuing on reconnect, or starting an app that needs a model already being fetched.

## Change

`AcquireDownload` reserves the target directory for the duration of the request; a duplicate gets 409, as an already-installed model does. It is taken before the SSE stream opens so the answer is a plain response rather than an error inside a stream body.

The key is the directory, not the model ID: every quantization of one repository is written into the same folder, so two *different* models can collide.

## Testing

`download_lock_test.go` covers refusal, release-then-retry, same-directory collision across different models, the no-deployment-variables fallback, and 20 concurrent callers under `-race`.

On a UNO Q, second install issued while the first was at 20%:

| | before | after |
|---|---|---|
| first stream | failed, ENOENT | completes, 98% → done |
| second stream | failed, ENOENT | `409 {"details":"model ... is already being downloaded"}` |
| on disk | 1 MB, nothing installed | 484 MB, model installed |

`go build`, `go vet`, `gofmt` clean; `go test ./internal/...` passes except the pre-existing Docker-dependent `TestRemoveImage`.

## Note

The guard is per-process, which matches the one daemon that owns the directory. It does not serialise two *different* repositories — those are independent and still download concurrently.
