### PR TITLE
fix: shell-quote GetCmd command and arguments on both adb and ssh

### DIFF
--- a/pkg/board/remote/adb/adb.go
+++ b/pkg/board/remote/adb/adb.go
@@ -246,17 +246,10 @@ type ADBCommand struct {
 }
 
 func (a *ADBConnection) GetCmd(cmd string, args ...string) remote.Cmder {
-	for i, arg := range args {
-		if strings.Contains(arg, " ") {
-			args[i] = fmt.Sprintf("%q", arg)
-		}
-	}
-
-	// TODO: fix command injection vulnerability
-	var cmds []string
-	cmds = append(cmds, a.adbPath, "-s", a.host, "shell", cmd)
-	if len(args) > 0 {
-		cmds = append(cmds, args...)
+	cmds := make([]string, 0, 5+len(args))
+	cmds = append(cmds, a.adbPath, "-s", a.host, "shell", remote.ShellQuote(cmd))
+	for _, arg := range args {
+		cmds = append(cmds, remote.ShellQuote(arg))
 	}
 
 	command, err := paths.NewProcess(nil, cmds...)

--- a/pkg/board/remote/remote_test.go
+++ b/pkg/board/remote/remote_test.go
@@ -208,32 +208,85 @@ func TestRemoteShell(t *testing.T) {
 
 				require.NoError(t, closer())
 			})
-
-			t.Run("VerbatimArgs", func(t *testing.T) {
-				// Each arg must reach the remote program literally, with no shell expansion.
-				for _, arg := range []string{
-					"$HOME and `whoami`",
-					"it's",
-					"a\nb",
-					"a && b; c",
-				} {
-					cmd := cmder("echo", arg)
-					output, err := cmd.Output(t.Context())
-					require.NoError(t, err)
-					got := strings.ReplaceAll(string(output), "\r\n", "\n") // adb pty rewrites \n as \r\n
-					assert.True(t, strings.HasPrefix(got, arg+"\n"), "expected %q to start with %q", got, arg)
-				}
-			})
-
-			t.Run("ShellScriptArg", func(t *testing.T) {
-				cmd := cmder("sh", "-c", "cd /tmp && pwd")
-				output, err := cmd.Output(t.Context())
-				require.NoError(t, err)
-				assert.Equal(t, "/tmp", strings.TrimSpace(string(output)))
-			})
 		}
 	}
+}
 
+// GetCmd interposes no shell of its own, so only a shell the caller asks for expands anything.
+func TestRemoteShellQuoting(t *testing.T) {
+	name, adbPort, sshPort := testtools.StartAdbDContainer(t)
+	t.Cleanup(func() { testtools.StopAdbDContainer(t, name) })
+
+	conns := []struct {
+		name string
+		conn remote.RemoteShell
+	}{{
+		"adb",
+		func() remote.RemoteShell {
+			conn, err := adb.FromHost("localhost:"+adbPort, "")
+			require.NoError(t, err)
+			return conn
+		}(),
+	}, {
+		"ssh",
+		func() remote.RemoteShell {
+			conn, err := ssh.FromHost("arduino", "arduino", "127.0.0.1:"+sshPort)
+			require.NoError(t, err)
+			return conn
+		}(),
+	}, {
+		"local",
+		func() remote.RemoteShell {
+			return &local.LocalConnection{}
+		}(),
+	},
+	}
+
+	tests := []struct {
+		cmd  string
+		args []string
+		want string
+	}{{
+		cmd:  "echo",
+		args: []string{"$HOME and `whoami`"},
+		want: "$HOME and `whoami`\n",
+	}, {
+		cmd:  "echo",
+		args: []string{"it's"},
+		want: "it's\n",
+	}, {
+		cmd:  "echo",
+		args: []string{"a\nb"},
+		want: "a\nb\n",
+	}, {
+		cmd:  "echo",
+		args: []string{"a && b; c"},
+		want: "a && b; c\n",
+	}, {
+		// shell expansion works when the caller explicitly asks for a shell.
+		cmd:  "sh",
+		args: []string{"-c", "cd /tmp && pwd"},
+		want: "/tmp\n",
+	}, {
+		// Newlines must stay inside the script arg, or each line runs as its own command.
+		cmd:  "sh",
+		args: []string{"-c", "X=multi\necho first $X\necho second $X"},
+		want: "first multi\nsecond multi\n",
+	},
+	}
+
+	for _, tc := range conns {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, tt := range tests {
+				name := fmt.Sprintf("%s %s", tt.cmd, strings.Join(tt.args, " "))
+				t.Run(name, func(t *testing.T) {
+					output, err := tc.conn.GetCmd(tt.cmd, tt.args...).Output(t.Context())
+					require.NoError(t, err)
+					assert.Equal(t, tt.want, string(output))
+				})
+			}
+		})
+	}
 }
 
 func TestRemoteForwarder(t *testing.T) {

--- a/pkg/board/remote/remote_test.go
+++ b/pkg/board/remote/remote_test.go
@@ -208,6 +208,29 @@ func TestRemoteShell(t *testing.T) {
 
 				require.NoError(t, closer())
 			})
+
+			t.Run("VerbatimArgs", func(t *testing.T) {
+				// Each arg must reach the remote program literally, with no shell expansion.
+				for _, arg := range []string{
+					"$HOME and `whoami`",
+					"it's",
+					"a\nb",
+					"a && b; c",
+				} {
+					cmd := cmder("echo", arg)
+					output, err := cmd.Output(t.Context())
+					require.NoError(t, err)
+					got := strings.ReplaceAll(string(output), "\r\n", "\n") // adb pty rewrites \n as \r\n
+					assert.True(t, strings.HasPrefix(got, arg+"\n"), "expected %q to start with %q", got, arg)
+				}
+			})
+
+			t.Run("ShellScriptArg", func(t *testing.T) {
+				cmd := cmder("sh", "-c", "cd /tmp && pwd")
+				output, err := cmd.Output(t.Context())
+				require.NoError(t, err)
+				assert.Equal(t, "/tmp", strings.TrimSpace(string(output)))
+			})
 		}
 	}
 

--- a/pkg/board/remote/ssh/ssh.go
+++ b/pkg/board/remote/ssh/ssh.go
@@ -284,12 +284,15 @@ func (a *SSHConnection) GetCmd(cmd string, args ...string) remote.Cmder {
 		}
 	}
 
-	// TODO: fix for command injection vulnerability
-	cmd = fmt.Sprintf("%s %s", cmd, strings.Join(args, " "))
+	parts := make([]string, 0, 1+len(args))
+	parts = append(parts, remote.ShellQuote(cmd))
+	for _, arg := range args {
+		parts = append(parts, remote.ShellQuote(arg))
+	}
 
 	return &SSHCommand{
 		session: session,
-		cmd:     cmd,
+		cmd:     strings.Join(parts, " "),
 	}
 }
 


### PR DESCRIPTION
### Motivation

`GetCmd` does not escape the arguments for the board shell on the ssh and adb transports. The board shell interprets the arguments instead of receiving them as data.

Issue found debugging the App Lab AI assistant, that runs commands on the board through this API. Two real cases:

- **ssh**: `GetCmd("sh", "-c", "cd '<dir>' && ls")` was sent unquoted, so the board login shell split it: `sh -c cd` did nothing and `ls` ran in `$HOME`. Every command silently ignored its working directory.
- **adb**: args were quoted with Go `%q`, which is not shell escaping: a multi-line command like `pip install requests` + `python3 main.py` became `pip install requestsnpython3` (the newline became a literal `\n`), and `$var` / backticks stayed live on the board shell.

### Change description

Quote cmd and every argument with the `ShellQuote` helper already used by the FS methods on both ssh and adb.
New contract: arguments reach the remote program **verbatim** (exec-like), the same on adb, ssh and local. Callers that want shell features ask for them explicitly with `sh -c "<script>"`.

### Additional Notes

- Follow-up idea: a `baseDir` option on the command would remove the need of the `cd` trick for callers — it can build on this fix, since it needs the same quoting internally.
- App Lab side: after this is released it is important to bump the pin in cloud-editor-mono, an update is required also on AppLab where GetCmd is used.

### Reviewer checklist

- [x] PR addresses a single concern.
- [x] PR title and description are properly filled.
- [x] Changes will be merged in `main`.
- [x] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
