### PR TITLE
fix: add arduino-router group to the container

### DIFF
--- a/debian/arduino-app-cli/DEBIAN/preinst
+++ b/debian/arduino-app-cli/DEBIAN/preinst
@@ -49,12 +49,3 @@ if [ "$1" = "upgrade" ]; then
     # remove it to cleanup stale files
     rm -rf /home/arduino/.local/share/arduino-app-cli/examples
 fi
-
-# Add the system user to the arduino-router group.
-# If the group does not exist, create it first.
-if ! getent group arduino-router >/dev/null; then
-    groupadd --system arduino-router || true
-fi
-if id -u "$username" >/dev/null 2>&1; then
-    usermod -a -G arduino-router "$username" || true
-fi

--- a/docs/user-documentation.md
+++ b/docs/user-documentation.md
@@ -16,6 +16,7 @@ The following environment variables are used to configure Arduino App CLI:
 | `ARDUINO_APP_CLI__DATA_DIR`            | `/var/lib/arduino-app-cli`                       | Path to the directory where internal data is stored (examples, assets, properties) |
 | `ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR` | `$HOME/.arduino-bricks/models`                   | Path to the directory where custom AI models are stored                            |
 | `ARDUINO_APP_CLI__ALLOW_ROOT`          | `false`                                          | Allow running `arduino-app-cli` as root (**Not recommended to set to true**)       |
+| `ARDUINO_APP_CLI__REQUIRED_RUNTIMES`   | `arduino-router:arduino-router,arduino-cloud-connector` | Comma separated list of host units whose socket is bind-mounted into the App containers, each in the form `<unit>[:<group>]` where the optional group is added to the container to access the socket |
 | `LIBRARIES_API_URL`                    | `https://api2.arduino.cc/libraries/v1/libraries` | URL of the external service used to search Arduino libraries                       |
 | `DOCKER_REGISTRY_BASE`                 | `ghcr.io/arduino/`                               | Docker registry used to pull docker images                                         |
 | `DOCKER_PYTHON_BASE_IMAGE`             | `app-bricks/python-apps-base:<RUNNER_VERSION>`   | Tag of the Docker image for the Python runner                                      |

--- a/docs/user-documentation.md
+++ b/docs/user-documentation.md
@@ -10,16 +10,16 @@ During the .deb installation, the package will check if an user with uid `1000` 
 
 The following environment variables are used to configure Arduino App CLI:
 
-| Environment Variable                   | Default Value                                    | Description                                                                        |
-| -------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| `ARDUINO_APP_CLI__APPS_DIR`            | `/home/arduino/ArduinoApps`                      | Path to the directory where Arduino Apps created by the user are stored            |
-| `ARDUINO_APP_CLI__DATA_DIR`            | `/var/lib/arduino-app-cli`                       | Path to the directory where internal data is stored (examples, assets, properties) |
-| `ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR` | `$HOME/.arduino-bricks/models`                   | Path to the directory where custom AI models are stored                            |
-| `ARDUINO_APP_CLI__ALLOW_ROOT`          | `false`                                          | Allow running `arduino-app-cli` as root (**Not recommended to set to true**)       |
+| Environment Variable                   | Default Value                                           | Description                                                                                                                                                                                          |
+| -------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ARDUINO_APP_CLI__APPS_DIR`            | `/home/arduino/ArduinoApps`                             | Path to the directory where Arduino Apps created by the user are stored                                                                                                                              |
+| `ARDUINO_APP_CLI__DATA_DIR`            | `/var/lib/arduino-app-cli`                              | Path to the directory where internal data is stored (examples, assets, properties)                                                                                                                   |
+| `ARDUINO_APP_BRICKS__CUSTOM_MODEL_DIR` | `$HOME/.arduino-bricks/models`                          | Path to the directory where custom AI models are stored                                                                                                                                              |
+| `ARDUINO_APP_CLI__ALLOW_ROOT`          | `false`                                                 | Allow running `arduino-app-cli` as root (**Not recommended to set to true**)                                                                                                                         |
 | `ARDUINO_APP_CLI__REQUIRED_RUNTIMES`   | `arduino-router:arduino-router,arduino-cloud-connector` | Comma separated list of host units whose socket is bind-mounted into the App containers, each in the form `<unit>[:<group>]` where the optional group is added to the container to access the socket |
-| `LIBRARIES_API_URL`                    | `https://api2.arduino.cc/libraries/v1/libraries` | URL of the external service used to search Arduino libraries                       |
-| `DOCKER_REGISTRY_BASE`                 | `ghcr.io/arduino/`                               | Docker registry used to pull docker images                                         |
-| `DOCKER_PYTHON_BASE_IMAGE`             | `app-bricks/python-apps-base:<RUNNER_VERSION>`   | Tag of the Docker image for the Python runner                                      |
+| `LIBRARIES_API_URL`                    | `https://api2.arduino.cc/libraries/v1/libraries`        | URL of the external service used to search Arduino libraries                                                                                                                                         |
+| `DOCKER_REGISTRY_BASE`                 | `ghcr.io/arduino/`                                      | Docker registry used to pull docker images                                                                                                                                                           |
+| `DOCKER_PYTHON_BASE_IMAGE`             | `app-bricks/python-apps-base:<RUNNER_VERSION>`          | Tag of the Docker image for the Python runner                                                                                                                                                        |
 
 ## Directory Structures
 

--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -80,7 +80,7 @@ func NewFromEnv() (Configuration, error) {
 	}
 	var requiredRuntimes []RequiredRuntime
 	for entry := range strings.SplitSeq(requiredRuntimesEnv, ",") {
-		unit, group, _ := strings.Cut(strings.TrimSpace(entry), ":")
+		unit, group, _ := strings.Cut(entry, ":")
 		if unit = strings.TrimSpace(unit); unit != "" {
 			requiredRuntimes = append(requiredRuntimes, RequiredRuntime{
 				Unit:  unit,

--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -27,7 +27,7 @@ var RunnerVersion = "0.12.0"
 type Configuration struct {
 	appsDir                          *paths.Path
 	dataDir                          *paths.Path
-	requiredRuntimes                 []string
+	requiredRuntimes                 []RequiredRuntime
 	customModelsDir                  *paths.Path
 	modelsDir                        *paths.Path
 	assetDir                         *paths.Path
@@ -39,6 +39,13 @@ type Configuration struct {
 	LibrariesAPIURL                  *url.URL
 	EdgeImpulseAPIURL                *url.URL
 	ArduinoPlatformVersionConstraint semver.Constraint
+}
+
+// RequiredRuntime is a host unit whose socket is bind-mounted into app
+// containers, together with the supplementary group needed to access it.
+type RequiredRuntime struct {
+	Unit  string
+	Group string
 }
 
 func NewFromEnv() (Configuration, error) {
@@ -65,14 +72,20 @@ func NewFromEnv() (Configuration, error) {
 	}
 
 	// Required host units bind-mounted as /run/<unit> into app containers.
+	// Each entry is `<unit>[:<group>]`, where the optional group is the host
+	// group required to access the unit socket.
 	requiredRuntimesEnv, ok := os.LookupEnv("ARDUINO_APP_CLI__REQUIRED_RUNTIMES")
 	if !ok {
-		requiredRuntimesEnv = "arduino-router,arduino-cloud-connector"
+		requiredRuntimesEnv = "arduino-router:arduino-router,arduino-cloud-connector"
 	}
-	var requiredRuntimes []string
-	for u := range strings.SplitSeq(requiredRuntimesEnv, ",") {
-		if u = strings.TrimSpace(u); u != "" {
-			requiredRuntimes = append(requiredRuntimes, u)
+	var requiredRuntimes []RequiredRuntime
+	for entry := range strings.SplitSeq(requiredRuntimesEnv, ",") {
+		unit, group, _ := strings.Cut(strings.TrimSpace(entry), ":")
+		if unit = strings.TrimSpace(unit); unit != "" {
+			requiredRuntimes = append(requiredRuntimes, RequiredRuntime{
+				Unit:  unit,
+				Group: strings.TrimSpace(group),
+			})
 		}
 	}
 
@@ -198,28 +211,41 @@ func (c *Configuration) ExamplesDirs(platform platform.Platform) paths.PathList 
 	return paths.PathList{c.ExamplesBaseDir().Join("inspirational").Join("common")}
 }
 
-// RequiredRuntimesPaths returns the discovered host paths for configured required
-// units, searching in order: /run/<unit>, /var/run/<unit>, /run/<unit>.sock,
+type ResolvedRequiredRuntime struct {
+	Path  *paths.Path
+	Group string
+}
+
+// RequiredRuntimes returns the configured required units that are available on
+// the host, each paired with the group needed to access its socket. The socket
+// path is searched in order: /run/<unit>, /var/run/<unit>, /run/<unit>.sock,
 // /var/run/<unit>.sock. The first existing entry per unit is returned.
-func (c *Configuration) RequiredRuntimesPaths() paths.PathList {
-	var result paths.PathList
+func (c *Configuration) RequiredRuntimes() []ResolvedRequiredRuntime {
+	var result []ResolvedRequiredRuntime
+	seen := map[string]bool{}
 	for _, runtime := range c.requiredRuntimes {
 		candidates := []*paths.Path{
-			paths.New("/run", runtime),
-			paths.New("/var/run", runtime),
-			paths.New("/run", runtime+".sock"),
-			paths.New("/var/run", runtime+".sock"),
+			paths.New("/run", runtime.Unit),
+			paths.New("/var/run", runtime.Unit),
+			paths.New("/run", runtime.Unit+".sock"),
+			paths.New("/var/run", runtime.Unit+".sock"),
 		}
 		found := false
 		for _, p := range candidates {
 			if p.Exist() {
-				result.AddIfMissing(p)
+				if !seen[p.String()] {
+					seen[p.String()] = true
+					result = append(result, ResolvedRequiredRuntime{
+						Path:  p,
+						Group: runtime.Group,
+					})
+				}
 				found = true
 				break
 			}
 		}
 		if !found {
-			slog.Debug("required runtime not found on host", "runtime", runtime)
+			slog.Debug("required runtime not found on host", "runtime", runtime.Unit)
 		}
 	}
 	return result

--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -341,12 +341,18 @@ func generateMainComposeFile(
 		},
 	}
 
-	for _, p := range cfg.RequiredRuntimesPaths() {
+	// Bind-mount the required runtime sockets and collect the groups needed to
+	// access them.
+	var runtimeGroupNames []string
+	for _, runtime := range cfg.RequiredRuntimes() {
 		volumes = append(volumes, volume{
 			Type:   "bind",
-			Source: p.String(),
-			Target: p.String(),
+			Source: runtime.Path.String(),
+			Target: runtime.Path.String(),
 		})
+		if runtime.Group != "" {
+			runtimeGroupNames = append(runtimeGroupNames, runtime.Group)
+		}
 	}
 
 	// camx CSI cameras are accessed through the cam_server socket and a host userspace library
@@ -359,6 +365,8 @@ func generateMainComposeFile(
 
 	volumes = addLedControl(platform, volumes)
 	groups := lookupGroups("video", "audio", "render", "dialout")
+	// Access to the required runtime sockets
+	groups = append(groups, lookupGroups(runtimeGroupNames...)...)
 	// Support for NPU
 	groups = append(groups, lookupGroups("fastrpc", "dmaheap")...)
 	// Support GPIO access


### PR DESCRIPTION
### Motivation

After the arduno-rotuer narrow permission, we need to allow the container to talk with the arduino-router

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
