### PR TITLE
feat: emit error on port collisions when starting an app

### DIFF
--- a/internal/composefile/composefile.go
+++ b/internal/composefile/composefile.go
@@ -1,0 +1,53 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package composefile provides helpers to inspect Docker Compose files without
+// contacting the Docker daemon.
+package composefile
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/arduino/go-paths-helper"
+	"github.com/compose-spec/compose-go/v2/loader"
+	"github.com/compose-spec/compose-go/v2/types"
+)
+
+// ExtractPorts returns the host ports published by every service declared in the given
+// compose file. When a service does not publish a port explicitly, the target port is
+// reported instead.
+func ExtractPorts(composeFile *paths.Path) ([]string, error) {
+	content, err := composeFile.ReadFile()
+	if err != nil {
+		return nil, err
+	}
+
+	prj, err := loader.LoadWithContext(
+		context.Background(),
+		types.ConfigDetails{
+			ConfigFiles: []types.ConfigFile{{Content: content}},
+			Environment: types.NewMapping(os.Environ()),
+		},
+		func(o *loader.Options) { o.SetProjectName("default", false); o.SkipConsistencyCheck = true },
+		loader.WithSkipValidation,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var ports []string
+	for _, svc := range prj.Services {
+		for _, p := range svc.Ports {
+			if p.Published != "" {
+				ports = append(ports, p.Published)
+			} else {
+				ports = append(ports, fmt.Sprintf("%d", p.Target))
+			}
+		}
+	}
+	return ports, nil
+}

--- a/internal/composefile/composefile_test.go
+++ b/internal/composefile/composefile_test.go
@@ -1,0 +1,92 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package composefile
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/arduino/go-paths-helper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractPorts(t *testing.T) {
+	testCases := []struct {
+		name      string
+		content   string
+		want      []string
+		expectErr bool
+	}{
+		{
+			name: "basic",
+			content: `
+version: "3"
+services:
+  web:
+    ports:
+      - "8080:80"
+      - "443:443"
+  db:
+    ports:
+      - "5432"
+      - "127.0.0.1:15432:5432"
+  cache:
+    ports:
+      - "6379"
+      - "6380:6380"
+  multi:
+    ports:
+      - "0.0.0.0:9000:9000/tcp"
+      - "10000:10000"
+`,
+			want:      []string{"8080", "443", "5432", "15432", "6379", "6380", "9000", "10000"},
+			expectErr: false,
+		},
+		{
+			name: "no_ports",
+			content: `
+version: "3"
+services:
+  web:
+    image: nginx
+  db:
+    image: postgres
+`,
+			want:      nil,
+			expectErr: false,
+		},
+		{
+			name: "invalid_yaml",
+			content: `
+version: "3"
+services
+  web:
+    ports: [8080:80]
+`,
+			want:      nil,
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpFile := paths.New(t.TempDir()).Join("compose.yaml")
+			err := tmpFile.WriteFile([]byte(tc.content))
+			require.NoError(t, err)
+
+			got, err := ExtractPorts(tmpFile)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				slices.Sort(tc.want)
+				slices.Sort(got)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/e2e/daemon/ai_models_handler_test.go
+++ b/internal/e2e/daemon/ai_models_handler_test.go
@@ -6,15 +6,11 @@
 package daemon
 
 import (
-	"bufio"
 	"cmp"
 	"context"
-	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -97,57 +93,6 @@ func TestModelHandlerDownloadFlow(t *testing.T) {
 		require.NotNil(t, resp.JSON200)
 		require.Equal(t, "not-installed", *resp.JSON200.Status, "model should not be installed after delete")
 	})
-}
-
-func newSSEClient(req *http.Request, lastEventID int64) (events chan Event, err error) {
-
-	if lastEventID > 0 {
-		req.Header.Set("Last-Event-ID", fmt.Sprintf("%d", lastEventID))
-	}
-	resp, err := http.DefaultClient.Do(req) //nolint
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("got response status code %d", resp.StatusCode)
-	}
-	events = make(chan Event)
-	go loop(resp.Body, events)
-	return events, nil
-}
-
-type Event struct {
-	ID    string
-	Event string
-	Data  []byte // json
-}
-
-func loop(r io.ReadCloser, events chan Event) {
-	defer r.Close()
-	reader := bufio.NewReader(r)
-
-	evt := Event{}
-	for {
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			close(events)
-			return
-		}
-		switch {
-		case strings.HasPrefix(line, "data:"):
-			evt.Data = []byte(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
-		case strings.HasPrefix(line, "event:"):
-			evt.Event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
-		case strings.HasPrefix(line, "id:"):
-			evt.ID = strings.TrimSpace(strings.TrimPrefix(line, "id:"))
-		case strings.HasPrefix(line, "\n"):
-			events <- evt
-		default:
-			fmt.Fprintf(os.Stderr, "Unknown line: '%s'", line)
-			close(events)
-		}
-	}
 }
 
 // getModelWithRetry retries GetAIModelDetailsWithResponse up to 5 times with a 1s

--- a/internal/e2e/daemon/app_port_collision_test.go
+++ b/internal/e2e/daemon/app_port_collision_test.go
@@ -1,0 +1,78 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arduino/arduino-app-cli/internal/e2e/client"
+)
+
+// TestAppStartPortCollision checks that an app declaring the same port from more than one
+// source is refused before the start does any real work. Both arduino:web_ui and
+// arduino:streamlit_ui declare port 7000, so an app using both cannot expose them all.
+//
+// The collision is detected before any Docker call, so this test never needs a running
+// Docker daemon nor any image.
+func TestAppStartPortCollision(t *testing.T) {
+	httpClient, daemonAddr := GetHttpclientAndAddr(t)
+	noEditor := func(ctx context.Context, req *http.Request) error { return nil }
+
+	createResp, err := httpClient.CreateAppWithResponse(
+		t.Context(),
+		&client.CreateAppParams{SkipSketch: new(true)},
+		client.CreateAppRequest{
+			Icon: new("💻"),
+			Name: "port-collision-app",
+		},
+		noEditor,
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode())
+	require.NotNil(t, createResp.JSON201)
+	appID := *createResp.JSON201.Id
+
+	for _, brickID := range []string{"arduino:web_ui", "arduino:streamlit_ui"} {
+		respBrick, err := httpClient.UpsertAppBrickInstanceWithResponse(
+			t.Context(), appID, brickID, client.BrickCreateUpdateRequest{}, noEditor,
+		)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, respBrick.StatusCode(), "failed to add brick %s", brickID)
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, daemonAddr+"/v1/apps/"+appID+"/start", nil)
+	require.NoError(t, err)
+	events, err := newSSEClient(req, 0)
+	require.NoError(t, err)
+
+	var errorMessages []string
+	for e := range events {
+		t.Log("Received SSE event", "event", e.Event, "data", string(e.Data))
+		if e.Event != "error" {
+			continue
+		}
+		var payload struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		}
+		require.NoError(t, json.Unmarshal(e.Data, &payload))
+		if payload.Code == "SERVER_CLOSED" {
+			// Emitted when the stream is torn down, not a failure of the start itself.
+			continue
+		}
+		errorMessages = append(errorMessages, payload.Message)
+	}
+
+	require.Len(t, errorMessages, 1, "expected the start to fail with a single error")
+	require.Contains(t, errorMessages[0], "port 7000 is declared by more than one source")
+	require.Contains(t, errorMessages[0], "arduino:web_ui")
+	require.Contains(t, errorMessages[0], "arduino:streamlit_ui")
+}

--- a/internal/e2e/daemon/app_port_collision_test.go
+++ b/internal/e2e/daemon/app_port_collision_test.go
@@ -27,7 +27,7 @@ func TestAppStartPortCollision(t *testing.T) {
 		message := startAppAndExpectError(t, httpClient, daemonAddr, "python-runner-collision",
 			"arduino:web_ui", "arduino:streamlit_ui")
 
-		require.Contains(t, message, "port 7000 is declared by more than one source")
+		require.Contains(t, message, "port 7000 is declared by multiple sources")
 		require.Contains(t, message, "arduino:web_ui")
 		require.Contains(t, message, "arduino:streamlit_ui")
 	})
@@ -38,7 +38,7 @@ func TestAppStartPortCollision(t *testing.T) {
 		message := startAppAndExpectError(t, httpClient, daemonAddr, "collision-between-containers",
 			"arduino:video_image_classification", "arduino:video_object_detection")
 
-		require.Contains(t, message, "port 4912 is declared by more than one source")
+		require.Contains(t, message, "port 4912 is declared by multiple sources")
 		require.Contains(t, message, "arduino:video_image_classification")
 		require.Contains(t, message, "arduino:video_object_detection")
 	})

--- a/internal/e2e/daemon/app_port_collision_test.go
+++ b/internal/e2e/daemon/app_port_collision_test.go
@@ -17,22 +17,47 @@ import (
 )
 
 // TestAppStartPortCollision checks that an app declaring the same port from more than one
-// source is refused before the start does any real work. Both arduino:web_ui and
-// arduino:streamlit_ui declare port 7000, so an app using both cannot expose them all.
-//
-// The collision is detected before any Docker call, so this test never needs a running
-// Docker daemon nor any image.
+// source is refused, and that the error names every source involved.
+
 func TestAppStartPortCollision(t *testing.T) {
 	httpClient, daemonAddr := GetHttpclientAndAddr(t)
+
+	// arduino:web_ui and arduino:streamlit_ui both declare port 7000 in the brick index.
+	t.Run("bricks running inside python runner", func(t *testing.T) {
+		message := startAppAndExpectError(t, httpClient, daemonAddr, "python-runner-collision",
+			"arduino:web_ui", "arduino:streamlit_ui")
+
+		require.Contains(t, message, "port 7000 is declared by more than one source")
+		require.Contains(t, message, "arduino:web_ui")
+		require.Contains(t, message, "arduino:streamlit_ui")
+	})
+
+	// arduino:video_image_classification and arduino:video_object_detection publish host port
+	// 4912 from their own brick_compose.yaml.
+	t.Run("bricks running in their own containers", func(t *testing.T) {
+		message := startAppAndExpectError(t, httpClient, daemonAddr, "collision-between-containers",
+			"arduino:video_image_classification", "arduino:video_object_detection")
+
+		require.Contains(t, message, "port 4912 is declared by more than one source")
+		require.Contains(t, message, "arduino:video_image_classification")
+		require.Contains(t, message, "arduino:video_object_detection")
+	})
+}
+
+func startAppAndExpectError(
+	t *testing.T,
+	httpClient *client.ClientWithResponses,
+	daemonAddr string,
+	appName string,
+	brickIDs ...string,
+) string {
+	t.Helper()
 	noEditor := func(ctx context.Context, req *http.Request) error { return nil }
 
 	createResp, err := httpClient.CreateAppWithResponse(
 		t.Context(),
 		&client.CreateAppParams{SkipSketch: new(true)},
-		client.CreateAppRequest{
-			Icon: new("💻"),
-			Name: "port-collision-app",
-		},
+		client.CreateAppRequest{Icon: new("💻"), Name: appName},
 		noEditor,
 	)
 	require.NoError(t, err)
@@ -40,7 +65,7 @@ func TestAppStartPortCollision(t *testing.T) {
 	require.NotNil(t, createResp.JSON201)
 	appID := *createResp.JSON201.Id
 
-	for _, brickID := range []string{"arduino:web_ui", "arduino:streamlit_ui"} {
+	for _, brickID := range brickIDs {
 		respBrick, err := httpClient.UpsertAppBrickInstanceWithResponse(
 			t.Context(), appID, brickID, client.BrickCreateUpdateRequest{}, noEditor,
 		)
@@ -72,7 +97,5 @@ func TestAppStartPortCollision(t *testing.T) {
 	}
 
 	require.Len(t, errorMessages, 1, "expected the start to fail with a single error")
-	require.Contains(t, errorMessages[0], "port 7000 is declared by more than one source")
-	require.Contains(t, errorMessages[0], "arduino:web_ui")
-	require.Contains(t, errorMessages[0], "arduino:streamlit_ui")
+	return errorMessages[0]
 }

--- a/internal/e2e/daemon/setup.go
+++ b/internal/e2e/daemon/setup.go
@@ -6,6 +6,12 @@
 package daemon
 
 import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,4 +35,55 @@ func GetHttpclientAndAddr(t *testing.T, opts ...e2e.ArduinoAppCLIOption) (*clien
 	httpClient, err := client.NewClientWithResponses(cli.DaemonAddr)
 	require.NoError(t, err)
 	return httpClient, cli.DaemonAddr
+}
+
+func newSSEClient(req *http.Request, lastEventID int64) (events chan Event, err error) {
+
+	if lastEventID > 0 {
+		req.Header.Set("Last-Event-ID", fmt.Sprintf("%d", lastEventID))
+	}
+	resp, err := http.DefaultClient.Do(req) //nolint
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("got response status code %d", resp.StatusCode)
+	}
+	events = make(chan Event)
+	go loop(resp.Body, events)
+	return events, nil
+}
+
+type Event struct {
+	ID    string
+	Event string
+	Data  []byte // json
+}
+
+func loop(r io.ReadCloser, events chan Event) {
+	defer r.Close()
+	reader := bufio.NewReader(r)
+
+	evt := Event{}
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			close(events)
+			return
+		}
+		switch {
+		case strings.HasPrefix(line, "data:"):
+			evt.Data = []byte(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		case strings.HasPrefix(line, "event:"):
+			evt.Event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "id:"):
+			evt.ID = strings.TrimSpace(strings.TrimPrefix(line, "id:"))
+		case strings.HasPrefix(line, "\n"):
+			events <- evt
+		default:
+			fmt.Fprintf(os.Stderr, "Unknown line: '%s'", line)
+			close(events)
+		}
+	}
 }

--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -6,7 +6,6 @@
 package bricksindex
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -18,11 +17,10 @@ import (
 	"strings"
 
 	"github.com/arduino/go-paths-helper"
-	"github.com/compose-spec/compose-go/v2/loader"
-	"github.com/compose-spec/compose-go/v2/types"
 	yaml "github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/ast"
 
+	"github.com/arduino/arduino-app-cli/internal/composefile"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/peripherals"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
@@ -280,7 +278,7 @@ func Load(platform platform.Platform, path *paths.Path) (*BricksIndex, error) {
 
 		// Extract ports from the compose file if it exists
 		if composeFile, ok := yamlIndex.Bricks[i].GetComposeFile(); ok {
-			if ports, err := extractPortsFromComposeFile(composeFile); err == nil {
+			if ports, err := composefile.ExtractPorts(composeFile); err == nil {
 				yamlIndex.Bricks[i].containerPorts = ports
 			} else {
 				slog.Warn("cannot extract ports from compose file, skipping", "brick_id", yamlIndex.Bricks[i].ID, "error", err)
@@ -315,36 +313,4 @@ func ParseBrickID(brickID string) (namespace, name string, err error) {
 		return "", "", errors.New("invalid ID")
 	}
 	return namespace, brickName, nil
-}
-
-func extractPortsFromComposeFile(composeFile *paths.Path) ([]string, error) {
-	content, err := composeFile.ReadFile()
-	if err != nil {
-		return nil, err
-	}
-
-	prj, err := loader.LoadWithContext(
-		context.Background(),
-		types.ConfigDetails{
-			ConfigFiles: []types.ConfigFile{{Content: content}},
-			Environment: types.NewMapping(os.Environ()),
-		},
-		func(o *loader.Options) { o.SetProjectName("default", false); o.SkipConsistencyCheck = true },
-		loader.WithSkipValidation,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	var ports []string
-	for _, svc := range prj.Services {
-		for _, p := range svc.Ports {
-			if p.Published != "" {
-				ports = append(ports, p.Published)
-			} else {
-				ports = append(ports, fmt.Sprintf("%d", p.Target))
-			}
-		}
-	}
-	return ports, nil
 }

--- a/internal/orchestrator/bricksindex/bricks_index_test.go
+++ b/internal/orchestrator/bricksindex/bricks_index_test.go
@@ -7,7 +7,6 @@ package bricksindex
 
 import (
 	"os"
-	"slices"
 	"testing"
 
 	"github.com/arduino/go-paths-helper"
@@ -485,83 +484,6 @@ func TestListBricksSupportedBoard(t *testing.T) {
 			got := b.ListBricks()
 			for i := range got {
 				require.Equal(t, tt.wantBricks[i].ID, got[i].ID)
-			}
-		})
-	}
-}
-
-func TestExtractPortsFromComposeFile(t *testing.T) {
-	testCases := []struct {
-		name      string
-		content   string
-		want      []string
-		expectErr bool
-	}{
-		{
-			name: "basic",
-			content: `
-version: "3"
-services:
-  web:
-    ports:
-      - "8080:80"
-      - "443:443"
-  db:
-    ports:
-      - "5432"
-      - "127.0.0.1:15432:5432"
-  cache:
-    ports:
-      - "6379"
-      - "6380:6380"
-  multi:
-    ports:
-      - "0.0.0.0:9000:9000/tcp"
-      - "10000:10000"
-`,
-			want:      []string{"8080", "443", "5432", "15432", "6379", "6380", "9000", "10000"},
-			expectErr: false,
-		},
-		{
-			name: "no_ports",
-			content: `
-version: "3"
-services:
-  web:
-    image: nginx
-  db:
-    image: postgres
-`,
-			want:      nil,
-			expectErr: false,
-		},
-		{
-			name: "invalid_yaml",
-			content: `
-version: "3"
-services
-  web:
-    ports: [8080:80]
-`,
-			want:      nil,
-			expectErr: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tmpFile := paths.New(t.TempDir()).Join("compose.yaml")
-			err := tmpFile.WriteFile([]byte(tc.content))
-			require.NoError(t, err)
-
-			got, err := extractPortsFromComposeFile(tmpFile)
-			if tc.expectErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				slices.Sort(tc.want)
-				slices.Sort(got)
-				assert.Equal(t, tc.want, got)
 			}
 		})
 	}

--- a/internal/orchestrator/check.go
+++ b/internal/orchestrator/check.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"maps"
 	"slices"
+	"strconv"
 
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
@@ -69,6 +70,48 @@ func checkBricks(ctx context.Context, bricks []app.Brick, index *bricksindex.Bri
 	}
 
 	return allErrors
+}
+
+// appPortsSource is the collision source name used for the ports declared in the app.yaml file.
+const appPortsSource = "app.yaml"
+
+// portCollision is a port declared by more than one source.
+type portCollision struct {
+	Port    string
+	Sources []string
+}
+
+func detectPortCollisions(appPorts []int, bricks []app.Brick, index *bricksindex.BricksIndex) []portCollision {
+	sourcesByPort := make(map[string][]string)
+	addSource := func(port, source string) {
+		if !slices.Contains(sourcesByPort[port], source) {
+			sourcesByPort[port] = append(sourcesByPort[port], source)
+		}
+	}
+
+	for _, p := range appPorts {
+		addSource(strconv.Itoa(p), appPortsSource)
+	}
+
+	for _, appBrick := range bricks {
+		indexBrick, found := index.FindBrickByID(appBrick.ID)
+		if !found {
+			continue
+		}
+
+		for _, p := range indexBrick.GetPorts() {
+			addSource(p, appBrick.ID)
+		}
+	}
+
+	var collisions []portCollision
+	for _, p := range slices.Sorted(maps.Keys(sourcesByPort)) {
+		if len(sourcesByPort[p]) > 1 {
+			collisions = append(collisions, portCollision{Port: p, Sources: sourcesByPort[p]})
+		}
+	}
+
+	return collisions
 }
 
 // requiredDeviceClasses returns the sorted device classes required by the app bricks, skipping the

--- a/internal/orchestrator/check.go
+++ b/internal/orchestrator/check.go
@@ -14,6 +14,7 @@ import (
 	"maps"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
@@ -112,6 +113,20 @@ func detectPortCollisions(appPorts []int, bricks []app.Brick, index *bricksindex
 	}
 
 	return collisions
+}
+
+// checkPortCollisions validates that no port is declared by more than one source of the app.
+// Errors are joined so every collision is reported at once.
+func checkPortCollisions(appPorts []int, bricks []app.Brick, index *bricksindex.BricksIndex) error {
+	var allErrors error
+	for _, collision := range detectPortCollisions(appPorts, bricks, index) {
+		slog.Error("port collision detected", slog.String("port", collision.Port), slog.Any("sources", collision.Sources))
+		allErrors = errors.Join(allErrors, fmt.Errorf(
+			"port %s is declared by more than one source (%s)", collision.Port, strings.Join(collision.Sources, ", "),
+		))
+	}
+
+	return allErrors
 }
 
 // requiredDeviceClasses returns the sorted device classes required by the app bricks, skipping the

--- a/internal/orchestrator/check.go
+++ b/internal/orchestrator/check.go
@@ -77,18 +77,24 @@ func checkBricks(ctx context.Context, bricks []app.Brick, index *bricksindex.Bri
 // appPortsSource is the collision source name used for the ports declared in the app.yaml file.
 const appPortsSource = "app.yaml"
 
-// portCollision is a port declared by more than one source.
-type portCollision struct {
-	Port    string
-	Sources []string
+// requiredService is a singleton service pulled in by an app brick. The brick that required it is
+// kept around because services are not a concept exposed to the user: collisions are reported
+// against the brick, not against the service.
+type requiredService struct {
+	name    string
+	brickID string
+	ports   []string
 }
 
-func detectPortCollisions(
-	appPorts []int,
-	bricks []app.Brick,
+// checkPortCollisions validates that no port is declared by more than one source of the app: the
+// ports field of app.yaml, the brick index, the brick compose files, and the compose files of the
+// services required by the bricks.
+// Errors are joined so that every collision is reported at once.
+func checkPortCollisions(
+	descriptor app.AppDescriptor,
 	index *bricksindex.BricksIndex,
-	servicePorts map[string][]string,
-) []portCollision {
+	servicesIndex *servicesindex.ServicesIndex,
+) error {
 	sourcesByPort := make(map[string][]string)
 	addSource := func(port, source string) {
 		if !slices.Contains(sourcesByPort[port], source) {
@@ -96,11 +102,10 @@ func detectPortCollisions(
 		}
 	}
 
-	for _, p := range appPorts {
-		addSource(strconv.Itoa(p), appPortsSource)
-	}
-
-	for _, appBrick := range bricks {
+	// A service can be required by more than one brick, but it is started once and publishes its
+	// ports once: collect the services first, keyed by ID, so that they count as a single source.
+	services := make(map[string]requiredService)
+	for _, appBrick := range descriptor.Bricks {
 		indexBrick, found := index.FindBrickByID(appBrick.ID)
 		if !found {
 			continue
@@ -109,83 +114,48 @@ func detectPortCollisions(
 		for _, p := range indexBrick.GetPorts() {
 			addSource(p, appBrick.ID)
 		}
-	}
-
-	for _, id := range slices.Sorted(maps.Keys(servicePorts)) {
-		for _, p := range servicePorts[id] {
-			addSource(p, id)
-		}
-	}
-
-	var collisions []portCollision
-	for _, p := range slices.Sorted(maps.Keys(sourcesByPort)) {
-		if len(sourcesByPort[p]) > 1 {
-			collisions = append(collisions, portCollision{Port: p, Sources: sourcesByPort[p]})
-		}
-	}
-
-	return collisions
-}
-
-// checkPortCollisions validates that no port is declared by more than one source of the app.
-// Errors are joined so every collision is reported at once.
-func checkPortCollisions(
-	appPorts []int,
-	bricks []app.Brick,
-	index *bricksindex.BricksIndex,
-	servicesIndex *servicesindex.ServicesIndex,
-) error {
-	services, err := requiredServices(index, servicesIndex, bricks)
-	if err != nil {
-		return err
-	}
-
-	servicePorts := make(map[string][]string, len(services))
-	for id, service := range services {
-		servicePorts[id] = service.GetPorts()
-	}
-
-	var allErrors error
-	for _, collision := range detectPortCollisions(appPorts, bricks, index, servicePorts) {
-		slog.Error("port collision detected", slog.String("port", collision.Port), slog.Any("sources", collision.Sources))
-		allErrors = errors.Join(allErrors, fmt.Errorf(
-			"port %s is declared by more than one source (%s)", collision.Port, strings.Join(collision.Sources, ", "),
-		))
-	}
-
-	return allErrors
-}
-
-func requiredServices(
-	bricksIndex *bricksindex.BricksIndex,
-	servicesIndex *servicesindex.ServicesIndex,
-	appBricks []app.Brick,
-) (map[string]servicesindex.Service, error) {
-	services := make(map[string]servicesindex.Service)
-	for _, appBrick := range appBricks {
-		indexBrick, found := bricksIndex.FindBrickByID(appBrick.ID)
-		if !found {
-			continue
-		}
 
 		matchingServices, err := indexBrick.GetMatchingService(bricksindex.BrickInstance{
 			Model: cmp.Or(appBrick.Model, indexBrick.ModelName),
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to get required services for brick %s: %w", appBrick.ID, err)
+			return fmt.Errorf("failed to get required services for brick %s: %w", appBrick.ID, err)
 		}
 
 		for _, id := range matchingServices {
+			if _, alreadyRequired := services[id]; alreadyRequired {
+				continue
+			}
 			service, found := servicesIndex.FindServiceByID(id)
 			if !found {
 				slog.Debug("service required by brick not found or not available for current board", slog.String("service_id", id), slog.String("brick_id", appBrick.ID))
 				continue
 			}
-			services[id] = *service
+			services[id] = requiredService{name: service.Name, brickID: appBrick.ID, ports: service.GetPorts()}
 		}
 	}
 
-	return services, nil
+	for _, id := range slices.Sorted(maps.Keys(services)) {
+		service := services[id]
+		for _, p := range service.ports {
+			addSource(p, fmt.Sprintf("%s (service %s)", service.brickID, service.name))
+		}
+	}
+
+	for _, p := range descriptor.Ports {
+		addSource(strconv.Itoa(p), appPortsSource)
+	}
+
+	var allErrors error
+	for _, p := range slices.Sorted(maps.Keys(sourcesByPort)) {
+		if len(sourcesByPort[p]) > 1 {
+			allErrors = errors.Join(allErrors, fmt.Errorf(
+				"port %s is declared by multiple sources: %s", p, strings.Join(sourcesByPort[p], ", "),
+			))
+		}
+	}
+
+	return allErrors
 }
 
 // requiredDeviceClasses returns the sorted device classes required by the app bricks, skipping the

--- a/internal/orchestrator/check.go
+++ b/internal/orchestrator/check.go
@@ -20,6 +20,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/peripherals"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 )
 
 // checkBricks validates that each app brick exists in the index, that its selected model (when
@@ -82,7 +83,12 @@ type portCollision struct {
 	Sources []string
 }
 
-func detectPortCollisions(appPorts []int, bricks []app.Brick, index *bricksindex.BricksIndex) []portCollision {
+func detectPortCollisions(
+	appPorts []int,
+	bricks []app.Brick,
+	index *bricksindex.BricksIndex,
+	servicePorts map[string][]string,
+) []portCollision {
 	sourcesByPort := make(map[string][]string)
 	addSource := func(port, source string) {
 		if !slices.Contains(sourcesByPort[port], source) {
@@ -105,6 +111,12 @@ func detectPortCollisions(appPorts []int, bricks []app.Brick, index *bricksindex
 		}
 	}
 
+	for _, id := range slices.Sorted(maps.Keys(servicePorts)) {
+		for _, p := range servicePorts[id] {
+			addSource(p, id)
+		}
+	}
+
 	var collisions []portCollision
 	for _, p := range slices.Sorted(maps.Keys(sourcesByPort)) {
 		if len(sourcesByPort[p]) > 1 {
@@ -117,9 +129,24 @@ func detectPortCollisions(appPorts []int, bricks []app.Brick, index *bricksindex
 
 // checkPortCollisions validates that no port is declared by more than one source of the app.
 // Errors are joined so every collision is reported at once.
-func checkPortCollisions(appPorts []int, bricks []app.Brick, index *bricksindex.BricksIndex) error {
+func checkPortCollisions(
+	appPorts []int,
+	bricks []app.Brick,
+	index *bricksindex.BricksIndex,
+	servicesIndex *servicesindex.ServicesIndex,
+) error {
+	services, err := requiredServices(index, servicesIndex, bricks)
+	if err != nil {
+		return err
+	}
+
+	servicePorts := make(map[string][]string, len(services))
+	for id, service := range services {
+		servicePorts[id] = service.GetPorts()
+	}
+
 	var allErrors error
-	for _, collision := range detectPortCollisions(appPorts, bricks, index) {
+	for _, collision := range detectPortCollisions(appPorts, bricks, index, servicePorts) {
 		slog.Error("port collision detected", slog.String("port", collision.Port), slog.Any("sources", collision.Sources))
 		allErrors = errors.Join(allErrors, fmt.Errorf(
 			"port %s is declared by more than one source (%s)", collision.Port, strings.Join(collision.Sources, ", "),
@@ -127,6 +154,38 @@ func checkPortCollisions(appPorts []int, bricks []app.Brick, index *bricksindex.
 	}
 
 	return allErrors
+}
+
+func requiredServices(
+	bricksIndex *bricksindex.BricksIndex,
+	servicesIndex *servicesindex.ServicesIndex,
+	appBricks []app.Brick,
+) (map[string]servicesindex.Service, error) {
+	services := make(map[string]servicesindex.Service)
+	for _, appBrick := range appBricks {
+		indexBrick, found := bricksIndex.FindBrickByID(appBrick.ID)
+		if !found {
+			continue
+		}
+
+		matchingServices, err := indexBrick.GetMatchingService(bricksindex.BrickInstance{
+			Model: cmp.Or(appBrick.Model, indexBrick.ModelName),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get required services for brick %s: %w", appBrick.ID, err)
+		}
+
+		for _, id := range matchingServices {
+			service, found := servicesIndex.FindServiceByID(id)
+			if !found {
+				slog.Debug("service required by brick not found or not available for current board", slog.String("service_id", id), slog.String("brick_id", appBrick.ID))
+				continue
+			}
+			services[id] = *service
+		}
+	}
+
+	return services, nil
 }
 
 // requiredDeviceClasses returns the sorted device classes required by the app bricks, skipping the

--- a/internal/orchestrator/check_test.go
+++ b/internal/orchestrator/check_test.go
@@ -625,3 +625,54 @@ func TestDetectPortCollisions(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckPortCollisions(t *testing.T) {
+	bIndex := &bricksindex.BricksIndex{
+		BuiltInBricks: []bricksindex.Brick{
+			{ID: "arduino:web_ui", Ports: []string{"7000"}},
+			{ID: "arduino:streamlit_ui", Ports: []string{"7000"}},
+			{ID: "arduino:data_logger", Ports: []string{"8080"}},
+			{ID: "arduino:object_detection"},
+		},
+	}
+
+	testCases := []struct {
+		name       string
+		appPorts   []int
+		bricks     []app.Brick
+		wantErrors []string
+	}{
+		{
+			name:   "no collision returns no error",
+			bricks: []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:object_detection"}},
+		},
+		{
+			name:       "two bricks on the same port",
+			bricks:     []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:streamlit_ui"}},
+			wantErrors: []string{`port 7000 is declared by more than one source (arduino:web_ui, arduino:streamlit_ui)`},
+		},
+		{
+			name:     "every collision is reported",
+			appPorts: []int{7000, 8080},
+			bricks:   []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:data_logger"}},
+			wantErrors: []string{
+				`port 7000 is declared by more than one source (app.yaml, arduino:web_ui)`,
+				`port 8080 is declared by more than one source (app.yaml, arduino:data_logger)`,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkPortCollisions(tc.appPorts, tc.bricks, bIndex)
+			if len(tc.wantErrors) == 0 {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, want := range tc.wantErrors {
+				assert.Contains(t, err.Error(), want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/check_test.go
+++ b/internal/orchestrator/check_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/peripherals"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 )
 
 func TestValidateAppDescriptorBricks(t *testing.T) {
@@ -576,10 +577,11 @@ func TestDetectPortCollisions(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name     string
-		appPorts []int
-		bricks   []app.Brick
-		want     []portCollision
+		name         string
+		appPorts     []int
+		bricks       []app.Brick
+		servicePorts map[string][]string
+		want         []portCollision
 	}{
 		{
 			name:   "no collision",
@@ -617,11 +619,34 @@ func TestDetectPortCollisions(t *testing.T) {
 				{Port: "8080", Sources: []string{appPortsSource, "arduino:data_logger"}},
 			},
 		},
+		{
+			name:         "a service colliding with a brick",
+			bricks:       []app.Brick{{ID: "arduino:web_ui"}},
+			servicePorts: map[string][]string{"arduino:proxy": {"7000"}},
+			want:         []portCollision{{Port: "7000", Sources: []string{"arduino:web_ui", "arduino:proxy"}}},
+		},
+		{
+			name:         "a service colliding with app.yaml",
+			appPorts:     []int{8086},
+			servicePorts: map[string][]string{"arduino:tsstore": {"8086"}},
+			want:         []portCollision{{Port: "8086", Sources: []string{appPortsSource, "arduino:tsstore"}}},
+		},
+		{
+			name:         "two services on the same port are reported in a stable order",
+			servicePorts: map[string][]string{"arduino:b-service": {"9000"}, "arduino:a-service": {"9000"}},
+			want:         []portCollision{{Port: "9000", Sources: []string{"arduino:a-service", "arduino:b-service"}}},
+		},
+		{
+			name:         "services not sharing a port are not a collision",
+			bricks:       []app.Brick{{ID: "arduino:web_ui"}},
+			servicePorts: map[string][]string{"arduino:tsstore": {"8086"}},
+			want:         nil,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, detectPortCollisions(tc.appPorts, tc.bricks, bIndex))
+			require.Equal(t, tc.want, detectPortCollisions(tc.appPorts, tc.bricks, bIndex, tc.servicePorts))
 		})
 	}
 }
@@ -664,7 +689,7 @@ func TestCheckPortCollisions(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := checkPortCollisions(tc.appPorts, tc.bricks, bIndex)
+			err := checkPortCollisions(tc.appPorts, tc.bricks, bIndex, &servicesindex.ServicesIndex{})
 			if len(tc.wantErrors) == 0 {
 				require.NoError(t, err)
 				return

--- a/internal/orchestrator/check_test.go
+++ b/internal/orchestrator/check_test.go
@@ -564,3 +564,64 @@ func TestNeedsAudioDevices(t *testing.T) {
 		})
 	}
 }
+
+func TestDetectPortCollisions(t *testing.T) {
+	bIndex := &bricksindex.BricksIndex{
+		BuiltInBricks: []bricksindex.Brick{
+			{ID: "arduino:web_ui", Ports: []string{"7000"}},
+			{ID: "arduino:streamlit_ui", Ports: []string{"7000"}},
+			{ID: "arduino:data_logger", Ports: []string{"8080", "8080"}},
+			{ID: "arduino:object_detection"},
+		},
+	}
+
+	testCases := []struct {
+		name     string
+		appPorts []int
+		bricks   []app.Brick
+		want     []portCollision
+	}{
+		{
+			name:   "no collision",
+			bricks: []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:object_detection"}},
+			want:   nil,
+		},
+		{
+			name:   "two bricks on the same port",
+			bricks: []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:streamlit_ui"}},
+			want:   []portCollision{{Port: "7000", Sources: []string{"arduino:web_ui", "arduino:streamlit_ui"}}},
+		},
+		{
+			name:     "app.yaml colliding with a brick",
+			appPorts: []int{7000},
+			bricks:   []app.Brick{{ID: "arduino:web_ui"}},
+			want:     []portCollision{{Port: "7000", Sources: []string{appPortsSource, "arduino:web_ui"}}},
+		},
+		{
+			name:     "duplicated ports within a single source are not a collision",
+			appPorts: []int{9000, 9000},
+			bricks:   []app.Brick{{ID: "arduino:data_logger"}},
+			want:     nil,
+		},
+		{
+			name:   "bricks missing from the index are skipped",
+			bricks: []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:unknown-brick"}},
+			want:   nil,
+		},
+		{
+			name:     "multiple collisions are sorted by port",
+			appPorts: []int{7000, 8080},
+			bricks:   []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:data_logger"}},
+			want: []portCollision{
+				{Port: "7000", Sources: []string{appPortsSource, "arduino:web_ui"}},
+				{Port: "8080", Sources: []string{appPortsSource, "arduino:data_logger"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, detectPortCollisions(tc.appPorts, tc.bricks, bIndex))
+		})
+	}
+}

--- a/internal/orchestrator/check_test.go
+++ b/internal/orchestrator/check_test.go
@@ -7,7 +7,9 @@ package orchestrator
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,6 +22,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/peripherals"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
+	"github.com/arduino/arduino-app-cli/internal/platform"
 )
 
 func TestValidateAppDescriptorBricks(t *testing.T) {
@@ -566,98 +569,42 @@ func TestNeedsAudioDevices(t *testing.T) {
 	}
 }
 
-func TestDetectPortCollisions(t *testing.T) {
+// writeServicesIndex builds a services index from compose files written on the fly, so that the
+// services have real ports: the field holding them is not exported.
+func writeServicesIndex(t *testing.T, composeByServiceID map[string]string) *servicesindex.ServicesIndex {
+	t.Helper()
+	root := paths.New(t.TempDir())
+	for id, compose := range composeByServiceID {
+		_, name, ok := strings.Cut(id, ":")
+		require.True(t, ok, "service id must be namespaced")
+		dir := root.Join("arduino", name)
+		require.NoError(t, dir.MkdirAll())
+		config := fmt.Sprintf("service_id: %s\nname: %s service\ncategory: test\n", id, name)
+		require.NoError(t, dir.Join("service_config.yaml").WriteFile([]byte(config)))
+		require.NoError(t, dir.Join("service_compose.yaml").WriteFile([]byte(compose)))
+	}
+	index, err := servicesindex.Load(platform.GetPlatform(nil), root)
+	require.NoError(t, err)
+	return index
+}
+
+func TestCheckPortCollisions(t *testing.T) {
+	servicesIndex := writeServicesIndex(t, map[string]string{
+		"arduino:audio": "services:\n  audio:\n    image: busybox\n    ports: [\"8085:8085\"]\n",
+		"arduino:db":    "services:\n  db:\n    image: busybox\n    ports: [\"9999:9999\"]\n",
+	})
+
 	bIndex := &bricksindex.BricksIndex{
 		BuiltInBricks: []bricksindex.Brick{
 			{ID: "arduino:web_ui", Ports: []string{"7000"}},
 			{ID: "arduino:streamlit_ui", Ports: []string{"7000"}},
 			{ID: "arduino:data_logger", Ports: []string{"8080", "8080"}},
 			{ID: "arduino:object_detection"},
-		},
-	}
-
-	testCases := []struct {
-		name         string
-		appPorts     []int
-		bricks       []app.Brick
-		servicePorts map[string][]string
-		want         []portCollision
-	}{
-		{
-			name:   "no collision",
-			bricks: []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:object_detection"}},
-			want:   nil,
-		},
-		{
-			name:   "two bricks on the same port",
-			bricks: []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:streamlit_ui"}},
-			want:   []portCollision{{Port: "7000", Sources: []string{"arduino:web_ui", "arduino:streamlit_ui"}}},
-		},
-		{
-			name:     "app.yaml colliding with a brick",
-			appPorts: []int{7000},
-			bricks:   []app.Brick{{ID: "arduino:web_ui"}},
-			want:     []portCollision{{Port: "7000", Sources: []string{appPortsSource, "arduino:web_ui"}}},
-		},
-		{
-			name:     "duplicated ports within a single source are not a collision",
-			appPorts: []int{9000, 9000},
-			bricks:   []app.Brick{{ID: "arduino:data_logger"}},
-			want:     nil,
-		},
-		{
-			name:   "bricks missing from the index are skipped",
-			bricks: []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:unknown-brick"}},
-			want:   nil,
-		},
-		{
-			name:     "multiple collisions are sorted by port",
-			appPorts: []int{7000, 8080},
-			bricks:   []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:data_logger"}},
-			want: []portCollision{
-				{Port: "7000", Sources: []string{appPortsSource, "arduino:web_ui"}},
-				{Port: "8080", Sources: []string{appPortsSource, "arduino:data_logger"}},
-			},
-		},
-		{
-			name:         "a service colliding with a brick",
-			bricks:       []app.Brick{{ID: "arduino:web_ui"}},
-			servicePorts: map[string][]string{"arduino:proxy": {"7000"}},
-			want:         []portCollision{{Port: "7000", Sources: []string{"arduino:web_ui", "arduino:proxy"}}},
-		},
-		{
-			name:         "a service colliding with app.yaml",
-			appPorts:     []int{8086},
-			servicePorts: map[string][]string{"arduino:tsstore": {"8086"}},
-			want:         []portCollision{{Port: "8086", Sources: []string{appPortsSource, "arduino:tsstore"}}},
-		},
-		{
-			name:         "two services on the same port are reported in a stable order",
-			servicePorts: map[string][]string{"arduino:b-service": {"9000"}, "arduino:a-service": {"9000"}},
-			want:         []portCollision{{Port: "9000", Sources: []string{"arduino:a-service", "arduino:b-service"}}},
-		},
-		{
-			name:         "services not sharing a port are not a collision",
-			bricks:       []app.Brick{{ID: "arduino:web_ui"}},
-			servicePorts: map[string][]string{"arduino:tsstore": {"8086"}},
-			want:         nil,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, detectPortCollisions(tc.appPorts, tc.bricks, bIndex, tc.servicePorts))
-		})
-	}
-}
-
-func TestCheckPortCollisions(t *testing.T) {
-	bIndex := &bricksindex.BricksIndex{
-		BuiltInBricks: []bricksindex.Brick{
-			{ID: "arduino:web_ui", Ports: []string{"7000"}},
-			{ID: "arduino:streamlit_ui", Ports: []string{"7000"}},
-			{ID: "arduino:data_logger", Ports: []string{"8080"}},
-			{ID: "arduino:object_detection"},
+			// Both speech bricks require the same service, like arduino:asr and arduino:tts do.
+			{ID: "arduino:asr", RequiresServices: bricksindex.RequiresServices{{ID: "arduino:audio"}}},
+			{ID: "arduino:tts", RequiresServices: bricksindex.RequiresServices{{ID: "arduino:audio"}}},
+			{ID: "arduino:storage", RequiresServices: bricksindex.RequiresServices{{ID: "arduino:db"}}},
+			{ID: "arduino:needs_missing", RequiresServices: bricksindex.RequiresServices{{ID: "arduino:missing"}}},
 		},
 	}
 
@@ -668,28 +615,62 @@ func TestCheckPortCollisions(t *testing.T) {
 		wantErrors []string
 	}{
 		{
-			name:   "no collision returns no error",
+			name:   "no collision",
 			bricks: []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:object_detection"}},
 		},
 		{
 			name:       "two bricks on the same port",
 			bricks:     []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:streamlit_ui"}},
-			wantErrors: []string{`port 7000 is declared by more than one source (arduino:web_ui, arduino:streamlit_ui)`},
+			wantErrors: []string{"port 7000 is declared by multiple sources: arduino:web_ui, arduino:streamlit_ui"},
+		},
+		{
+			name:       "app.yaml colliding with a brick",
+			appPorts:   []int{7000},
+			bricks:     []app.Brick{{ID: "arduino:web_ui"}},
+			wantErrors: []string{"port 7000 is declared by multiple sources: arduino:web_ui, app.yaml"},
+		},
+		{
+			name:     "duplicated ports within a single source are not a collision",
+			appPorts: []int{9000, 9000},
+			bricks:   []app.Brick{{ID: "arduino:data_logger"}},
+		},
+		{
+			name:   "bricks missing from the index are skipped",
+			bricks: []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:unknown-brick"}},
 		},
 		{
 			name:     "every collision is reported",
 			appPorts: []int{7000, 8080},
 			bricks:   []app.Brick{{ID: "arduino:web_ui"}, {ID: "arduino:data_logger"}},
 			wantErrors: []string{
-				`port 7000 is declared by more than one source (app.yaml, arduino:web_ui)`,
-				`port 8080 is declared by more than one source (app.yaml, arduino:data_logger)`,
+				"port 7000 is declared by multiple sources: arduino:web_ui, app.yaml",
+				"port 8080 is declared by multiple sources: arduino:data_logger, app.yaml",
 			},
+		},
+		{
+			name:       "a service port is reported against the brick that required it",
+			appPorts:   []int{8085},
+			bricks:     []app.Brick{{ID: "arduino:asr"}},
+			wantErrors: []string{"port 8085 is declared by multiple sources: arduino:asr (service audio service), app.yaml"},
+		},
+		{
+			name:   "a service required by two bricks is a single source",
+			bricks: []app.Brick{{ID: "arduino:asr"}, {ID: "arduino:tts"}},
+		},
+		{
+			name:   "services publishing different ports are not a collision",
+			bricks: []app.Brick{{ID: "arduino:asr"}, {ID: "arduino:storage"}},
+		},
+		{
+			name:   "services missing from the index are skipped",
+			bricks: []app.Brick{{ID: "arduino:needs_missing"}},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := checkPortCollisions(tc.appPorts, tc.bricks, bIndex, &servicesindex.ServicesIndex{})
+			descriptor := app.AppDescriptor{Ports: tc.appPorts, Bricks: tc.bricks}
+			err := checkPortCollisions(descriptor, bIndex, servicesIndex)
 			if len(tc.wantErrors) == 0 {
 				require.NoError(t, err)
 				return

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -114,13 +114,8 @@ func StartApp(
 		return err
 	}
 
-	for _, collision := range detectPortCollisions(appToStart.Descriptor.Ports, appToStart.Descriptor.Bricks, bricksIndex) {
-		slog.Warn("port collision detected", slog.String("port", collision.Port), slog.Any("sources", collision.Sources))
-		// TODO convert this eventn in warning type after https://github.com/arduino/arduino-app-cli/issues/382 is approved and handled by App Lab
-		cb(StreamMessage{data: fmt.Sprintf(
-			"[WARNING] port %s is declared by more than one source (%s): only one of them will be reachable",
-			collision.Port, strings.Join(collision.Sources, ", "),
-		)})
+	if err := checkPortCollisions(appToStart.Descriptor.Ports, appToStart.Descriptor.Bricks, bricksIndex); err != nil {
+		return err
 	}
 
 	requiredClasses, err := requiredDeviceClasses(bricksIndex, appToStart.Descriptor.Bricks)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -113,6 +113,16 @@ func StartApp(
 	if err := checkBricks(ctx, appToStart.Descriptor.Bricks, bricksIndex, modelsIndex); err != nil {
 		return err
 	}
+
+	for _, collision := range detectPortCollisions(appToStart.Descriptor.Ports, appToStart.Descriptor.Bricks, bricksIndex) {
+		slog.Warn("port collision detected", slog.String("port", collision.Port), slog.Any("sources", collision.Sources))
+		//TODO convert this eventn in warning type after https://github.com/arduino/arduino-app-cli/issues/382 is approved and handled by App Lab
+		cb(StreamMessage{data: fmt.Sprintf(
+			"[WARNING] port %s is declared by more than one source (%s): only one of them will be reachable",
+			collision.Port, strings.Join(collision.Sources, ", "),
+		)})
+	}
+
 	requiredClasses, err := requiredDeviceClasses(bricksIndex, appToStart.Descriptor.Bricks)
 	if err != nil {
 		return err

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -114,7 +114,7 @@ func StartApp(
 		return err
 	}
 
-	if err := checkPortCollisions(appToStart.Descriptor.Ports, appToStart.Descriptor.Bricks, bricksIndex, servicesIndex); err != nil {
+	if err := checkPortCollisions(appToStart.Descriptor, bricksIndex, servicesIndex); err != nil {
 		return err
 	}
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -116,7 +116,7 @@ func StartApp(
 
 	for _, collision := range detectPortCollisions(appToStart.Descriptor.Ports, appToStart.Descriptor.Bricks, bricksIndex) {
 		slog.Warn("port collision detected", slog.String("port", collision.Port), slog.Any("sources", collision.Sources))
-		//TODO convert this eventn in warning type after https://github.com/arduino/arduino-app-cli/issues/382 is approved and handled by App Lab
+		// TODO convert this eventn in warning type after https://github.com/arduino/arduino-app-cli/issues/382 is approved and handled by App Lab
 		cb(StreamMessage{data: fmt.Sprintf(
 			"[WARNING] port %s is declared by more than one source (%s): only one of them will be reachable",
 			collision.Port, strings.Join(collision.Sources, ", "),

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -114,7 +114,7 @@ func StartApp(
 		return err
 	}
 
-	if err := checkPortCollisions(appToStart.Descriptor.Ports, appToStart.Descriptor.Bricks, bricksIndex); err != nil {
+	if err := checkPortCollisions(appToStart.Descriptor.Ports, appToStart.Descriptor.Bricks, bricksIndex, servicesIndex); err != nil {
 		return err
 	}
 

--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -6,6 +6,7 @@
 package orchestrator
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -215,11 +216,7 @@ func generateMainComposeFile(
 		ports[fmt.Sprintf("%d:%d", p, p)] = struct{}{}
 	}
 
-	brickServices, err := requiredServices(bricksIndex, servicesIndex, app.Descriptor.Bricks)
-	if err != nil {
-		return err
-	}
-
+	brickServices := make(map[string]servicesindex.Service)
 	var composeFiles paths.PathList
 	services := make([]serviceInfo, 0, len(app.Descriptor.Bricks))
 	for _, brick := range app.Descriptor.Bricks {
@@ -234,13 +231,29 @@ func generateMainComposeFile(
 			ports[fmt.Sprintf("%s:%s", p, p)] = struct{}{}
 		}
 
-		// 2. Retrieve the brick_compose.yaml file.
+		// 2. Retrieve the required singleton services
+		matchingServices, err := idxBrick.GetMatchingService(bricksindex.BrickInstance{
+			Model: cmp.Or(brick.Model, idxBrick.ModelName),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to get required services for brick %s: %w", brick.ID, err)
+		}
+		for _, id := range matchingServices {
+			service, found := servicesIndex.FindServiceByID(id)
+			if !found {
+				slog.Debug("service required by brick not found or not available for current board", slog.String("service_id", id), slog.String("brick_id", brick.ID))
+				continue
+			}
+			brickServices[id] = *service
+		}
+
+		// 3. Retrieve the brick_compose.yaml file.
 		composeFilePath, ok := idxBrick.GetComposeFile()
 		if !ok {
 			continue
 		}
 
-		// 3. Retrieve the compose services names.
+		// 4. Retrieve the compose services names.
 		svcs, err := extractServicesFromComposeFile(composeFilePath)
 		if err != nil {
 			slog.Warn("loading brick_compose", slog.String("brick_id", brick.ID), slog.String("path", composeFilePath.String()), slog.Any("error", err))
@@ -251,7 +264,7 @@ func generateMainComposeFile(
 			continue
 		}
 
-		// 4. Retrieve the required devices that we have to mount
+		// 5. Retrieve the required devices that we have to mount
 		slog.Debug("Brick config", slog.Bool("mount_devices_into_container", idxBrick.MountDevicesIntoContainer), slog.Any("ports", ports), slog.Any("required_devices", idxBrick.RequiredDevices))
 		if idxBrick.MountDevicesIntoContainer {
 			for i := range svcs {

--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -6,7 +6,6 @@
 package orchestrator
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -216,7 +215,11 @@ func generateMainComposeFile(
 		ports[fmt.Sprintf("%d:%d", p, p)] = struct{}{}
 	}
 
-	brickServices := make(map[string]servicesindex.Service)
+	brickServices, err := requiredServices(bricksIndex, servicesIndex, app.Descriptor.Bricks)
+	if err != nil {
+		return err
+	}
+
 	var composeFiles paths.PathList
 	services := make([]serviceInfo, 0, len(app.Descriptor.Bricks))
 	for _, brick := range app.Descriptor.Bricks {
@@ -231,29 +234,13 @@ func generateMainComposeFile(
 			ports[fmt.Sprintf("%s:%s", p, p)] = struct{}{}
 		}
 
-		// 2. Retrieve the required singleton services
-		matchingServices, err := idxBrick.GetMatchingService(bricksindex.BrickInstance{
-			Model: cmp.Or(brick.Model, idxBrick.ModelName),
-		})
-		if err != nil {
-			return fmt.Errorf("failed to get required services for brick %s: %w", brick.ID, err)
-		}
-		for _, id := range matchingServices {
-			service, found := servicesIndex.FindServiceByID(id)
-			if !found {
-				slog.Debug("service required by brick not found or not available for current board", slog.String("service_id", id), slog.String("brick_id", brick.ID))
-				continue
-			}
-			brickServices[id] = *service
-		}
-
-		// 3. Retrieve the brick_compose.yaml file.
+		// 2. Retrieve the brick_compose.yaml file.
 		composeFilePath, ok := idxBrick.GetComposeFile()
 		if !ok {
 			continue
 		}
 
-		// 4. Retrieve the compose services names.
+		// 3. Retrieve the compose services names.
 		svcs, err := extractServicesFromComposeFile(composeFilePath)
 		if err != nil {
 			slog.Warn("loading brick_compose", slog.String("brick_id", brick.ID), slog.String("path", composeFilePath.String()), slog.Any("error", err))
@@ -264,7 +251,7 @@ func generateMainComposeFile(
 			continue
 		}
 
-		// 5. Retrieve the required devices that we have to mount
+		// 4. Retrieve the required devices that we have to mount
 		slog.Debug("Brick config", slog.Bool("mount_devices_into_container", idxBrick.MountDevicesIntoContainer), slog.Any("ports", ports), slog.Any("required_devices", idxBrick.RequiredDevices))
 		if idxBrick.MountDevicesIntoContainer {
 			for i := range svcs {

--- a/internal/orchestrator/servicesindex/services_index.go
+++ b/internal/orchestrator/servicesindex/services_index.go
@@ -7,12 +7,14 @@ package servicesindex
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"slices"
 
 	"github.com/arduino/go-paths-helper"
 	"github.com/goccy/go-yaml"
 
+	"github.com/arduino/arduino-app-cli/internal/composefile"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
 
@@ -28,6 +30,15 @@ type Service struct {
 	SupportedBoards []string `yaml:"supported_boards"`
 
 	ComposeFile *paths.Path `yaml:"-"` // brick_compose.yaml file path, optional
+
+	containerPorts []string `yaml:"-"` // Ports extracted from the compose file, optional
+}
+
+// GetPorts returns the host ports published by the service compose file, sorted and deduplicated.
+func (s Service) GetPorts() []string {
+	ports := slices.Clone(s.containerPorts)
+	slices.Sort(ports)
+	return slices.Compact(ports)
 }
 
 func Load(platform platform.Platform, dir *paths.Path) (*ServicesIndex, error) {
@@ -103,5 +114,14 @@ func load(platform platform.Platform, servicePath *paths.Path) (a Service, err e
 		}
 	}
 	service.ComposeFile = composeFile
+
+	if composeFile, ok := service.GetComposeFile(); ok {
+		if ports, err := composefile.ExtractPorts(composeFile); err == nil {
+			service.containerPorts = ports
+		} else {
+			slog.Warn("cannot extract ports from compose file, skipping", "service_id", service.ServiceID, "error", err)
+		}
+	}
+
 	return service, nil
 }

--- a/internal/orchestrator/servicesindex/services_index_test.go
+++ b/internal/orchestrator/servicesindex/services_index_test.go
@@ -67,3 +67,66 @@ func TestLoadServicesSupportedBoard(t *testing.T) {
 		})
 	}
 }
+
+func TestServicePorts(t *testing.T) {
+	testCases := []struct {
+		name           string
+		composeContent string
+		want           []string
+	}{
+		{
+			name: "ports are extracted from the service compose file",
+			composeContent: `
+services:
+  influx:
+    image: influxdb:2.7
+    ports:
+      - "127.0.0.1:8086:8086"
+  proxy:
+    image: nginx
+    ports:
+      - "8085"
+`,
+			want: []string{"8085", "8086"},
+		},
+		{
+			name: "ports declared more than once are deduplicated",
+			composeContent: `
+services:
+  a:
+    image: nginx
+    ports: ["9000:9000"]
+  b:
+    image: nginx
+    ports: ["9000:9000"]
+`,
+			want: []string{"9000"},
+		},
+		{
+			name: "a service publishing nothing has no ports",
+			composeContent: `
+services:
+  worker:
+    image: busybox
+`,
+			want: nil,
+		},
+		{
+			name:           "an unreadable compose file is skipped without failing the load",
+			composeContent: "services\n  broken:\n",
+			want:           nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			servicePath := paths.New(t.TempDir())
+			require.NoError(t, servicePath.Join("service_config.yaml").WriteFile([]byte("service_id: arduino:test\nname: Test Service\n")))
+			require.NoError(t, servicePath.Join("service_compose.yaml").WriteFile([]byte(tc.composeContent)))
+
+			service, err := load(platform.GetPlatform(nil), servicePath)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, service.GetPorts())
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
Two bricks can ask for the same host port. If they run inside `main`, Compose merges
the duplicate, and the app starts with one UI silently unreachable. If they run in their
own containers, Docker refuses to bind, but only after provisioning and image pull, and
the error names the port, never the bricks.

### Change description

1. `checkPortCollisions` collects the ports of every source of the app and fails the
   start when one is declared more than once. . Errors are joined:

   ```
   port 7000 is declared by multiple sources: arduino:web_ui, arduino:streamlit_ui
   ```

   Sources: `app.yaml`, the brick index, the `brick_compose.yaml` files, and the
   `service_compose.yaml` of the required services. Services are reported against the
   brick requiring them, and count as one source even when required by several bricks.

2. Compose port extraction moved to `internal/composefile`, so `servicesindex` can reuse
   it. `servicesindex.Service` gains `containerPorts` + `GetPorts`, like `bricksindex.Brick`.

3. Unit tests per source, plus two e2e tests for the two cases above.
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
