### PR TITLE
fix: handle sigterm signal for systemd

### DIFF
--- a/cmd/arduino-app-cli/daemon/daemon.go
+++ b/cmd/arduino-app-cli/daemon/daemon.go
@@ -138,7 +138,7 @@ func httpHandler(ctx context.Context, cfg config.Configuration, daemonPort, vers
 
 	// Start the HTTP server
 	address := "127.0.0.1:" + daemonPort
-	// All the requests derive from srvCtx: cancelling it interrupts the long-lived
+	// All the requests derive from srvCtx: canceling it interrupts the long-lived
 	// SSE streams, that otherwise block the shutdown until the timeout.
 	srvCtx, cancelRequests := context.WithCancel(context.Background())
 	httpSrv := http.Server{

--- a/cmd/arduino-app-cli/daemon/daemon.go
+++ b/cmd/arduino-app-cli/daemon/daemon.go
@@ -138,7 +138,7 @@ func httpHandler(ctx context.Context, cfg config.Configuration, daemonPort, vers
 
 	// Start the HTTP server
 	address := "127.0.0.1:" + daemonPort
-	// All the requests derive from srvCtx: canceling it interrupts the long-lived
+	// All the requests derive from srvCtx: canceling it interrupts all requests, including the long-lived
 	// SSE streams, that otherwise block the shutdown until the timeout.
 	srvCtx, cancelRequests := context.WithCancel(context.Background())
 	httpSrv := http.Server{

--- a/cmd/arduino-app-cli/daemon/daemon.go
+++ b/cmd/arduino-app-cli/daemon/daemon.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 
@@ -114,9 +115,9 @@ func httpHandler(ctx context.Context, cfg config.Configuration, daemonPort, vers
 		servicelocator.GetDockerClient(),
 		version,
 		update.NewManager(
-			apt.New().WithSelfKill(),
+			apt.New(),
 			arduino.NewArduinoPlatformUpdater(servicelocator.GetPlatform(), cfg.ArduinoPlatformVersionConstraint),
-		),
+		).WithSelfRestart(),
 		servicelocator.GetProvisioner(),
 		servicelocator.GetModelsIndex(),
 		servicelocator.GetBricksIndex(),
@@ -137,10 +138,14 @@ func httpHandler(ctx context.Context, cfg config.Configuration, daemonPort, vers
 
 	// Start the HTTP server
 	address := "127.0.0.1:" + daemonPort
+	// All the requests derive from srvCtx: cancelling it interrupts the long-lived
+	// SSE streams, that otherwise block the shutdown until the timeout.
+	srvCtx, cancelRequests := context.WithCancel(context.Background())
 	httpSrv := http.Server{
 		Addr:              address,
 		Handler:           httprecover.RecoverPanic(apiSrv),
 		ReadHeaderTimeout: 60 * time.Second,
+		BaseContext:       func(net.Listener) context.Context { return srvCtx },
 	}
 	go func() {
 		if err := httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -151,8 +156,10 @@ func httpHandler(ctx context.Context, cfg config.Configuration, daemonPort, vers
 	<-ctx.Done()
 	slog.Info("Shutting down HTTP server", slog.String("address", address))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	_ = httpSrv.Shutdown(ctx)
+	cancelRequests()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	_ = httpSrv.Shutdown(shutdownCtx)
 	cancel()
 	slog.Info("HTTP server shut down", slog.String("address", address))
 }

--- a/cmd/arduino-app-cli/main.go
+++ b/cmd/arduino-app-cli/main.go
@@ -82,6 +82,12 @@ func run(configuration cfg.Configuration) error {
 		syscall.SIGTERM, // SIGTERM used by systemd in daemon mode.
 	)
 	defer stop()
+	// Restore the default action after the first signal, so that a second Ctrl+C
+	// or SIGTERM still kills a command that ignores its context.
+	go func() {
+		<-ctx.Done()
+		stop()
+	}()
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		return err
 	}

--- a/cmd/arduino-app-cli/main.go
+++ b/cmd/arduino-app-cli/main.go
@@ -11,9 +11,10 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
-	"go.bug.st/cleanup"
 
 	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/app"
 	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/brick"
@@ -76,8 +77,11 @@ func run(configuration cfg.Configuration) error {
 		model.NewModelCmd(configuration),
 	)
 
-	ctx := context.Background()
-	ctx, _ = cleanup.InterruptableContext(ctx)
+	ctx, stop := signal.NotifyContext(context.Background(),
+		os.Interrupt,    // SIGINT used by Ctrl+C in interactive mode.
+		syscall.SIGTERM, // SIGTERM used by systemd in daemon mode.
+	)
+	defer stop()
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/tmaxmax/go-sse v0.11.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/warthog618/go-gpiocdev v0.9.1
-	go.bug.st/cleanup v1.0.0
 	go.bug.st/f v0.5.0
 	go.bug.st/relaxed-semver v0.15.0
 	golang.org/x/crypto v0.54.0
@@ -329,6 +328,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zclconf/go-cty v1.17.0 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
+	go.bug.st/cleanup v1.0.0 // indirect
 	go.bug.st/downloader/v3 v3.0.0 // indirect
 	go.bug.st/serial v1.8.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/internal/api/handlers/update.go
+++ b/internal/api/handlers/update.go
@@ -135,6 +135,31 @@ func HandleUpdateEvents(updater *update.Manager) http.HandlerFunc {
 		ch := updater.Subscribe()
 		defer updater.Unsubscribe(ch)
 
+		forward := func(event update.Event) {
+			switch event.Type {
+			case update.ErrorEvent:
+				err := event.GetError()
+				code := render.InternalServiceErr
+				if c := update.GetUpdateErrorCode(err); c != update.UnknownErrorCode {
+					code = render.SSEErrCode(string(c))
+				}
+				sseStream.SendError(render.SSEErrorData{
+					Code:    code,
+					Message: err.Error(),
+				})
+			case update.ProgressEvent:
+				sseStream.Send(render.SSEEvent{
+					Type: event.Type.String(),
+					Data: event.GetProgress(),
+				})
+			default:
+				sseStream.Send(render.SSEEvent{
+					Type: event.Type.String(),
+					Data: event.GetData(),
+				})
+			}
+		}
+
 		for {
 			select {
 			case event, ok := <-ch:
@@ -142,31 +167,22 @@ func HandleUpdateEvents(updater *update.Manager) http.HandlerFunc {
 					slog.Info("APT event channel closed, stopping SSE stream")
 					return
 				}
-				switch event.Type {
-				case update.ErrorEvent:
-					err := event.GetError()
-					code := render.InternalServiceErr
-					if c := update.GetUpdateErrorCode(err); c != update.UnknownErrorCode {
-						code = render.SSEErrCode(string(c))
-					}
-					sseStream.SendError(render.SSEErrorData{
-						Code:    code,
-						Message: err.Error(),
-					})
-				case update.ProgressEvent:
-					sseStream.Send(render.SSEEvent{
-						Type: event.Type.String(),
-						Data: event.GetProgress(),
-					})
-				default:
-					sseStream.Send(render.SSEEvent{
-						Type: event.Type.String(),
-						Data: event.GetData(),
-					})
-				}
+				forward(event)
 
 			case <-r.Context().Done():
-				return
+				// The daemon is shutting down, the self upgrade above all: deliver
+				// the events already broadcast, the restarting one included.
+				for {
+					select {
+					case event, ok := <-ch:
+						if !ok {
+							return
+						}
+						forward(event)
+					default:
+						return
+					}
+				}
 			}
 		}
 	}

--- a/internal/render/sse.go
+++ b/internal/render/sse.go
@@ -75,7 +75,9 @@ func NewSSEStream(ctx context.Context, w http.ResponseWriter) (*SSEStream, error
 
 	const maxStreamTime = 24 * time.Hour
 
-	ctx, cancel := context.WithTimeout(ctx, maxStreamTime)
+	// The write loop outlives the request context on purpose: it lets the handler
+	// flush its last events when a shutdown cancels the request. Close ends it.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), maxStreamTime)
 	s := &SSEStream{
 		sseFlusher:        flusher,
 		heartbeatInterval: 30 * time.Second,
@@ -104,7 +106,7 @@ func (s *SSEStream) loop() {
 	for {
 		select {
 		case <-s.ctx.Done():
-			slog.Debug("stream SSE request context done")
+			slog.Debug("SSE stream closed")
 			return
 		case <-time.After(s.heartbeatInterval):
 			if err := s.heartbeat(); err != nil {

--- a/internal/render/sse.go
+++ b/internal/render/sse.go
@@ -131,15 +131,16 @@ func (s *SSEStream) Send(event SSEEvent) {
 		slog.Debug("SSE stream is closing, ignoring event", slog.String("event", event.Type))
 		return
 	}
-	s.messageCh <- event
+	select {
+	case s.messageCh <- event:
+	case <-s.stoppedCh:
+		// The write loop is gone, a failed write above all: never block the caller.
+		slog.Debug("SSE stream is stopped, ignoring event", slog.String("event", event.Type))
+	}
 }
 
 func (s *SSEStream) SendError(event SSEErrorData) {
-	if s.isClosing.Load() {
-		slog.Debug("SSE stream is closing, ignoring event", slog.String("event", "error"))
-		return
-	}
-	s.messageCh <- SSEEvent{Type: "error", Data: event}
+	s.Send(SSEEvent{Type: "error", Data: event})
 }
 
 func (s *SSEStream) Close() {

--- a/internal/update/apt/service.go
+++ b/internal/update/apt/service.go
@@ -13,12 +13,9 @@ import (
 	"io"
 	"iter"
 	"log/slog"
-	"os"
 	"regexp"
-	"slices"
 	"strings"
 	"sync"
-	"syscall"
 
 	"github.com/arduino/go-paths-helper"
 	"go.bug.st/f"
@@ -30,19 +27,11 @@ import (
 // Service for apt package management operations.
 // It manages subscribers and publishes events to all of them.
 type Service struct {
-	lock     sync.Mutex
-	selfKill bool
+	lock sync.Mutex
 }
 
 func New() *Service {
 	return &Service{}
-}
-
-// The daemon is restarted after a self-upgrade either way: only it may take the
-// shortcut of killing itself, since systemd respawns it. The CLI must not.
-func (s *Service) WithSelfKill() *Service {
-	s.selfKill = true
-	return s
 }
 
 // ListUpgradablePackages lists all upgradable packages using the `apt list --upgradable` command.
@@ -70,8 +59,6 @@ func (s *Service) ListUpgradablePackages(ctx context.Context, matcher func(updat
 	return pkgs, nil
 }
 
-const selfPackageName = "arduino-app-cli"
-
 // Progress milestones on a local 0-100 scale: the Manager rescales them to the
 // slice of the whole update process this updater is responsible for. Most of the
 // scale is reserved to the docker images download, by far the longest step.
@@ -89,24 +76,6 @@ const (
 func (s *Service) UpgradePackages(ctx context.Context, packages []update.PackageInfo, eventCB update.EventCallback) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-
-	selfUpgrade := slices.ContainsFunc(packages, func(p update.PackageInfo) bool {
-		return p.Name == selfPackageName
-	})
-
-	defer func() {
-		if !selfUpgrade || !s.selfKill {
-			return
-		}
-		eventCB(update.NewDataEvent(update.RestartEvent, fmt.Sprintf("Upgrade completed. Restarting (pid %d) ...", os.Getpid())))
-		// needrestart skips its caller's cgroup, so we signal ourselves
-		// to let systemd respawn us on the new binary.
-		if p, err := os.FindProcess(os.Getpid()); err == nil {
-			if err := p.Signal(syscall.SIGTERM); err != nil {
-				slog.Error("failed to send SIGTERM to self after upgrade", slog.String("error", err.Error()))
-			}
-		}
-	}()
 
 	names := f.Map(packages, func(pkg update.PackageInfo) string {
 		return pkg.Name

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -10,9 +10,12 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -45,11 +48,15 @@ type ServiceUpdater interface {
 	UpgradePackages(ctx context.Context, packages []PackageInfo, eventCB EventCallback) error
 }
 
+// The deb package of this very program: upgrading it needs a process restart.
+const selfPackageName = "arduino-app-cli"
+
 type Manager struct {
 	lock                         sync.Mutex
 	isUpgrading                  atomic.Bool
 	debUpdateService             ServiceUpdater
 	arduinoPlatformUpdateService ServiceUpdater
+	selfRestart                  bool
 
 	mu   sync.RWMutex
 	subs map[chan Event]struct{}
@@ -61,6 +68,13 @@ func NewManager(debUpdateService ServiceUpdater, arduinoPlatformUpdateService Se
 		arduinoPlatformUpdateService: arduinoPlatformUpdateService,
 		subs:                         make(map[chan Event]struct{}),
 	}
+}
+
+// The daemon is restarted after a self-upgrade either way: only it may take the
+// shortcut of killing itself, since systemd respawns it. The CLI must not.
+func (m *Manager) WithSelfRestart() *Manager {
+	m.selfRestart = true
+	return m
 }
 
 func (m *Manager) ListUpgradablePackages(ctx context.Context, matcher func(UpgradablePackage) bool) ([]UpgradablePackage, error) {
@@ -171,6 +185,18 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 		m.broadcast(NewProgressEvent("upgrade", 100.0))
 
 		m.broadcast(NewDataEvent(DoneEvent, "Update completed"))
+
+		isSelfUpgrade := slices.ContainsFunc(debPkgs, func(p PackageInfo) bool { return p.Name == selfPackageName })
+		if m.selfRestart && isSelfUpgrade {
+			m.broadcast(NewDataEvent(RestartEvent, fmt.Sprintf("Upgrade completed. Restarting (pid %d) ...", os.Getpid())))
+			// needrestart skips its caller's cgroup, so we signal ourselves to let
+			// systemd respawn us on the new binary, after the last broadcast.
+			if p, err := os.FindProcess(os.Getpid()); err == nil {
+				if err := p.Signal(syscall.SIGTERM); err != nil {
+					slog.Error("failed to send SIGTERM to self after upgrade", slog.String("error", err.Error()))
+				}
+			}
+		}
 	}()
 	return nil
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -182,15 +182,18 @@ func (m *Manager) UpgradePackages(ctx context.Context, pkgs []UpgradablePackage)
 			// operation, DoneEvent is always broadcast as the only terminal event.
 		}
 
+		restartSelf := m.selfRestart && slices.ContainsFunc(debPkgs, func(p PackageInfo) bool { return p.Name == selfPackageName })
+		if restartSelf {
+			m.broadcast(NewDataEvent(RestartEvent, fmt.Sprintf("Upgrade completed. Restarting (pid %d) ...", os.Getpid())))
+		}
+
 		m.broadcast(NewProgressEvent("upgrade", 100.0))
 
 		m.broadcast(NewDataEvent(DoneEvent, "Update completed"))
 
-		isSelfUpgrade := slices.ContainsFunc(debPkgs, func(p PackageInfo) bool { return p.Name == selfPackageName })
-		if m.selfRestart && isSelfUpgrade {
-			m.broadcast(NewDataEvent(RestartEvent, fmt.Sprintf("Upgrade completed. Restarting (pid %d) ...", os.Getpid())))
+		if restartSelf {
 			// needrestart skips its caller's cgroup, so we signal ourselves to let
-			// systemd respawn us on the new binary, after the last broadcast.
+			// systemd respawn us on the new binary. DoneEvent stays the last event.
 			if p, err := os.FindProcess(os.Getpid()); err == nil {
 				if err := p.Signal(syscall.SIGTERM); err != nil {
 					slog.Error("failed to send SIGTERM to self after upgrade", slog.String("error", err.Error()))


### PR DESCRIPTION
### Motivation

Our graceful shutdown mechanism wasn't handling the SIGTERM signal used by systemd, and recently also by us. 

This is especially important in the update flow, when we signal ourselves to restart, and we will need to make sure all the inflight messages to the FE are actually sent.

### Change description

This PR also cover all the following changes to be sure the daemon server is correctly terminated.

1. Add a custom context in the handler so we can kill the ongoing SSE stream
1. Move the daemon self-kill in the update manager so we are sure restart events are always sent
1. Make sure all the channels, including SSE and update broadcast ones, are flushed before termination

So the termination flow is:

1. The daemon receives SIGINT 
2. We signal termination with a new context 
4. All ongoing requests are terminated, including the SSE ones
5. At most after 30 seconds, the whole server is stopped

If the signal is sent by themself for autotermination, we are sure that all the channels are flushed and so the SSE caller got the restart|done event.

This PR also covers all the following changes to be sure the daemon server is correctly terminated.

1. Handle SIGTERM, and not only SIGINT, in the root context of the CLI
1. Give the HTTP server a custom `BaseContext`, so we can kill the ongoing SSE streams
1. Move the daemon self-kill from the apt service to the update manager, so the restart and done events are always broadcast before the signal
1. Flush the events already broadcast to the SSE clients before their streams are closed

So the termination flow is:

1. The daemon receives SIGTERM, or SIGINT when it runs in a terminal
2. The root context is cancelled, and with it the context of every ongoing request
3. Each SSE stream delivers the events it already has, then it is closed with the `close` event
4. The server waits for the handlers, 30 seconds at most; with the streams cut, it takes milliseconds

If the signal is sent by ourselves for autotermination, every event is broadcast before the signal is raised, so the SSE caller always gets the `restarting` and `done` events.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [x] PR addresses a single concern.
- [x] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [x] Logging is meaningful in case of troubleshooting.
