### PR TITLE
fix: remove arduino user and home dependency

### DIFF
--- a/debian/arduino-app-cli/DEBIAN/postinst
+++ b/debian/arduino-app-cli/DEBIAN/postinst
@@ -6,13 +6,13 @@ systemctl enable arduino-avahi-serial.service
 mkdir -p /etc/bash_completion.d/
 export ARDUINO_APP_CLI__ALLOW_ROOT=true && arduino-app-cli completion bash > /etc/bash_completion.d/arduino-app-cli.bash || true
 
-chown -R arduino:arduino /var/lib/arduino-app-cli \
-|| chown -R :arduino /var/lib/arduino-app-cli
+chown -R 1000:arduino /var/lib/arduino-app-cli
 
 chmod -R 775 /var/lib/arduino-app-cli
 
-if [ "$1" = "configure" ]; then
-    rm -rf /home/arduino/.local/share/arduino-app-cli
+user_home="$(getent passwd 1000 | cut -d: -f6)"
+if [ "$1" = "configure" ] && [ -n "$user_home" ]; then
+    rm -rf "$user_home/.local/share/arduino-app-cli"
 fi
 
 #LOAD_HELPER

--- a/debian/arduino-app-cli/DEBIAN/postinst
+++ b/debian/arduino-app-cli/DEBIAN/postinst
@@ -6,12 +6,13 @@ systemctl enable arduino-avahi-serial.service
 mkdir -p /etc/bash_completion.d/
 export ARDUINO_APP_CLI__ALLOW_ROOT=true && arduino-app-cli completion bash > /etc/bash_completion.d/arduino-app-cli.bash || true
 
-chown -R 1000:arduino /var/lib/arduino-app-cli
+chown -R arduino:arduino /var/lib/arduino-app-cli \
+|| chown -R :arduino /var/lib/arduino-app-cli
 
 chmod -R 775 /var/lib/arduino-app-cli
 
-user_home="$(getent passwd 1000 | cut -d: -f6)"
 if [ "$1" = "configure" ] && [ -n "$user_home" ]; then
+    user_home="$(getent passwd 1000 | cut -d: -f6)"
     rm -rf "$user_home/.local/share/arduino-app-cli"
 fi
 

--- a/debian/arduino-app-cli/DEBIAN/postinst
+++ b/debian/arduino-app-cli/DEBIAN/postinst
@@ -1,19 +1,23 @@
 #!/bin/bash
 
+USER_ID=1000
+
 systemctl enable arduino-app-cli
 systemctl enable arduino-avahi-serial.service
 
 mkdir -p /etc/bash_completion.d/
 export ARDUINO_APP_CLI__ALLOW_ROOT=true && arduino-app-cli completion bash > /etc/bash_completion.d/arduino-app-cli.bash || true
 
-chown -R arduino:arduino /var/lib/arduino-app-cli \
+USER_NAME="$(getent passwd "$USER_ID" | cut -d: -f1)"
+USER_HOME="$(getent passwd "$USER_ID" | cut -d: -f6)"
+
+chown -R "$USER_NAME":arduino /var/lib/arduino-app-cli \
 || chown -R :arduino /var/lib/arduino-app-cli
 
 chmod -R 775 /var/lib/arduino-app-cli
 
-if [ "$1" = "configure" ] && [ -n "$user_home" ]; then
-    user_home="$(getent passwd 1000 | cut -d: -f6)"
-    rm -rf "$user_home/.local/share/arduino-app-cli"
+if [ "$1" = "configure" ] && [ -n "$USER_HOME" ]; then
+    rm -rf "$USER_HOME/.local/share/arduino-app-cli"
 fi
 
 #LOAD_HELPER

--- a/debian/arduino-app-cli/DEBIAN/postinst.helper.sh
+++ b/debian/arduino-app-cli/DEBIAN/postinst.helper.sh
@@ -1,5 +1,5 @@
 configure_agent_profiles() {
-  USER_HOME="$(getent passwd 1000 | cut -d: -f6)"
+  USER_HOME="$(getent passwd "$USER_ID" | cut -d: -f6)"
   [ -n "$USER_HOME" ] || return 0
 
   MASTER_AGENT="/etc/arduino-app-cli/AGENTS.md"

--- a/debian/arduino-app-cli/DEBIAN/postinst.helper.sh
+++ b/debian/arduino-app-cli/DEBIAN/postinst.helper.sh
@@ -1,11 +1,13 @@
 configure_agent_profiles() {
-  USER_HOME="/home/arduino"
+  user_home="$(getent passwd 1000 | cut -d: -f6)"
+  [ -n "$user_home" ] || return 0
+
   MASTER_AGENT="/etc/arduino-app-cli/AGENTS.md"
   PATHS_TO_LINK="
-$USER_HOME/.claude/CLAUDE.md
-$USER_HOME/.gemini/GEMINI.md
-$USER_HOME/.codex/AGENTS.md
-$USER_HOME/.copilot/copilot-instructions.md
+$user_home/.claude/CLAUDE.md
+$user_home/.gemini/GEMINI.md
+$user_home/.codex/AGENTS.md
+$user_home/.copilot/copilot-instructions.md
 "
 
   INSTALLED_LINKS=""

--- a/debian/arduino-app-cli/DEBIAN/postinst.helper.sh
+++ b/debian/arduino-app-cli/DEBIAN/postinst.helper.sh
@@ -1,13 +1,13 @@
 configure_agent_profiles() {
-  user_home="$(getent passwd 1000 | cut -d: -f6)"
-  [ -n "$user_home" ] || return 0
+  USER_HOME="$(getent passwd 1000 | cut -d: -f6)"
+  [ -n "$USER_HOME" ] || return 0
 
   MASTER_AGENT="/etc/arduino-app-cli/AGENTS.md"
   PATHS_TO_LINK="
-$user_home/.claude/CLAUDE.md
-$user_home/.gemini/GEMINI.md
-$user_home/.codex/AGENTS.md
-$user_home/.copilot/copilot-instructions.md
+$USER_HOME/.claude/CLAUDE.md
+$USER_HOME/.gemini/GEMINI.md
+$USER_HOME/.codex/AGENTS.md
+$USER_HOME/.copilot/copilot-instructions.md
 "
 
   INSTALLED_LINKS=""

--- a/debian/arduino-app-cli/DEBIAN/postrm
+++ b/debian/arduino-app-cli/DEBIAN/postrm
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+USER_ID=1000
+
 if [ -d /run/systemd/system ]; then
   systemctl daemon-reload
 fi

--- a/debian/arduino-app-cli/DEBIAN/postrm.helper.sh
+++ b/debian/arduino-app-cli/DEBIAN/postrm.helper.sh
@@ -1,16 +1,16 @@
 cleanup_agent_profiles() {
-  user_home="$(getent passwd 1000 | cut -d: -f6)"
-  [ -n "$user_home" ] || return 0
+  USER_HOME="$(getent passwd 1000 | cut -d: -f6)"
+  [ -n "$USER_HOME" ] || return 0
 
   MASTER_AGENT="/etc/arduino-app-cli/AGENTS.md"
   PATHS_TO_LINK="
-$user_home/.claude/CLAUDE.md
-$user_home/.gemini/GEMINI.md
-$user_home/.codex/AGENTS.md
-$user_home/.copilot/copilot-instructions.md
+$USER_HOME/.claude/CLAUDE.md
+$USER_HOME/.gemini/GEMINI.md
+$USER_HOME/.codex/AGENTS.md
+$USER_HOME/.copilot/copilot-instructions.md
 "
 
-  echo "arduino-app-cli: Cleaning up AI agent symlinks in $user_home..."
+  echo "arduino-app-cli: Cleaning up AI agent symlinks in $USER_HOME..."
 
   for TARGET_PATH in $PATHS_TO_LINK; do
     [ -z "$TARGET_PATH" ] && continue

--- a/debian/arduino-app-cli/DEBIAN/postrm.helper.sh
+++ b/debian/arduino-app-cli/DEBIAN/postrm.helper.sh
@@ -1,14 +1,16 @@
 cleanup_agent_profiles() {
-  USER_HOME="/home/arduino"
+  user_home="$(getent passwd 1000 | cut -d: -f6)"
+  [ -n "$user_home" ] || return 0
+
   MASTER_AGENT="/etc/arduino-app-cli/AGENTS.md"
   PATHS_TO_LINK="
-$USER_HOME/.claude/CLAUDE.md
-$USER_HOME/.gemini/GEMINI.md
-$USER_HOME/.codex/AGENTS.md
-$USER_HOME/.copilot/copilot-instructions.md
+$user_home/.claude/CLAUDE.md
+$user_home/.gemini/GEMINI.md
+$user_home/.codex/AGENTS.md
+$user_home/.copilot/copilot-instructions.md
 "
 
-  echo "arduino-app-cli: Cleaning up AI agent symlinks in $USER_HOME..."
+  echo "arduino-app-cli: Cleaning up AI agent symlinks in $user_home..."
 
   for TARGET_PATH in $PATHS_TO_LINK; do
     [ -z "$TARGET_PATH" ] && continue

--- a/debian/arduino-app-cli/DEBIAN/postrm.helper.sh
+++ b/debian/arduino-app-cli/DEBIAN/postrm.helper.sh
@@ -1,5 +1,5 @@
 cleanup_agent_profiles() {
-  USER_HOME="$(getent passwd 1000 | cut -d: -f6)"
+  USER_HOME="$(getent passwd "$USER_ID" | cut -d: -f6)"
   [ -n "$USER_HOME" ] || return 0
 
   MASTER_AGENT="/etc/arduino-app-cli/AGENTS.md"

--- a/debian/arduino-app-cli/DEBIAN/preinst
+++ b/debian/arduino-app-cli/DEBIAN/preinst
@@ -20,7 +20,8 @@ if ! getent passwd "$USER_ID" >/dev/null 2>&1; then
         "arduino" >/dev/null
 fi
 
-username="$(getent passwd $USER_ID | cut -d: -f1)"
+username="$(getent passwd "$USER_ID" | cut -d: -f1)"
+USER_HOME="$(getent passwd "$USER_ID" | cut -d: -f6)"
 
 usermod -aG "$GROUP_NAME" "$username"
 
@@ -34,8 +35,7 @@ done
 # Starting with this version, the arduino-app-cli user directory is
 # no longer located at /home/arduino/.local/share/arduino-app-cli
 # Move the related file to the new location
-if [ "$1" = "upgrade" ]; then
-    USER_HOME="$(getent passwd $USER_ID | cut -d: -f6)"
+if [ "$1" = "upgrade" ] && [ -n "$USER_HOME" ]; then
     LEGACY_DIR="${USER_HOME}/.local/share/arduino-app-cli"
     mkdir -p /var/lib/arduino-app-cli
     cp "${LEGACY_DIR}/properties.msgpack" /var/lib/arduino-app-cli || true

--- a/debian/arduino-app-cli/DEBIAN/preinst
+++ b/debian/arduino-app-cli/DEBIAN/preinst
@@ -35,15 +35,15 @@ done
 # no longer located at /home/arduino/.local/share/arduino-app-cli
 # Move the related file to the new location
 if [ "$1" = "upgrade" ]; then
-    user_home="$(getent passwd $USER_ID | cut -d: -f6)"
-    LEGACY_DIR="${user_home}/.local/share/arduino-app-cli"
+    USER_HOME="$(getent passwd $USER_ID | cut -d: -f6)"
+    LEGACY_DIR="${USER_HOME}/.local/share/arduino-app-cli"
     mkdir -p /var/lib/arduino-app-cli
     cp "${LEGACY_DIR}/properties.msgpack" /var/lib/arduino-app-cli || true
     cp "${LEGACY_DIR}/bootloader_burned.flag" /var/lib/arduino-app-cli/default.app || true
 
     DEFAULT_APP_FILE="${LEGACY_DIR}/default.app"
     if [ -f "${DEFAULT_APP_FILE}" ]; then
-        sed -s "s|${user_home}/.local/share|/var/lib|" "${DEFAULT_APP_FILE}" > /var/lib/arduino-app-cli/default.app
+        sed -s "s|${USER_HOME}/.local/share|/var/lib|" "${DEFAULT_APP_FILE}" > /var/lib/arduino-app-cli/default.app
     fi
 
 

--- a/debian/arduino-app-cli/DEBIAN/preinst
+++ b/debian/arduino-app-cli/DEBIAN/preinst
@@ -35,17 +35,19 @@ done
 # no longer located at /home/arduino/.local/share/arduino-app-cli
 # Move the related file to the new location
 if [ "$1" = "upgrade" ]; then
+    user_home="$(getent passwd $USER_ID | cut -d: -f6)"
+    LEGACY_DIR="${user_home}/.local/share/arduino-app-cli"
     mkdir -p /var/lib/arduino-app-cli
-    cp /home/arduino/.local/share/arduino-app-cli/properties.msgpack /var/lib/arduino-app-cli || true
-    cp /home/arduino/.local/share/arduino-app-cli/bootloader_burned.flag /var/lib/arduino-app-cli/default.app || true
+    cp "${LEGACY_DIR}/properties.msgpack" /var/lib/arduino-app-cli || true
+    cp "${LEGACY_DIR}/bootloader_burned.flag" /var/lib/arduino-app-cli/default.app || true
 
-    DEFAULT_APP_FILE="/home/arduino/.local/share/arduino-app-cli/default.app"
+    DEFAULT_APP_FILE="${LEGACY_DIR}/default.app"
     if [ -f "${DEFAULT_APP_FILE}" ]; then
-        sed -s "s|/home/arduino/.local/share|/var/lib|" ${DEFAULT_APP_FILE} > /var/lib/arduino-app-cli/default.app
+        sed -s "s|${user_home}/.local/share|/var/lib|" "${DEFAULT_APP_FILE}" > /var/lib/arduino-app-cli/default.app
     fi
 
-    
+
     # the examples directory changed its structure,
     # remove it to cleanup stale files
-    rm -rf /home/arduino/.local/share/arduino-app-cli/examples
+    rm -rf "${LEGACY_DIR}/examples"
 fi

--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -207,7 +207,7 @@ func runSystemUpdate(t *testing.T, containerName string) {
 
 	cmd := exec.Command(
 		"docker", "exec",
-		"--user", "arduino",
+		"--user", "1000",
 		containerName,
 		"arduino-app-cli", "system", "update", "--only-arduino", "--yes",
 	)

--- a/internal/e2e/updatetest/helpers.go
+++ b/internal/e2e/updatetest/helpers.go
@@ -180,7 +180,7 @@ func getAppCliVersion(t *testing.T, containerName string) string {
 
 	cmd := exec.Command(
 		"docker", "exec",
-		"--user", "arduino",
+		"--user", "1000",
 		containerName,
 		"arduino-app-cli", "version", "--format", "json",
 	)


### PR DESCRIPTION
### Motivation

The only prerequisite for running arduino-app-cli should be having a `1000` UID and an `arduino` group. 

### Change description

Remove the hardoded dependency on the arduino user or arduino home fodler.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
