### PR TITLE
docs(ei model specification): Use verbatim EI category names in compatibility table

### DIFF
--- a/docs/edge-impulse-models-specfication.md
+++ b/docs/edge-impulse-models-specfication.md
@@ -72,20 +72,20 @@ For Edge Impulse compatible bricks, the `bricks` list defines which AI Bricks ar
 
 The compatible bricks are determined by the **project category** set in Edge Impulse Studio. The table lists the mapping between Edge Impulse project categories and the corresponding AI Brick IDs, along with the required `model_configuration` variable name for each brick.
 
-| EI Project Category     | AI Brick ID                           | `model_configuration` variable         |
-| ----------------------- | ------------------------------------- | -------------------------------------- |
-| Object Detection        | `arduino:object_detection`            | `EI_OBJ_DETECTION_MODEL`               |
-| Object Detection        | `arduino:video_object_detection`      | `EI_V_OBJ_DETECTION_MODEL`             |
-| Images (Classification) | `arduino:image_classification`        | `EI_CLASSIFICATION_MODEL`              |
-| Images (Classification) | `arduino:video_image_classification`  | `EI_V_CLASSIFICATION_MODEL`            |
-| Images (Visual Anomaly) | `arduino:visual_anomaly_detection`    | `EI_V_ANOMALY_DETECTION_MODEL`         |
-| Audio                   | `arduino:audio_classification`        | `EI_AUDIO_CLASSIFICATION_MODEL`        |
-| Keyword Spotting        | `arduino:audio_classification`        | `EI_AUDIO_CLASSIFICATION_MODEL`        |
-| Keyword Spotting        | `arduino:keyword_spotting`            | `EI_KEYWORD_SPOTTING_MODEL`            |
-| Accelerometer           | `arduino:motion_detection`            | `EI_MOTION_DETECTION_MODEL`            |
-| Accelerometer           | `arduino:vibration_anomaly_detection` | `EI_VIBRATION_ANOMALY_DETECTION_MODEL` |
+| EI Project Category                             | AI Brick ID                           | `model_configuration` variable         |
+| ----------------------------------------------- | ------------------------------------- | -------------------------------------- |
+| Object detection                                | `arduino:object_detection`            | `EI_OBJ_DETECTION_MODEL`               |
+| Object detection                                | `arduino:video_object_detection`      | `EI_V_OBJ_DETECTION_MODEL`             |
+| Images                                          | `arduino:image_classification`        | `EI_CLASSIFICATION_MODEL`              |
+| Images                                          | `arduino:video_image_classification`  | `EI_V_CLASSIFICATION_MODEL`            |
+| Images[<sup>1</sup>](#v-anomaly-detection-note) | `arduino:visual_anomaly_detection`    | `EI_V_ANOMALY_DETECTION_MODEL`         |
+| Audio                                           | `arduino:audio_classification`        | `EI_AUDIO_CLASSIFICATION_MODEL`        |
+| Keyword spotting                                | `arduino:audio_classification`        | `EI_AUDIO_CLASSIFICATION_MODEL`        |
+| Keyword spotting                                | `arduino:keyword_spotting`            | `EI_KEYWORD_SPOTTING_MODEL`            |
+| Accelerometer                                   | `arduino:motion_detection`            | `EI_MOTION_DETECTION_MODEL`            |
+| Accelerometer                                   | `arduino:vibration_anomaly_detection` | `EI_VIBRATION_ANOMALY_DETECTION_MODEL` |
 
-> **Note on Visual Anomaly Detection**: The `arduino:visual_anomaly_detection` brick is only compatible with impulses that include a `KerasVisualAnomaly` learn block. Generic image classification impulses from the `Images` category are not compatible with this brick.
+> <a id="v-anomaly-detection-note"></a> <sup>1</sup> **Note on Visual Anomaly Detection**: The `arduino:visual_anomaly_detection` brick is only compatible with impulses that include a `KerasVisualAnomaly` learn block. Generic image classification impulses from the `Images` category are not compatible with this brick.
 
 ### Complete Example - Object Detection Model (`model.yaml`)
 


### PR DESCRIPTION
### Motivation

The determination of which bricks an Edge Impulse model may be used with is based on the name of the project category assigned by Edge Impulse.

The mapping between category name and Brick IDs is documented by a table in the "Edge Impulse Model Specification". This information is essential for the user to ensure their model can be used with a given Brick, and for troubleshooting the situation where a model is unexpectedly not available for selection from the Brick configuration in App Lab.

Previously, there was some inconsistency between the category names as written in the table and the actual names used by Edge Impulse. This made it impossible for the user to determine from the table alone whether their project category would result in a model compatible with a target Brick. They would instead only be able to determine this by trial and error, or examining the Arduino App CLI source code.

### Change description

The category names written in the compatibility table are hereby adjusted to exactly match the actual names.

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
