### PR TITLE
chore(ci): include forward update in update test

### DIFF
--- a/.github/workflows/test-update.yml
+++ b/.github/workflows/test-update.yml
@@ -32,12 +32,17 @@ jobs:
         distro:
           - debian:trixie
           - ubuntu:24.04
-        # A scenario with a warn message reports it instead of blocking the PR.
         include:
+          # A scenario with a warn message reports it instead of blocking the PR.
           - scenario: DowngradeToPublishedRelease
             warn: >-
               Downgrading to the last published release is expected to fail;
               the test reports the reason in the job log.
+          # The other legs shim `system init` away to save time. This one runs
+          # it, so the upgrade path is tested with the real command once.
+          - scenario: StableToCurrent
+            distro: debian:trixie
+            skip_system_init: "0"
 
     name: ${{ matrix.scenario }} on ${{ matrix.distro }}
 
@@ -56,6 +61,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ARDUINOBOT_TOKEN }}
           TEST_BASE_IMAGE: ${{ matrix.distro }}
+          TEST_SKIP_SYSTEM_INIT: ${{ matrix.skip_system_init }}
         run: |
           go tool task test:update -- -run 'TestUpdatePackage/${{ matrix.scenario }}'
 

--- a/.github/workflows/test-update.yml
+++ b/.github/workflows/test-update.yml
@@ -1,17 +1,42 @@
-name: test the system update flow
+name: Run System Update Tests
 
 on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 permissions:
   contents: read
 
+# A PR gets one run at a time: superseded pushes are cancelled instead of
+# stacking three jobs each.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-and-update:
     runs-on: ubuntu-22.04
+
+    strategy:
+      # The scenarios share the host network, the docker socket and the build
+      # directory, so they only run in parallel on separate runners.
+      fail-fast: false
+      matrix:
+        scenario:
+          - StableToCurrent
+          - CurrentToCurrent
+          - DowngradeToPublishedRelease
+        # A scenario with a warn message reports it instead of blocking the PR.
+        include:
+          - scenario: DowngradeToPublishedRelease
+            warn: >-
+              Downgrading to the last published release is expected to fail;
+              the test reports the reason in the job log.
+
+    name: ${{ matrix.scenario }}
 
     steps:
       - name: Checkout
@@ -23,19 +48,13 @@ jobs:
           go-version-file: go.mod
 
       - name: Run dep package update test
+        id: test
+        continue-on-error: ${{ matrix.warn != '' }}
         env:
           GH_TOKEN: ${{ secrets.ARDUINOBOT_TOKEN }}
         run: |
-          go tool task test:update
+          go tool task test:update -- -run 'TestUpdatePackage/${{ matrix.scenario }}'
 
-      - name: Slack notification of unexpected failure
-        if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.TEAM_TOOLING_CHANNEL_SLACK_WEBHOOK }}
-          SLACK_MESSAGE: |
-            :warning::warning::warning::warning:
-            WARNING: ${{ github.repository }} ${{ github.workflow }} workflow run had an unexpected failure!!!
-            :warning::warning::warning::warning:
-          SLACK_COLOR: danger
-          MSG_MINIMAL: true
+      - name: Warn about the expected failure
+        if: ${{ matrix.warn != '' && steps.test.outcome == 'failure' }}
+        run: echo "::warning title=${{ matrix.scenario }}::${{ matrix.warn }}"

--- a/.github/workflows/test-update.yml
+++ b/.github/workflows/test-update.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 # A PR gets one run at a time: superseded pushes are cancelled instead of
-# stacking three jobs each.
+# stacking every leg of the matrix again.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -29,6 +29,9 @@ jobs:
           - StableToCurrent
           - CurrentToCurrent
           - DowngradeToPublishedRelease
+        distro:
+          - debian:trixie
+          - ubuntu:24.04
         # A scenario with a warn message reports it instead of blocking the PR.
         include:
           - scenario: DowngradeToPublishedRelease
@@ -36,7 +39,7 @@ jobs:
               Downgrading to the last published release is expected to fail;
               the test reports the reason in the job log.
 
-    name: ${{ matrix.scenario }}
+    name: ${{ matrix.scenario }} on ${{ matrix.distro }}
 
     steps:
       - name: Checkout
@@ -52,9 +55,10 @@ jobs:
         continue-on-error: ${{ matrix.warn != '' }}
         env:
           GH_TOKEN: ${{ secrets.ARDUINOBOT_TOKEN }}
+          TEST_BASE_IMAGE: ${{ matrix.distro }}
         run: |
           go tool task test:update -- -run 'TestUpdatePackage/${{ matrix.scenario }}'
 
       - name: Warn about the expected failure
         if: ${{ matrix.warn != '' && steps.test.outcome == 'failure' }}
-        run: echo "::warning title=${{ matrix.scenario }}::${{ matrix.warn }}"
+        run: echo "::warning title=${{ matrix.scenario }} on ${{ matrix.distro }}::${{ matrix.warn }}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -65,7 +65,7 @@ tasks:
 
   test:update:
     cmds:
-      - go tool gotest.tools/gotestsum -- -v -timeout=60m ./internal/e2e/updatetest
+      - go tool gotest.tools/gotestsum -- -v -timeout=60m {{ .CLI_ARGS }} ./internal/e2e/updatetest
 
   test:pkg:
     desc: Run only tests in the pkg directory

--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -84,8 +84,10 @@ func buildDebVersion(t *testing.T, storePath, tagVersion, arch string) {
 		outputDir,
 	)
 
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("failed to run build command: %v", err)
+	// Without the output a failing task only reports task's own exit code 201.
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to run build command: %v\n%s", err, out)
 	}
 }
 

--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -148,6 +148,10 @@ func buildDockerImage(t *testing.T, dockerfile, name, arch string) {
 	if image := os.Getenv("TEST_BASE_IMAGE"); image != "" {
 		args = append(args, "--build-arg", "BASE_IMAGE="+image)
 	}
+	// Set to 0 to run the real `system init` instead of the shim that skips it.
+	if skip := os.Getenv("TEST_SKIP_SYSTEM_INIT"); skip != "" {
+		args = append(args, "--build-arg", "SKIP_SYSTEM_INIT="+skip)
+	}
 	args = append(args, "-t", name, "-f", dockerfile, ".")
 
 	cmd := exec.Command("docker", args...) //nolint:gosec

--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -141,9 +141,14 @@ func genMinorTag(t *testing.T, tag string) string {
 func buildDockerImage(t *testing.T, dockerfile, name, arch string) {
 	t.Helper()
 
-	arch = fmt.Sprintf("ARCH=%s", arch)
+	args := []string{"build", "--build-arg", fmt.Sprintf("ARCH=%s", arch)}
+	// The distribution under test, the dockerfile default applies when it is unset.
+	if image := os.Getenv("TEST_BASE_IMAGE"); image != "" {
+		args = append(args, "--build-arg", "BASE_IMAGE="+image)
+	}
+	args = append(args, "-t", name, "-f", dockerfile, ".")
 
-	cmd := exec.Command("docker", "build", "--build-arg", arch, "-t", name, "-f", dockerfile, ".")
+	cmd := exec.Command("docker", args...)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -175,31 +175,38 @@ func startDockerContainer(t *testing.T, containerName string, containerImageName
 
 }
 
+// getAppCliVersion reports the running daemon's version, not the binary on disk.
 func getAppCliVersion(t *testing.T, containerName string) string {
 	t.Helper()
-
-	cmd := exec.Command(
-		"docker", "exec",
-		"--user", "1000",
-		containerName,
-		"arduino-app-cli", "version", "--format", "json",
-	)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("command failed: %v\nOutput: %s", err, output)
-	}
 
 	var version struct {
 		Version       string `json:"version"`
 		DaemonVersion string `json:"daemon_version"`
 	}
-	err = json.Unmarshal(output, &version)
-	require.NoError(t, err)
-	// TODO to enable after 0.6.7
-	// require.Equal(t, version.Version, version.DaemonVersion, "client and daemon versions should match")
-	require.NotEmpty(t, version.Version)
-	return version.Version
+	// The old daemon keeps serving until its restart completes.
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		cmd := exec.Command(
+			"docker", "exec",
+			"--user", "1000",
+			containerName,
+			"arduino-app-cli", "version", "--format", "json",
+		)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command failed: %v\nOutput: %s", err, output)
+		}
+		require.NoError(t, json.Unmarshal(output, &version))
 
+		if version.Version != "" && version.Version == version.DaemonVersion {
+			return version.DaemonVersion
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("daemon reports version %q while the installed binary is %q",
+				version.DaemonVersion, version.Version)
+		}
+		time.Sleep(time.Second)
+	}
 }
 
 func runSystemUpdate(t *testing.T, containerName string) {
@@ -209,7 +216,7 @@ func runSystemUpdate(t *testing.T, containerName string) {
 		"docker", "exec",
 		"--user", "1000",
 		containerName,
-		"arduino-app-cli", "system", "update", "--only-arduino", "--yes",
+		"arduino-app-cli", "--log-level", "debug", "system", "update", "--only-arduino", "--yes",
 	)
 
 	cmd.Stderr = os.Stderr
@@ -226,6 +233,41 @@ func runSystemUpdate(t *testing.T, containerName string) {
 		}
 		require.NoError(t, err, "system update failed")
 	}
+}
+
+const daemonHost = "127.0.0.1:8800"
+
+// startDaemonContainer starts the container and waits for the daemon, making sure the
+// daemon's own log always ends up in the test output.
+func startDaemonContainer(t *testing.T, containerName, imageName string) {
+	t.Helper()
+
+	t.Logf("start container %s and wait for daemon", containerName)
+	startDockerContainer(t, containerName, imageName)
+	t.Cleanup(func() { stopDockerContainer(t, containerName) })
+	// Registered after the stop so LIFO reads the journal while the container lives.
+	t.Cleanup(func() { dumpDaemonJournal(t, containerName) })
+
+	waitForPort(t, daemonHost, 5*time.Second)
+}
+
+// dumpDaemonJournal prints the daemon's own log, which the SSE stream does not carry.
+func dumpDaemonJournal(t *testing.T, containerName string) {
+	t.Helper()
+
+	cmd := exec.Command(
+		"docker", "exec",
+		containerName,
+		// No tail limit: the daemon restarts right after the moment of interest, so
+		// the entries we need are not at the end.
+		"journalctl", "-u", "arduino-app-cli.service", "--no-pager", "-o", "short-precise",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("could not read the daemon journal: %v\n%s", err, output)
+		return
+	}
+	t.Logf("daemon journal of %s:\n%s", containerName, output)
 }
 
 func removeDockerImage(t *testing.T, imageName string) {

--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -148,7 +148,7 @@ func buildDockerImage(t *testing.T, dockerfile, name, arch string) {
 	}
 	args = append(args, "-t", name, "-f", dockerfile, ".")
 
-	cmd := exec.Command("docker", args...)
+	cmd := exec.Command("docker", args...) //nolint:gosec
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/e2e/updatetest/test.Dockerfile
+++ b/internal/e2e/updatetest/test.Dockerfile
@@ -43,9 +43,6 @@ RUN { echo '#!/bin/sh'; \
 RUN echo "deb [trusted=yes arch=${ARCH}] file:/var/www/html/myrepo local main" \
     > /etc/apt/sources.list.d/my-mock-repo.list
 
-# Limit the tests to UNO Q (this reduces the number of pulled containers).
-RUN echo '{"board_name": "unoq"}' > /var/lib/arduino-app-cli/platform.json
-
 EXPOSE 8800
 # CMD: systemd must be PID 1
 CMD ["/sbin/init"]

--- a/internal/e2e/updatetest/test.Dockerfile
+++ b/internal/e2e/updatetest/test.Dockerfile
@@ -28,6 +28,17 @@ RUN mkdir -p /etc/systemd/system/arduino-app-cli.service.d && \
     printf '[Service]\nExecStart=\nExecStart=/usr/bin/arduino-app-cli daemon --port 8800 --log-level debug\n' \
     > /etc/systemd/system/arduino-app-cli.service.d/log-level.conf
 
+# `system init` pulls the docker images and the arduino libraries of whichever
+# version drives the upgrade, and the test only checks the version transition.
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+RUN { echo '#!/bin/sh'; \
+      echo 'if [ "$1" = system ] && [ "$2" = init ]; then exit 0; fi'; \
+      echo 'exec /usr/bin/arduino-app-cli "$@"'; \
+    } > /usr/local/bin/arduino-app-cli \
+    && chmod +x /usr/local/bin/arduino-app-cli \
+    && printf '[Service]\nEnvironment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n' \
+       > /etc/systemd/system/arduino-app-cli.service.d/skip-system-init.conf
+
 RUN echo "deb [trusted=yes arch=${ARCH}] file:/var/www/html/myrepo local main" \
     > /etc/apt/sources.list.d/my-mock-repo.list
 

--- a/internal/e2e/updatetest/test.Dockerfile
+++ b/internal/e2e/updatetest/test.Dockerfile
@@ -30,6 +30,7 @@ RUN mkdir -p /etc/systemd/system/arduino-app-cli.service.d && \
 
 # `system init` pulls the docker images and the arduino libraries of whichever
 # version drives the upgrade, and the test only checks the version transition.
+# Update the PATH so that the shim is found first.
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN { echo '#!/bin/sh'; \
       echo 'if [ "$1" = system ] && [ "$2" = init ]; then exit 0; fi'; \

--- a/internal/e2e/updatetest/test.Dockerfile
+++ b/internal/e2e/updatetest/test.Dockerfile
@@ -30,15 +30,19 @@ RUN mkdir -p /etc/systemd/system/arduino-app-cli.service.d && \
 
 # `system init` pulls the docker images and the arduino libraries of whichever
 # version drives the upgrade, and the test only checks the version transition.
+# One CI leg builds with SKIP_SYSTEM_INIT=0 to run the real command.
+ARG SKIP_SYSTEM_INIT=1
 # Update the PATH so that the shim is found first.
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-RUN { echo '#!/bin/sh'; \
-      echo 'if [ "$1" = system ] && [ "$2" = init ]; then exit 0; fi'; \
-      echo 'exec /usr/bin/arduino-app-cli "$@"'; \
-    } > /usr/local/bin/arduino-app-cli \
-    && chmod +x /usr/local/bin/arduino-app-cli \
-    && printf '[Service]\nEnvironment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n' \
-       > /etc/systemd/system/arduino-app-cli.service.d/skip-system-init.conf
+RUN if [ "${SKIP_SYSTEM_INIT}" = 1 ]; then \
+      { echo '#!/bin/sh'; \
+        echo 'if [ "$1" = system ] && [ "$2" = init ]; then exit 0; fi'; \
+        echo 'exec /usr/bin/arduino-app-cli "$@"'; \
+      } > /usr/local/bin/arduino-app-cli \
+      && chmod +x /usr/local/bin/arduino-app-cli \
+      && printf '[Service]\nEnvironment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n' \
+         > /etc/systemd/system/arduino-app-cli.service.d/skip-system-init.conf; \
+    fi
 
 RUN echo "deb [trusted=yes arch=${ARCH}] file:/var/www/html/myrepo local main" \
     > /etc/apt/sources.list.d/my-mock-repo.list

--- a/internal/e2e/updatetest/test.Dockerfile
+++ b/internal/e2e/updatetest/test.Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:trixie
+ARG BASE_IMAGE=debian:trixie
+FROM ${BASE_IMAGE}
 
 RUN apt update && \
     apt install -y systemd systemd-sysv dbus initramfs-tools\
@@ -14,11 +15,11 @@ COPY build/stable/arduino-router*_${ARCH}.deb /tmp/router.deb
 
 RUN apt update && apt install -y /tmp/stable.deb /tmp/router.deb \
     && rm /tmp/stable.deb /tmp/router.deb \
-    && mkdir -p /var/www/html/myrepo/dists/trixie/main/binary-${ARCH} \
-    && mv /tmp/unstable.deb /var/www/html/myrepo/dists/trixie/main/binary-${ARCH}/
+    && mkdir -p /var/www/html/myrepo/dists/local/main/binary-${ARCH} \
+    && mv /tmp/unstable.deb /var/www/html/myrepo/dists/local/main/binary-${ARCH}/
 
 WORKDIR /var/www/html/myrepo
-RUN dpkg-scanpackages dists/trixie/main/binary-${ARCH} /dev/null | gzip -9c > dists/trixie/main/binary-${ARCH}/Packages.gz
+RUN dpkg-scanpackages dists/local/main/binary-${ARCH} /dev/null | gzip -9c > dists/local/main/binary-${ARCH}/Packages.gz
 WORKDIR /
 
 # Debug level so the daemon's own warnings reach the journal. The drop-in is not
@@ -31,7 +32,7 @@ RUN usermod -s /bin/bash arduino || true
 RUN mkdir -p /home/arduino && chown -R arduino:arduino /home/arduino
 RUN usermod -aG docker arduino
 
-RUN echo "deb [trusted=yes arch=${ARCH}] file:/var/www/html/myrepo trixie main" \
+RUN echo "deb [trusted=yes arch=${ARCH}] file:/var/www/html/myrepo local main" \
     > /etc/apt/sources.list.d/my-mock-repo.list
 
 # Limit the tests to UNO Q (this reduces the number of pulled containers).

--- a/internal/e2e/updatetest/test.Dockerfile
+++ b/internal/e2e/updatetest/test.Dockerfile
@@ -28,10 +28,6 @@ RUN mkdir -p /etc/systemd/system/arduino-app-cli.service.d && \
     printf '[Service]\nExecStart=\nExecStart=/usr/bin/arduino-app-cli daemon --port 8800 --log-level debug\n' \
     > /etc/systemd/system/arduino-app-cli.service.d/log-level.conf
 
-RUN usermod -s /bin/bash arduino || true
-RUN mkdir -p /home/arduino && chown -R arduino:arduino /home/arduino
-RUN usermod -aG docker arduino
-
 RUN echo "deb [trusted=yes arch=${ARCH}] file:/var/www/html/myrepo local main" \
     > /etc/apt/sources.list.d/my-mock-repo.list
 

--- a/internal/e2e/updatetest/test.Dockerfile
+++ b/internal/e2e/updatetest/test.Dockerfile
@@ -21,6 +21,12 @@ WORKDIR /var/www/html/myrepo
 RUN dpkg-scanpackages dists/trixie/main/binary-${ARCH} /dev/null | gzip -9c > dists/trixie/main/binary-${ARCH}/Packages.gz
 WORKDIR /
 
+# Debug level so the daemon's own warnings reach the journal. The drop-in is not
+# owned by the package, so it survives the upgrade under test.
+RUN mkdir -p /etc/systemd/system/arduino-app-cli.service.d && \
+    printf '[Service]\nExecStart=\nExecStart=/usr/bin/arduino-app-cli daemon --port 8800 --log-level debug\n' \
+    > /etc/systemd/system/arduino-app-cli.service.d/log-level.conf
+
 RUN usermod -s /bin/bash arduino || true
 RUN mkdir -p /home/arduino && chown -R arduino:arduino /home/arduino
 RUN usermod -aG docker arduino

--- a/internal/e2e/updatetest/update_test.go
+++ b/internal/e2e/updatetest/update_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +17,6 @@ import (
 var arch = runtime.GOARCH
 
 const dockerFile = "test.Dockerfile"
-const daemonHost = "127.0.0.1:8800"
 
 func TestUpdatePackage(t *testing.T) {
 	fmt.Printf("***** ARCH %s ***** \n", arch)
@@ -43,11 +41,7 @@ func TestUpdatePackage(t *testing.T) {
 
 		t.Run("CLI Command", func(t *testing.T) {
 			const containerName = "apt-test-update"
-			t.Cleanup(func() { stopDockerContainer(t, containerName) })
-
-			t.Logf("start container %s and wait for daemon", containerName)
-			startDockerContainer(t, containerName, dockerImageName)
-			waitForPort(t, daemonHost, 5*time.Second)
+			startDaemonContainer(t, containerName, dockerImageName)
 
 			preUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+preUpdateVersion, tagAppCli)
@@ -60,11 +54,7 @@ func TestUpdatePackage(t *testing.T) {
 
 		t.Run("HTTP Request", func(t *testing.T) {
 			const containerName = "apt-test-update-http"
-			t.Cleanup(func() { stopDockerContainer(t, containerName) })
-
-			t.Logf("start container %s and wait for daemon", containerName)
-			startDockerContainer(t, containerName, dockerImageName)
-			waitForPort(t, daemonHost, 5*time.Second)
+			startDaemonContainer(t, containerName, dockerImageName)
 
 			preUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+preUpdateVersion, tagAppCli)
@@ -77,8 +67,61 @@ func TestUpdatePackage(t *testing.T) {
 		})
 	})
 
-	// Test that the upgrade works from a newer version to the current one.
-	t.Run("CurrentToStable", func(t *testing.T) {
+	// Test the steady state, with both ends of the upgrade built from the current
+	// source: it is the only case where the changes in the branch are in place
+	// both while the upgrade runs and after it.
+	t.Run("CurrentToCurrent", func(t *testing.T) {
+		t.Cleanup(func() { os.RemoveAll("build") })
+
+		// Both debs are built here, so the versions only need to be ordered.
+		const fromTag = "v9.9.0"
+		const toTag = "v9.9.1"
+
+		fetchDebPackageLatest(t, "build/stable", "arduino/arduino-router")
+
+		t.Logf("Updating from current version %s to current version %s", fromTag, toTag)
+		t.Logf("build deb version %s", fromTag)
+		buildDebVersion(t, "build/stable", fromTag, arch)
+		t.Logf("build deb version %s", toTag)
+		buildDebVersion(t, "build", toTag, arch)
+
+		const dockerImageName = "test-apt-update-current-image"
+		t.Logf("build docker image %s", dockerImageName)
+		buildDockerImage(t, dockerFile, dockerImageName, arch)
+		t.Cleanup(func() { removeDockerImage(t, dockerImageName) })
+
+		t.Run("CLI Command", func(t *testing.T) {
+			const containerName = "apt-test-update-current"
+			startDaemonContainer(t, containerName, dockerImageName)
+
+			preUpdateVersion := getAppCliVersion(t, containerName)
+			require.Equal(t, "v"+preUpdateVersion, fromTag)
+
+			runSystemUpdate(t, containerName)
+
+			postUpdateVersion := getAppCliVersion(t, containerName)
+			require.Equal(t, "v"+postUpdateVersion, toTag)
+		})
+
+		t.Run("HTTP Request", func(t *testing.T) {
+			const containerName = "apt-test-update-current-http"
+			startDaemonContainer(t, containerName, dockerImageName)
+
+			preUpdateVersion := getAppCliVersion(t, containerName)
+			require.Equal(t, "v"+preUpdateVersion, fromTag)
+
+			putUpdateRequest(t, daemonHost)
+			waitForUpgrade(t, daemonHost)
+
+			postUpdateVersion := getAppCliVersion(t, containerName)
+			require.Equal(t, "v"+postUpdateVersion, toTag)
+		})
+	})
+
+	// The destination is a deb published before this branch, so none of the
+	// changes in the current source survive the upgrade. A failure here means
+	// this version cannot be downgraded, not that the upgrade is broken.
+	t.Run("DowngradeToPublishedRelease", func(t *testing.T) {
 		t.Cleanup(func() { os.RemoveAll("build") })
 
 		tagAppCli := fetchDebPackageLatest(t, "build", "arduino/arduino-app-cli")
@@ -86,6 +129,13 @@ func TestUpdatePackage(t *testing.T) {
 
 		minorTag := genMinorTag(t, tagAppCli)
 		t.Logf("Updating from unstable version %s to stable version %s", minorTag, tagAppCli)
+
+		t.Cleanup(func() {
+			if t.Failed() {
+				t.Logf("DOWNGRADE NOT SUPPORTED: the published %s predates this build, so nothing "+
+					"%s changes in the package survives the upgrade", tagAppCli, minorTag)
+			}
+		})
 
 		t.Logf("build deb version %s", minorTag)
 		buildDebVersion(t, "build/stable", minorTag, arch)
@@ -97,11 +147,7 @@ func TestUpdatePackage(t *testing.T) {
 
 		t.Run("CLI Command", func(t *testing.T) {
 			const containerName = "apt-test-update-unstable"
-			t.Cleanup(func() { stopDockerContainer(t, containerName) })
-
-			t.Logf("start container %s and wait for daemon", containerName)
-			startDockerContainer(t, containerName, dockerImageName)
-			waitForPort(t, daemonHost, 5*time.Second)
+			startDaemonContainer(t, containerName, dockerImageName)
 
 			preUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+preUpdateVersion, minorTag)
@@ -114,11 +160,7 @@ func TestUpdatePackage(t *testing.T) {
 
 		t.Run("HTTP Request", func(t *testing.T) {
 			const containerName = "apt-test-update--unstable-http"
-			t.Cleanup(func() { stopDockerContainer(t, containerName) })
-
-			t.Logf("start container %s and wait for daemon", containerName)
-			startDockerContainer(t, containerName, dockerImageName)
-			waitForPort(t, daemonHost, 5*time.Second)
+			startDaemonContainer(t, containerName, dockerImageName)
 
 			preUpdateVersion := getAppCliVersion(t, containerName)
 			require.Equal(t, "v"+preUpdateVersion, minorTag)


### PR DESCRIPTION
### Motivation

The update test running in the CI wasn't testing the real case of a new version upgrading to a new new version. It instead tested old and new updates back and forth. This is conceptually wrong because the important thing is to keep updates working forward; backward compatibility isn't a requirement.

### Change description

1. Speed up the update test via matrix strategy
2. Shim the `system init` to completely skip image and library installation
3. Run the update CI on every PR
4. Include a new `CurrentToCurrent`
5. Rename `CurrentToStable` to `DowngradeToPublishedRelease` and make it optional
6. Collect CLI and daemon logs in debug mode, printed to stdout instead of uploaded as artifacts
7. Check also the daemon version and not only the binary version

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
