### PR TITLE
feat(task): publish a locally built package as an update on the board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ go.work.sum
 
 build/
 
+# local task configuration, may hold the board password
+.env.local
+
 **/.cache
 
 /arduino-app-cli

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -260,6 +260,68 @@ tasks:
       - adb push ./build/arduino-app-cli_*_arm64.deb /tmp/
       - ./scripts/run-remote-sudo.sh "dpkg -i /tmp/arduino-app-cli*_arm64.deb && needrestart -r a"
 
+  # Publishes the working tree on the board as the update that `system update`
+  # will offer, by turning a locally built package into an apt repository the
+  # board follows. The package must come from the working tree and not from a
+  # release, because the update path depends on files shipped by the package
+  # itself: both ends of the upgrade have to carry the code under test.
+  #
+  # The board is reached over adb by default; set BOARD (e.g.
+  # BOARD=arduino@my-board.local, also via `.env.local`) to use ssh instead, and
+  # BOARD_PASSWORD to skip the password prompts.
+  board:publish-update:
+    desc: Build the working tree as a .deb and publish it on the board as the available update
+    interactive: true
+    vars:
+      REPO_DIR: ./build/local-apt-repo
+      STAGING_DIR: /tmp/arduino-app-cli-local-repo
+      BOARD_REPO_DIR: /opt/arduino-app-cli-local-repo
+      SOURCE_LIST: /etc/apt/sources.list.d/arduino-app-cli-local.list
+      # A version that outranks whatever the official repository offers, so apt
+      # picks the local build as the candidate.
+      LOCAL_VERSION:
+        sh: echo "${LOCAL_VERSION:-99.0.0+$(git rev-parse --short HEAD)}"
+    cmds:
+      - rm -rf {{ .REPO_DIR }}
+      - task: build-deb
+        vars:
+          VERSION: "{{ .LOCAL_VERSION }}"
+          OUTPUT: "{{ .REPO_DIR }}"
+      - ./scripts/build-apt-repo.sh {{ .REPO_DIR }}
+      - ./scripts/board-push.sh {{ .REPO_DIR }} {{ .STAGING_DIR }}
+      - |
+          ./scripts/board-sudo.sh "$(cat <<'EOS'
+          set -e
+          rm -rf {{ .BOARD_REPO_DIR }}
+          mkdir -p {{ .BOARD_REPO_DIR }}
+          cp -r {{ .STAGING_DIR }}/. {{ .BOARD_REPO_DIR }}/
+          rm -rf {{ .STAGING_DIR }}
+          chown -R root:root {{ .BOARD_REPO_DIR }}
+          chmod -R a+rX {{ .BOARD_REPO_DIR }}
+          printf 'deb [trusted=yes] file:%s ./\n' {{ .BOARD_REPO_DIR }} > {{ .SOURCE_LIST }}
+          apt-get update
+          apt-cache policy arduino-app-cli
+          EOS
+          )"
+      - echo "Version {{ .LOCAL_VERSION }} published, 'system update' on the board now offers it."
+
+  board:publish-update:clean:
+    desc: Remove the locally published update from the board, restoring the official repository
+    interactive: true
+    vars:
+      BOARD_REPO_DIR: /opt/arduino-app-cli-local-repo
+      SOURCE_LIST: /etc/apt/sources.list.d/arduino-app-cli-local.list
+    cmds:
+      - |
+          ./scripts/board-sudo.sh "$(cat <<'EOS'
+          set -e
+          rm -f {{ .SOURCE_LIST }}
+          rm -rf {{ .BOARD_REPO_DIR }}
+          apt-get update
+          apt-cache policy arduino-app-cli
+          EOS
+          )"
+
   bump:runner-version:
     desc: Update the RunnerVersion constant in config.go to match RUNNER_VERSION.
     vars:

--- a/docs/contributor-guide/development.md
+++ b/docs/contributor-guide/development.md
@@ -60,6 +60,23 @@ This is reccomended way to test a local development version of Arduino App CLI o
 1. Connect an [Arduino UNO Q](https://docs.arduino.cc/hardware/uno-q/) board via USB.
 1. `go tool task board:install` installs the current version of Arduino App CLI on the board (`adb` is needed). The password of the `arduino` username of the board is requested.
 
+## Testing the system update flow on the board
+
+To test an update on the board, the working tree has to be offered as the available upgrade instead of the released version.
+
+- `go tool task board:publish-update` builds the debian package from the working tree with a version that outranks the official one, copies it to `/opt/arduino-app-cli-local-repo` on the board, generates the package index next to it, and registers that directory as an apt source. From that point on, an update triggered through the daemon, the CLI, or the app installs the code under test.
+- `go tool task board:publish-update:clean` removes the source and the directory, putting the board back to following the official repository.
+
+The package is built from the working tree and not fetched from a release on purpose: the update path also depends on files shipped by the package itself, so both ends of the upgrade have to carry the code under test.
+
+The board is reached over `adb` by default. To use `ssh` instead, set `BOARD` to the board address, either inline or in `.env.local`:
+
+```
+BOARD=arduino@my-board.local go tool task board:publish-update
+```
+
+Both tasks ask for the board password (up to three times over `ssh`: login, copy, and `sudo`). Setting `BOARD_PASSWORD` skips every prompt and runs unattended; it requires `sshpass`, and it is passed through `sshpass -e`, so it does not show up in the process list. Keep it in `.env.local`, which is not tracked.
+
 ## Automatic Corrections
 
 Tools are provided to automatically bring the project into compliance with some of the required checks.

--- a/scripts/board-push.sh
+++ b/scripts/board-push.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# This file is part of arduino-app-cli.
+#
+# SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Copies a local file or directory to the board.
+#
+# The transport is selected by the BOARD variable (it can be set in `.env.local`,
+# which the Taskfile loads):
+#   BOARD unset             -> adb, for a board connected via USB
+#   BOARD=arduino@<host>    -> ssh/scp
+#
+# Set BOARD_PASSWORD to avoid being asked for the board password at every step;
+# it is handed to ssh through `sshpass -e`, so it never shows up in the process
+# list.
+#
+# The remote path is always the final destination, never the parent directory,
+# and it is replaced if it already exists.
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <local-path> <remote-path>" >&2
+  exit 1
+fi
+
+LOCAL_PATH="$1"
+REMOTE_PATH="$2"
+
+if [ -z "${BOARD:-}" ]; then
+  adb shell "rm -rf '$REMOTE_PATH'"
+  adb push "$LOCAL_PATH" "$REMOTE_PATH"
+  exit 0
+fi
+
+if [ -n "${BOARD_PASSWORD:-}" ]; then
+  if ! command -v sshpass >/dev/null; then
+    echo "$0: BOARD_PASSWORD is set but sshpass is not installed" >&2
+    exit 1
+  fi
+  export SSHPASS="$BOARD_PASSWORD"
+  ssh_cmd() { sshpass -e ssh "$@"; }
+  scp_cmd() { sshpass -e scp "$@"; }
+else
+  ssh_cmd() { ssh "$@"; }
+  scp_cmd() { scp "$@"; }
+fi
+
+ssh_cmd "$BOARD" "rm -rf '$REMOTE_PATH'"
+scp_cmd -r "$LOCAL_PATH" "$BOARD:$REMOTE_PATH"

--- a/scripts/board-sudo.sh
+++ b/scripts/board-sudo.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# This file is part of arduino-app-cli.
+#
+# SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Runs a command as sudo on the board, asking for the password interactively.
+#
+# The transport is selected by the BOARD variable (it can be set in `.env.local`,
+# which the Taskfile loads):
+#   BOARD unset             -> adb, for a board connected via USB
+#   BOARD=arduino@<host>    -> ssh
+#
+# Set BOARD_PASSWORD to skip the prompt and run unattended; over ssh it is also
+# handed to the login through `sshpass -e`, so it never shows up in the process
+# list.
+#
+# The command is given as arguments, and may span multiple lines:
+#   ./scripts/board-sudo.sh "apt-get update && apt-get install -y foo"
+
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <command>" >&2
+  exit 1
+fi
+
+# The command travels base64-encoded and is decoded on the board: that keeps it
+# intact through the local shell, the remote shell, and (for adb) the way adb
+# joins its arguments back into a single command line.
+ENCODED_CMD="$(printf '%s' "$*" | base64 | tr -d '\n')"
+# The decoding happens in a command substitution, so that stdin stays free for
+# the password that `sudo -S` reads.
+REMOTE_CMD="sudo -S sh -c \"\$(printf %s $ENCODED_CMD | base64 -d)\""
+
+if [ -n "${BOARD_PASSWORD:-}" ]; then
+  SUDO_PASS="$BOARD_PASSWORD"
+else
+  read -r -s -p "Enter device sudo password: " SUDO_PASS
+  echo
+fi
+
+if [ -z "${BOARD:-}" ]; then
+  echo "$SUDO_PASS" | adb shell "$REMOTE_CMD"
+  exit 0
+fi
+
+if [ -n "${BOARD_PASSWORD:-}" ]; then
+  if ! command -v sshpass >/dev/null; then
+    echo "$0: BOARD_PASSWORD is set but sshpass is not installed" >&2
+    exit 1
+  fi
+  export SSHPASS="$BOARD_PASSWORD"
+  echo "$SUDO_PASS" | sshpass -e ssh "$BOARD" "$REMOTE_CMD"
+else
+  echo "$SUDO_PASS" | ssh "$BOARD" "$REMOTE_CMD"
+fi

--- a/scripts/build-apt-repo.sh
+++ b/scripts/build-apt-repo.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# This file is part of arduino-app-cli.
+#
+# SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Turns a directory containing .deb files into a flat apt repository, by
+# generating the package index (`Packages`, `Packages.gz`, `Release`) next to
+# them.
+#
+# The index is generated here and not on the board, because `dpkg-dev` and
+# `apt-utils` are not part of the board image, and installing them there would
+# alter the very system we are about to test. Docker is already required to
+# build the package, so it is used to provide those tools.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <repo-dir>" >&2
+  exit 1
+fi
+
+REPO_DIR="$(cd "$1" && pwd)"
+IMAGE="arduino-app-cli-aptrepo"
+
+# Cached by docker after the first run.
+docker build -q -t "$IMAGE" - <<'DOCKERFILE'
+FROM debian:bookworm
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends dpkg-dev apt-utils \
+  && rm -rf /var/lib/apt/lists/*
+DOCKERFILE
+
+# Run as the current user, so the generated files are not owned by root.
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  --volume "$REPO_DIR:/repo" \
+  --workdir /repo \
+  "$IMAGE" \
+  sh -euc '
+    rm -f Packages Packages.gz Release
+    dpkg-scanpackages --multiversion . > Packages
+    gzip --keep --force Packages
+    # Written aside and moved in place, so that the index does not end up
+    # describing a half-written copy of itself.
+    apt-ftparchive release . > Release.tmp
+    mv Release.tmp Release
+  '
+
+echo "Apt repository index generated in ${REPO_DIR}."


### PR DESCRIPTION
Closes #596

Adds `board:publish-update`: builds the working tree as a `.deb` with a version that
outranks the official one, copies it to the board, generates the apt index next to it
and registers it as an apt source, so a `system update` installs the code under test.

## Usage

```
go tool task board:publish-update          # publish
go tool task board:publish-update:clean    # remove it, back to the official repo
```

The board is reached over `adb` by default. Set `BOARD` for ssh, and `BOARD_PASSWORD`
(needs `sshpass`) to skip the password prompts:

```
BOARD=arduino@my-board.local BOARD_PASSWORD=... go tool task board:publish-update
```

The index is generated in Docker, not on the board, which has no `dpkg-dev`.
`board:install` is untouched.

Tested on an UNO Q: candidate becomes the local build and `apt list --upgradable`
reports it, so the daemon offers it.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
