### PR TITLE
Report python runner version

### DIFF
--- a/cmd/arduino-app-cli/main.go
+++ b/cmd/arduino-app-cli/main.go
@@ -71,7 +71,7 @@ func run(configuration cfg.Configuration) error {
 		properties.NewPropertiesCmd(configuration),
 		config.NewConfigCmd(configuration),
 		system.NewSystemCmd(configuration),
-		version.NewVersionCmd(Version),
+		version.NewVersionCmd(Version, configuration.PythonImage),
 		monitor.NewMonitorCmd(),
 		model.NewModelCmd(configuration),
 	)

--- a/cmd/arduino-app-cli/version/version.go
+++ b/cmd/arduino-app-cli/version/version.go
@@ -26,9 +26,9 @@ const (
 	ProgramName     = "Arduino App CLI"
 )
 
-// NewVersionCmd creates the version command. bricksVersion is the Python runner
+// NewVersionCmd creates the version command. pythonRunnerVersion is the Python runner
 // image resolved from the CLI environment.
-func NewVersionCmd(clientVersion string, bricksVersion string) *cobra.Command {
+func NewVersionCmd(clientVersion string, pythonRunnerVersion string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the version number of Arduino App CLI",
@@ -41,11 +41,11 @@ func NewVersionCmd(clientVersion string, bricksVersion string) *cobra.Command {
 			}
 
 			result := versionResult{
-				Name:                ProgramName,
-				Version:             clientVersion,
-				BricksVersion:       bricksVersion,
-				DaemonVersion:       daemon.Version,
-				DaemonBricksVersion: daemon.BricksVersion,
+				Name:                      ProgramName,
+				Version:                   clientVersion,
+				PythonRunnerVersion:       pythonRunnerVersion,
+				DaemonVersion:             daemon.Version,
+				DaemonPythonRunnerVersion: daemon.PythonRunnerVersion,
 			}
 
 			feedback.PrintResult(result)
@@ -57,8 +57,8 @@ func NewVersionCmd(clientVersion string, bricksVersion string) *cobra.Command {
 
 // daemonVersion mirrors the daemon /v1/version response.
 type daemonVersion struct {
-	Version       string `json:"version"`
-	BricksVersion string `json:"bricks_version"`
+	Version             string `json:"version"`
+	PythonRunnerVersion string `json:"python_runner_version"`
 }
 
 func getDaemonVersion(httpClient http.Client, port string) (daemonVersion, error) {
@@ -90,23 +90,23 @@ func getDaemonVersion(httpClient http.Client, port string) (daemonVersion, error
 }
 
 type versionResult struct {
-	Name                string `json:"name"`
-	Version             string `json:"version"`
-	BricksVersion       string `json:"bricks_version"`
-	DaemonVersion       string `json:"daemon_version,omitempty"`
-	DaemonBricksVersion string `json:"daemon_bricks_version,omitempty"`
+	Name                      string `json:"name"`
+	Version                   string `json:"version"`
+	PythonRunnerVersion       string `json:"python_runner_version"`
+	DaemonVersion             string `json:"daemon_version,omitempty"`
+	DaemonPythonRunnerVersion string `json:"daemon_python_runner_version,omitempty"`
 }
 
 func (r versionResult) String() string {
-	resultMessage := fmt.Sprintf("%s version %s\nbricks version: %s", ProgramName, r.Version, r.BricksVersion)
+	resultMessage := fmt.Sprintf("%s version %s\npython runner version: %s", ProgramName, r.Version, r.PythonRunnerVersion)
 
 	if r.DaemonVersion != "" {
 		resultMessage = fmt.Sprintf("%s\ndaemon version: %s",
 			resultMessage, r.DaemonVersion)
 	}
-	if r.DaemonBricksVersion != "" {
-		resultMessage = fmt.Sprintf("%s\ndaemon bricks version: %s",
-			resultMessage, r.DaemonBricksVersion)
+	if r.DaemonPythonRunnerVersion != "" {
+		resultMessage = fmt.Sprintf("%s\ndaemon python runner version: %s",
+			resultMessage, r.DaemonPythonRunnerVersion)
 	}
 	return resultMessage
 }

--- a/cmd/arduino-app-cli/version/version.go
+++ b/cmd/arduino-app-cli/version/version.go
@@ -26,22 +26,26 @@ const (
 	ProgramName     = "Arduino App CLI"
 )
 
-func NewVersionCmd(clientVersion string) *cobra.Command {
+// NewVersionCmd creates the version command. bricksVersion is the Python runner
+// image resolved from the CLI environment.
+func NewVersionCmd(clientVersion string, bricksVersion string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the version number of Arduino App CLI",
 		Run: func(cmd *cobra.Command, args []string) {
 			port, _ := cmd.Flags().GetString("port")
 
-			daemonVersion, err := getDaemonVersion(http.Client{}, port)
+			daemon, err := getDaemonVersion(http.Client{}, port)
 			if err != nil {
 				feedback.Warnf("Warning: cannot get the running daemon version on %s:%s\n", DefaultHostname, port)
 			}
 
 			result := versionResult{
-				Name:          ProgramName,
-				Version:       clientVersion,
-				DaemonVersion: daemonVersion,
+				Name:                ProgramName,
+				Version:             clientVersion,
+				BricksVersion:       bricksVersion,
+				DaemonVersion:       daemon.Version,
+				DaemonBricksVersion: daemon.BricksVersion,
 			}
 
 			feedback.PrintResult(result)
@@ -51,7 +55,13 @@ func NewVersionCmd(clientVersion string) *cobra.Command {
 	return cmd
 }
 
-func getDaemonVersion(httpClient http.Client, port string) (string, error) {
+// daemonVersion mirrors the daemon /v1/version response.
+type daemonVersion struct {
+	Version       string `json:"version"`
+	BricksVersion string `json:"bricks_version"`
+}
+
+func getDaemonVersion(httpClient http.Client, port string) (daemonVersion, error) {
 
 	httpClient.Timeout = time.Second
 
@@ -63,36 +73,40 @@ func getDaemonVersion(httpClient http.Client, port string) (string, error) {
 
 	resp, err := httpClient.Get(url.String())
 	if err != nil {
-		return "", err
+		return daemonVersion{}, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status code received")
+		return daemonVersion{}, fmt.Errorf("unexpected status code received")
 	}
 
-	var daemonResponse struct {
-		Version string `json:"version"`
-	}
+	var daemonResponse daemonVersion
 	if err := json.NewDecoder(resp.Body).Decode(&daemonResponse); err != nil {
-		return "", err
+		return daemonVersion{}, err
 	}
 
-	return daemonResponse.Version, nil
+	return daemonResponse, nil
 }
 
 type versionResult struct {
-	Name          string `json:"name"`
-	Version       string `json:"version"`
-	DaemonVersion string `json:"daemon_version,omitempty"`
+	Name                string `json:"name"`
+	Version             string `json:"version"`
+	BricksVersion       string `json:"bricks_version"`
+	DaemonVersion       string `json:"daemon_version,omitempty"`
+	DaemonBricksVersion string `json:"daemon_bricks_version,omitempty"`
 }
 
 func (r versionResult) String() string {
-	resultMessage := fmt.Sprintf("%s version %s", ProgramName, r.Version)
+	resultMessage := fmt.Sprintf("%s version %s\nbricks version: %s", ProgramName, r.Version, r.BricksVersion)
 
 	if r.DaemonVersion != "" {
 		resultMessage = fmt.Sprintf("%s\ndaemon version: %s",
 			resultMessage, r.DaemonVersion)
+	}
+	if r.DaemonBricksVersion != "" {
+		resultMessage = fmt.Sprintf("%s\ndaemon bricks version: %s",
+			resultMessage, r.DaemonBricksVersion)
 	}
 	return resultMessage
 }

--- a/cmd/arduino-app-cli/version/version_test.go
+++ b/cmd/arduino-app-cli/version/version_test.go
@@ -20,35 +20,35 @@ func TestDaemonVersion(t *testing.T) {
 		name                 string
 		serverStub           Tripper
 		port                 string
-		expectedResult       string
+		expectedResult       daemonVersion
 		expectedErrorMessage string
 	}{
 		{
 			name:                 "return the server version when the server is up",
 			serverStub:           successServer,
 			port:                 "8800",
-			expectedResult:       "3.0-server",
+			expectedResult:       daemonVersion{Version: "3.0-server", BricksVersion: "ghcr.io/arduino/app-bricks/python-apps-base:0.12.0"},
 			expectedErrorMessage: "",
 		},
 		{
 			name:                 "return error if default server is not listening on default port",
 			serverStub:           failureServer,
 			port:                 "8800",
-			expectedResult:       "",
+			expectedResult:       daemonVersion{},
 			expectedErrorMessage: `Get "http://localhost:8800/v1/version": connection refused`,
 		},
 		{
 			name:                 "return error if provided server is not listening on provided port",
 			serverStub:           failureServer,
 			port:                 "1234",
-			expectedResult:       "",
+			expectedResult:       daemonVersion{},
 			expectedErrorMessage: `Get "http://localhost:1234/v1/version": connection refused`,
 		},
 		{
 			name:                 "return error for server response 500 Internal Server Error",
 			serverStub:           failureInternalServerError,
 			port:                 "0",
-			expectedResult:       "",
+			expectedResult:       daemonVersion{},
 			expectedErrorMessage: "unexpected status code received",
 		},
 
@@ -56,7 +56,7 @@ func TestDaemonVersion(t *testing.T) {
 			name:                 "return error for server up and wrong json response",
 			serverStub:           successServerWrongJson,
 			port:                 "8800",
-			expectedResult:       "",
+			expectedResult:       daemonVersion{},
 			expectedErrorMessage: "invalid character '<' looking for beginning of value",
 		},
 	}
@@ -88,7 +88,7 @@ func (t Tripper) RoundTrip(request *http.Request) (*http.Response, error) {
 }
 
 var successServer = Tripper(func(*http.Request) (*http.Response, error) {
-	body := io.NopCloser(strings.NewReader(`{"version":"3.0-server"}`))
+	body := io.NopCloser(strings.NewReader(`{"version":"3.0-server","bricks_version":"ghcr.io/arduino/app-bricks/python-apps-base:0.12.0"}`))
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       body,

--- a/cmd/arduino-app-cli/version/version_test.go
+++ b/cmd/arduino-app-cli/version/version_test.go
@@ -27,7 +27,7 @@ func TestDaemonVersion(t *testing.T) {
 			name:                 "return the server version when the server is up",
 			serverStub:           successServer,
 			port:                 "8800",
-			expectedResult:       daemonVersion{Version: "3.0-server", BricksVersion: "ghcr.io/arduino/app-bricks/python-apps-base:0.12.0"},
+			expectedResult:       daemonVersion{Version: "3.0-server", PythonRunnerVersion: "ghcr.io/arduino/app-bricks/python-apps-base:0.12.0"},
 			expectedErrorMessage: "",
 		},
 		{
@@ -88,7 +88,7 @@ func (t Tripper) RoundTrip(request *http.Request) (*http.Response, error) {
 }
 
 var successServer = Tripper(func(*http.Request) (*http.Response, error) {
-	body := io.NopCloser(strings.NewReader(`{"version":"3.0-server","bricks_version":"ghcr.io/arduino/app-bricks/python-apps-base:0.12.0"}`))
+	body := io.NopCloser(strings.NewReader(`{"version":"3.0-server","python_runner_version":"ghcr.io/arduino/app-bricks/python-apps-base:0.12.0"}`))
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       body,

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -45,7 +45,7 @@ func NewHTTPRouter(
 	mux := http.NewServeMux()
 	mux.Handle("GET /debug/", http.DefaultServeMux) // pprof endpoints
 
-	mux.Handle("GET /v1/version", handlers.HandlerVersion(version))
+	mux.Handle("GET /v1/version", handlers.HandlerVersion(version, cfg.PythonImage))
 	mux.Handle("GET /v1/config", handlers.HandleConfig(cfg))
 	mux.Handle("GET /v1/examples", handlers.HandleExamples(cfg, bricksIndex, idProvider))
 	mux.Handle("GET /v1/bricks", handlers.HandleBrickList(brickService))

--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -2110,6 +2110,8 @@ components:
       type: object
     VersionResponse:
       properties:
+        bricks_version:
+          type: string
         version:
           type: string
       type: object

--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -2110,7 +2110,7 @@ components:
       type: object
     VersionResponse:
       properties:
-        bricks_version:
+        python_runner_version:
           type: string
         version:
           type: string

--- a/internal/api/handlers/version.go
+++ b/internal/api/handlers/version.go
@@ -13,11 +13,13 @@ import (
 
 type VersionResponse struct {
 	Version string `json:"version"`
+	// BricksVersion is the Python runner image used by bricks, e.g. ghcr.io/arduino/app-bricks/python-apps-base:0.12.0
+	BricksVersion string `json:"bricks_version"`
 }
 
-func HandlerVersion(version string) http.HandlerFunc {
+func HandlerVersion(version string, bricksVersion string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		version := VersionResponse{Version: version}
+		version := VersionResponse{Version: version, BricksVersion: bricksVersion}
 		render.EncodeResponse(w, http.StatusOK, version)
 	}
 }

--- a/internal/api/handlers/version.go
+++ b/internal/api/handlers/version.go
@@ -13,13 +13,13 @@ import (
 
 type VersionResponse struct {
 	Version string `json:"version"`
-	// BricksVersion is the Python runner image used by bricks, e.g. ghcr.io/arduino/app-bricks/python-apps-base:0.12.0
-	BricksVersion string `json:"bricks_version"`
+	// PythonRunnerVersion is the Python runner image, e.g. ghcr.io/arduino/app-bricks/python-apps-base:0.12.0
+	PythonRunnerVersion string `json:"python_runner_version"`
 }
 
-func HandlerVersion(version string, bricksVersion string) http.HandlerFunc {
+func HandlerVersion(version string, pythonRunnerVersion string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		version := VersionResponse{Version: version, BricksVersion: bricksVersion}
+		version := VersionResponse{Version: version, PythonRunnerVersion: pythonRunnerVersion}
 		render.EncodeResponse(w, http.StatusOK, version)
 	}
 }

--- a/internal/e2e/client/client.gen.go
+++ b/internal/e2e/client/client.gen.go
@@ -508,8 +508,8 @@ type UpgradablePackage struct {
 
 // VersionResponse defines model for VersionResponse.
 type VersionResponse struct {
-	BricksVersion *string `json:"bricks_version,omitempty"`
-	Version       *string `json:"version,omitempty"`
+	PythonRunnerVersion *string `json:"python_runner_version,omitempty"`
+	Version             *string `json:"version,omitempty"`
 }
 
 // BadRequest defines model for BadRequest.

--- a/internal/e2e/client/client.gen.go
+++ b/internal/e2e/client/client.gen.go
@@ -508,7 +508,8 @@ type UpgradablePackage struct {
 
 // VersionResponse defines model for VersionResponse.
 type VersionResponse struct {
-	Version *string `json:"version,omitempty"`
+	BricksVersion *string `json:"bricks_version,omitempty"`
+	Version       *string `json:"version,omitempty"`
 }
 
 // BadRequest defines model for BadRequest.


### PR DESCRIPTION
### Motivation

`arduino-app-cli version` only reports the CLI and daemon versions. There is no way to see which Python runner image is in use without peeking at config files.

### Change description

- `GET /v1/version` now returns `python_runner_version` with the daemon's full Python runner image reference.
- `arduino-app-cli version` prints the runner image resolved from its own environment (`python_runner_version`) and the daemon's (`daemon_python_runner_version`).
- OpenAPI spec and e2e client updated accordingly.

### Additional Notes

N/A

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
