### PR TITLE
Implement secret management

### DIFF
--- a/internal/api/handlers/app_delete.go
+++ b/internal/api/handlers/app_delete.go
@@ -44,7 +44,7 @@ func HandleAppDelete(
 			return
 		}
 
-		err = orchestrator.DeleteApp(r.Context(), dockerClient, platform, app, cfg)
+		err = orchestrator.DeleteApp(r.Context(), dockerClient, platform, app, idProvider, cfg)
 		if err != nil {
 			slog.Error("Unable to delete the app", slog.String("error", err.Error()))
 			render.EncodeResponse(w, http.StatusInternalServerError, models.ErrorResponse{Details: "unable to delete the app"})

--- a/internal/api/handlers/app_details.go
+++ b/internal/api/handlers/app_details.go
@@ -103,7 +103,7 @@ func HandleAppDetailsEdits(
 				Description: editRequest.Description,
 			}
 		}
-		err = orchestrator.EditApp(appEditRequest, &appToEdit, cfg)
+		err = orchestrator.EditApp(appEditRequest, &appToEdit, idProvider, cfg)
 		if err != nil {
 			switch {
 			case errors.Is(err, app.ErrInvalidApp):

--- a/internal/orchestrator/appenv.go
+++ b/internal/orchestrator/appenv.go
@@ -87,6 +87,7 @@ func appEnvironment(
 
 	brickIndex = brickIndex.WithAppBricks(app.LocalBricks)
 	models := modelsIndex.NewLookup()
+	isSecret := secretNames(app, brickIndex)
 
 	for _, brick := range app.Descriptor.Bricks {
 		if brickDef, found := brickIndex.FindBrickByID(brick.ID); found {
@@ -103,7 +104,15 @@ func appEnvironment(
 			}
 		}
 
-		slog.Debug("adding Brick", slog.String("brickID", brick.ID), slog.String("model", brick.Model), slog.Any("variables", brick.Variables))
+		// A secret value is never logged, whether it comes from the store or is
+		// still in app.yaml.
+		logged := maps.Clone(brick.Variables)
+		for name := range logged {
+			if isSecret[name] {
+				logged[name] = "***"
+			}
+		}
+		slog.Debug("adding Brick", slog.String("brickID", brick.ID), slog.String("model", brick.Model), slog.Any("variables", logged))
 		maps.Insert(envs, maps.All(brick.Variables))
 	}
 
@@ -111,7 +120,7 @@ func appEnvironment(
 
 	// A secret is only referenced here: its value is filled in when the app is
 	// rendered, so it is never written to a template that can be shipped.
-	for name := range appSecrets(app, brickIndex) {
+	for name := range isSecret {
 		envs[name] = "${" + name + "}"
 	}
 
@@ -135,12 +144,31 @@ func hostEnvironment(ctx context.Context, appPath *paths.Path, cfg config.Config
 	return envs
 }
 
-// appSecrets is the value of every variable a brick declares secret. It is read at
-// render time, on the board the app runs on, and never written to a template.
+// secretNames are the variables the bricks of an app declare secret.
+func secretNames(arduinoApp app.ArduinoApp, brickIndex *bricksindex.BricksIndex) map[string]bool {
+	brickIndex = brickIndex.WithAppBricks(arduinoApp.LocalBricks)
+
+	names := map[string]bool{}
+	for _, brick := range arduinoApp.Descriptor.Bricks {
+		brickDef, found := brickIndex.FindBrickByID(brick.ID)
+		if !found {
+			continue
+		}
+		for _, variable := range brickDef.Variables {
+			if variable.Secret {
+				names[variable.Name] = true
+			}
+		}
+	}
+	return names
+}
+
+// appSecrets is the value of every variable a brick declares secret, read on the board
+// the app runs on and never written to a template.
 //
-// app.yaml is not what the render step normally reads: a secret is only there because
-// that is the storage there is for now. A real secret store replaces this function.
-func appSecrets(arduinoApp app.ArduinoApp, brickIndex *bricksindex.BricksIndex) types.Mapping {
+// A value in app.yaml wins, because the api still writes there and secrets.Adopt has
+// copied it into the store already. A release has none, so the store answers for it.
+func appSecrets(arduinoApp app.ArduinoApp, brickIndex *bricksindex.BricksIndex, stored map[string]string) types.Mapping {
 	brickIndex = brickIndex.WithAppBricks(arduinoApp.LocalBricks)
 
 	secrets := make(types.Mapping)
@@ -154,7 +182,10 @@ func appSecrets(arduinoApp app.ArduinoApp, brickIndex *bricksindex.BricksIndex) 
 				continue
 			}
 			secrets[variable.Name] = variable.DefaultValue
-			if value, set := brick.Variables[variable.Name]; set {
+			if value := stored[variable.Name]; value != "" {
+				secrets[variable.Name] = value
+			}
+			if value, set := brick.Variables[variable.Name]; set && value != "" {
 				secrets[variable.Name] = value
 			}
 		}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -37,6 +37,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/peripherals"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/pipewire"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/secrets"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
@@ -107,6 +108,21 @@ func StartApp(
 	}
 
 	bricksIndex = bricksIndex.WithAppBricks(appToStart.LocalBricks)
+
+	// The secrets of the app, by the id its folder has on this board. What the api
+	// wrote in app.yaml is moved into the store here, and app.yaml is blanked.
+	appToStartID, err := appid.NewAppProvider(cfg, platform).IDFromPath(appToStart.FullPath)
+	if err != nil {
+		return fmt.Errorf("cannot identify the app to start: %w", err)
+	}
+	secretsStore := secrets.NewStore(cfg)
+	if err := secrets.Adopt(secretsStore, appToStartID, &appToStart, bricksIndex); err != nil {
+		return fmt.Errorf("cannot store the secrets of the app: %w", err)
+	}
+	storedSecrets, err := secretsStore.Get(appToStartID)
+	if err != nil {
+		return fmt.Errorf("cannot read the secrets of the app: %w", err)
+	}
 
 	if err := checkBricks(ctx, appToStart.Descriptor.Bricks, bricksIndex, modelsIndex); err != nil {
 		return err
@@ -219,7 +235,7 @@ func StartApp(
 		// What the template references, answered on this board: for a release the app
 		// half will come from the bundle instead of being resolved again here.
 		env := hostEnvironment(ctx, appToStart.FullPath, cfg).Merge(appEnv)
-		if err := provisioner.Render(ctx, &appToStart, env, appSecrets(appToStart, bricksIndex)); err != nil {
+		if err := provisioner.Render(ctx, &appToStart, env, appSecrets(appToStart, bricksIndex, storedSecrets)); err != nil {
 			return err
 		}
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -109,21 +109,6 @@ func StartApp(
 
 	bricksIndex = bricksIndex.WithAppBricks(appToStart.LocalBricks)
 
-	// The secrets of the app, by the id its folder has on this board. What the api
-	// wrote in app.yaml is moved into the store here, and app.yaml is blanked.
-	appToStartID, err := appid.NewAppProvider(cfg, platform).IDFromPath(appToStart.FullPath)
-	if err != nil {
-		return fmt.Errorf("cannot identify the app to start: %w", err)
-	}
-	secretsStore := secrets.NewStore(cfg)
-	if err := secrets.Adopt(secretsStore, appToStartID, &appToStart, bricksIndex); err != nil {
-		return fmt.Errorf("cannot store the secrets of the app: %w", err)
-	}
-	storedSecrets, err := secretsStore.Get(appToStartID)
-	if err != nil {
-		return fmt.Errorf("cannot read the secrets of the app: %w", err)
-	}
-
 	if err := checkBricks(ctx, appToStart.Descriptor.Bricks, bricksIndex, modelsIndex); err != nil {
 		return err
 	}
@@ -216,6 +201,23 @@ func StartApp(
 	}
 
 	if appToStart.MainPythonFile != nil {
+		// The secrets of the app, by the id its folder has on this board. What the api
+		// wrote in app.yaml is moved into the store here, and app.yaml is blanked. It
+		// happens once the app is known to be startable, and only where it is read:
+		// nothing else in a start needs a secret.
+		appToStartID, err := appid.NewAppProvider(cfg, platform).IDFromPath(appToStart.FullPath)
+		if err != nil {
+			return fmt.Errorf("cannot identify the app to start: %w", err)
+		}
+		secretsStore := secrets.NewStore(cfg)
+		if err := secrets.Adopt(secretsStore, appToStartID, &appToStart, bricksIndex); err != nil {
+			return fmt.Errorf("cannot store the secrets of the app: %w", err)
+		}
+		storedSecrets, err := secretsStore.Get(appToStartID)
+		if err != nil {
+			return fmt.Errorf("cannot read the secrets of the app: %w", err)
+		}
+
 		appEnv := appEnvironment(ctx, appToStart, bricksIndex, modelsIndex, platform)
 
 		cb(StreamMessage{data: "python provisioning"})
@@ -854,13 +856,29 @@ func CloneApp(
 	if err != nil {
 		return CloneAppResponse{}, fmt.Errorf("failed to get app id: %w", err)
 	}
+
+	// The secrets are not in the copied files: the clone gets its own copy of them,
+	// so it starts with the same values the origin runs with.
+	if err := secrets.NewStore(cfg).Copy(req.FromID, id); err != nil {
+		return CloneAppResponse{}, fmt.Errorf("failed to copy the secrets of the app: %w", err)
+	}
+
 	return CloneAppResponse{ID: id}, nil
 }
 
-func DeleteApp(ctx context.Context, dockerClient command.Cli, platform platform.Platform, app app.ArduinoApp, cfg config.Configuration) error {
+func DeleteApp(ctx context.Context, dockerClient command.Cli, platform platform.Platform, app app.ArduinoApp, idProvider *appid.Provider, cfg config.Configuration) error {
 	// We try to remove docker related resources at best effort
 	_ = StopAndDestroyApp(ctx, dockerClient, platform, app, cfg, func(StreamMessage) {})
 	// TODO: Shall we report stop error?
+
+	// Remove the secrets stored for the app that is being deleted.
+	id, err := idProvider.IDFromPath(app.FullPath)
+	if err != nil {
+		return fmt.Errorf("cannot identify the app to delete: %w", err)
+	}
+	if err := secrets.NewStore(cfg).Delete(id); err != nil {
+		return fmt.Errorf("cannot delete the secrets of the app: %w", err)
+	}
 
 	return app.FullPath.RemoveAll()
 }
@@ -921,6 +939,7 @@ type AppEditRequest struct {
 func EditApp(
 	req AppEditRequest,
 	editApp *app.ArduinoApp,
+	idProvider *appid.Provider,
 	cfg config.Configuration,
 ) (editErr error) {
 	if req.Default != nil {
@@ -948,11 +967,25 @@ func EditApp(
 		if newPath.Exist() {
 			return ErrAppAlreadyExists
 		}
+		// The id of an app is its folder, so a rename is a new id: the old id is read
+		// while the folder is still there, and the secrets follow it.
+		oldID, err := idProvider.IDFromPath(editApp.FullPath)
+		if err != nil {
+			return fmt.Errorf("cannot identify the app to edit: %w", err)
+		}
 		if err := editApp.FullPath.Rename(newPath); err != nil {
 			return fmt.Errorf("failed to rename app path: %w", err)
 		}
 		editApp.FullPath = newPath
 		editApp.Name = editApp.Descriptor.Name
+
+		newID, err := idProvider.IDFromPath(newPath)
+		if err != nil {
+			return fmt.Errorf("cannot identify the renamed app: %w", err)
+		}
+		if err := secrets.NewStore(cfg).Move(oldID, newID); err != nil {
+			return fmt.Errorf("failed to move the secrets of the app: %w", err)
+		}
 	}
 
 	return editApp.Save()

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/modelsindex"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/secrets"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
 
@@ -165,7 +166,7 @@ func TestEditApp(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, previousDefaultApp)
 
-			err = EditApp(AppEditRequest{Default: new(true)}, &app, cfg)
+			err = EditApp(AppEditRequest{Default: new(true)}, &app, idProvider, cfg)
 			require.NoError(t, err)
 
 			currentDefaultApp, err := GetDefaultApp(cfg)
@@ -181,7 +182,7 @@ func TestEditApp(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, appDir.EquivalentTo(previousDefaultApp.FullPath))
 
-			err = EditApp(AppEditRequest{Default: new(false)}, &app, cfg)
+			err = EditApp(AppEditRequest{Default: new(false)}, &app, idProvider, cfg)
 			require.NoError(t, err)
 
 			currentDefaultApp, err := GetDefaultApp(cfg)
@@ -198,7 +199,7 @@ func TestEditApp(t *testing.T) {
 		userApp := f.Must(app.Load(appDir))
 		originalPath := userApp.FullPath
 
-		err = EditApp(AppEditRequest{Name: new("new-name")}, &userApp, cfg)
+		err = EditApp(AppEditRequest{Name: new("new-name")}, &userApp, idProvider, cfg)
 		require.NoError(t, err)
 		editedApp, err := app.Load(cfg.AppsDir().Join("new-name"))
 		require.NoError(t, err)
@@ -212,7 +213,7 @@ func TestEditApp(t *testing.T) {
 			appDir := cfg.AppsDir().Join(existingAppName)
 			existingApp := f.Must(app.Load(appDir))
 
-			err = EditApp(AppEditRequest{Name: new(existingAppName)}, &existingApp, cfg)
+			err = EditApp(AppEditRequest{Name: new(existingAppName)}, &existingApp, idProvider, cfg)
 			require.ErrorIs(t, err, ErrAppAlreadyExists)
 		})
 	})
@@ -227,12 +228,79 @@ func TestEditApp(t *testing.T) {
 		err = EditApp(AppEditRequest{
 			Icon:        new("💻"),
 			Description: new("new desc"),
-		}, &commonApp, cfg)
+		}, &commonApp, idProvider, cfg)
 		require.NoError(t, err)
 		editedApp := f.Must(app.Load(commonAppDir))
 		require.Equal(t, "new desc", editedApp.Descriptor.Description)
 		require.Equal(t, "💻", editedApp.Descriptor.Icon)
 	})
+}
+
+// The secrets of an app live outside its folder, keyed by the id the folder has: an
+// operation that changes the folder has to carry them, or they are lost or inherited.
+func TestAppSecretsFollowTheApp(t *testing.T) {
+	cfg := setTestOrchestratorConfig(t)
+	idProvider := appid.NewAppProvider(cfg, unoQPlatform)
+	store := secrets.NewStore(cfg)
+
+	t.Run("a rename moves them", func(t *testing.T) {
+		_, err := CreateApp(CreateAppRequest{Name: "app-to-rename"}, &bricksindex.BricksIndex{}, idProvider, cfg)
+		require.NoError(t, err)
+		userApp := f.Must(app.Load(cfg.AppsDir().Join("app-to-rename")))
+		oldID := f.Must(idProvider.ParseID("user:app-to-rename"))
+		require.NoError(t, store.Set(oldID, map[string]string{"API_KEY": "secret"}))
+
+		require.NoError(t, EditApp(AppEditRequest{Name: new("app-renamed")}, &userApp, idProvider, cfg))
+
+		newID := f.Must(idProvider.ParseID("user:app-renamed"))
+		require.Equal(t, map[string]string{"API_KEY": "secret"}, f.Must(store.Get(newID)))
+		require.Empty(t, f.Must(store.Get(oldID)))
+	})
+
+	t.Run("a clone copies them", func(t *testing.T) {
+		_, err := CreateApp(CreateAppRequest{Name: "app-to-clone"}, &bricksindex.BricksIndex{}, idProvider, cfg)
+		require.NoError(t, err)
+		originID := f.Must(idProvider.ParseID("user:app-to-clone"))
+		require.NoError(t, store.Set(originID, map[string]string{"API_KEY": "secret"}))
+
+		resp, err := CloneApp(CloneAppRequest{FromID: originID, Name: new("app-cloned")}, idProvider, cfg)
+		require.NoError(t, err)
+
+		require.Equal(t, map[string]string{"API_KEY": "secret"}, f.Must(store.Get(resp.ID)))
+		require.Equal(t, map[string]string{"API_KEY": "secret"}, f.Must(store.Get(originID)))
+	})
+
+	t.Run("a new app does not inherit the ones of a deleted app", func(t *testing.T) {
+		_, err := CreateApp(CreateAppRequest{Name: "app-to-delete"}, &bricksindex.BricksIndex{}, idProvider, cfg)
+		require.NoError(t, err)
+		appDir := cfg.AppsDir().Join("app-to-delete")
+		id := f.Must(idProvider.ParseID("user:app-to-delete"))
+		require.NoError(t, store.Set(id, map[string]string{"API_KEY": "secret"}))
+
+		require.NoError(t, DeleteApp(t.Context(), newTestDockerCli(t), unoQPlatform, f.Must(app.Load(appDir)), idProvider, cfg))
+		require.True(t, appDir.NotExist())
+
+		_, err = CreateApp(CreateAppRequest{Name: "app-to-delete"}, &bricksindex.BricksIndex{}, idProvider, cfg)
+		require.NoError(t, err)
+		require.Empty(t, f.Must(store.Get(id)))
+	})
+}
+
+func newTestDockerCli(t *testing.T) command.Cli {
+	t.Helper()
+
+	docker, err := dockerClient.NewClientWithOpts(
+		dockerClient.FromEnv,
+		dockerClient.WithAPIVersionNegotiation(),
+	)
+	require.NoError(t, err)
+	dockerCli, err := command.NewDockerCli(
+		command.WithAPIClient(docker),
+		command.WithBaseContext(t.Context()),
+	)
+	require.NoError(t, err)
+	require.NoError(t, dockerCli.Initialize(&flags.ClientOptions{}))
+	return dockerCli
 }
 
 func TestListApp(t *testing.T) {

--- a/internal/orchestrator/render.go
+++ b/internal/orchestrator/render.go
@@ -100,8 +100,13 @@ func renderComposeFile(ctx context.Context, arduinoApp *app.ArduinoApp, env, sec
 	// docker compose interpolates the file it is given, and compose-go escapes nothing
 	// it writes: a value holding a $ would be substituted a second time.
 	data = bytes.ReplaceAll(data, []byte("$"), []byte("$$"))
+	// The only file that holds a resolved secret, read by docker compose as this user.
 	composeFile := arduinoApp.AppComposeFilePath()
-	if err := fatomic.WriteFile(composeFile.String(), data, 0644); err != nil {
+	if err := fatomic.WriteFile(composeFile.String(), data, 0600); err != nil {
+		return nil, err
+	}
+	// renameio keeps the mode a file already has, and older apps have it 0644.
+	if err := os.Chmod(composeFile.String(), 0600); err != nil {
 		return nil, err
 	}
 	slog.Debug("wrote the app compose file", slog.String("path", composeFile.String()))

--- a/internal/orchestrator/secrets/secrets.go
+++ b/internal/orchestrator/secrets/secrets.go
@@ -5,20 +5,21 @@
 
 // Package secrets stores the value of the variables a brick declares secret, outside
 // the app folder: a release is installed read-only and its app.yaml carries no value.
+// A secret is one file, the shape docker compose mounts as /run/secrets/<name>.
 package secrets
 
 import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"log/slog"
 	"maps"
 	"os"
+	"regexp"
 	"slices"
-	"sync"
 
 	"github.com/arduino/go-paths-helper"
-	yaml "github.com/goccy/go-yaml"
 
 	"github.com/arduino/arduino-app-cli/internal/fatomic"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
@@ -35,33 +36,15 @@ const (
 
 type Store struct {
 	dir *paths.Path
-
-	// A write is read-modify-write, and the daemon serves more than one request.
-	mux sync.Mutex
 }
 
 func NewStore(cfg config.Configuration) *Store {
 	return &Store{dir: cfg.DataDir().Join("secrets")}
 }
 
-// storeFile is one app. The id is written for whoever has to tell the files apart:
-// the name is a hash, so that an app addressed by path does not overflow the file
-// name limit, and does not put that path in a directory listing.
-type storeFile struct {
-	App     string            `yaml:"app"`
-	Version int               `yaml:"version"`
-	Values  map[string]string `yaml:"values"`
-}
-
-func (s *Store) path(id appid.ID) *paths.Path {
-	sum := sha256.Sum256([]byte(id.String()))
-	return s.dir.Join(hex.EncodeToString(sum[:]) + ".yaml")
-}
-
 // Get is the values of an app. An app with no secrets stored is not an error.
 func (s *Store) Get(id appid.ID) (map[string]string, error) {
-	file := s.path(id)
-	data, err := file.ReadFile()
+	files, err := s.appDir(id).ReadDir()
 	if os.IsNotExist(err) {
 		return map[string]string{}, nil
 	}
@@ -69,62 +52,82 @@ func (s *Store) Get(id appid.ID) (map[string]string, error) {
 		return nil, err
 	}
 
-	// The file is written 0600, but renameio keeps the mode a file already has.
-	if info, err := file.Stat(); err == nil && info.Mode().Perm() != fileMode {
-		slog.Warn("repairing the permissions of a secrets file", slog.String("path", file.String()))
-		if err := os.Chmod(file.String(), fileMode); err != nil {
+	values := map[string]string{}
+	for _, file := range files {
+		if file.IsDir() || !nameIsValid(file.Base()) {
+			slog.Warn("skipping a file that is not a secret", slog.String("path", file.String()))
+			continue
+		}
+		// The mode comes from the open file, so it is the mode of what the read returns.
+		value, err := func() ([]byte, error) {
+			f, err := file.Open()
+			if err != nil {
+				return nil, err
+			}
+			defer f.Close()
+
+			info, err := f.Stat()
+			if err != nil {
+				return nil, err
+			}
+			// A mode the store did not write means the value is exposed already.
+			if info.Mode().Perm() != fileMode {
+				slog.Warn("skipping an exposed secret",
+					slog.String("path", file.String()),
+					slog.String("mode", fmt.Sprintf("%#o", info.Mode().Perm())))
+				return nil, nil
+			}
+			return io.ReadAll(f)
+		}()
+		if err != nil {
 			return nil, err
+		}
+		if value == nil {
+			continue
+		}
+		values[file.Base()] = string(value)
+	}
+	return values, nil
+}
+
+// Set writes the updates of an app, one file each. A name set to an empty value is
+// removed, and an app left with nothing has no directory.
+func (s *Store) Set(id appid.ID, updates map[string]string) error {
+	for name := range updates {
+		if !nameIsValid(name) {
+			return fmt.Errorf("%q is not a valid secret name", name)
 		}
 	}
 
-	var stored storeFile
-	if err := yaml.Unmarshal(data, &stored); err != nil {
-		return nil, fmt.Errorf("cannot read %s: %w", file, err)
-	}
-	if stored.Values == nil {
-		stored.Values = map[string]string{}
-	}
-	return stored.Values, nil
-}
-
-// Set merges updates into what the app has. A name set to an empty value is removed,
-// and an app left with nothing has no file.
-func (s *Store) Set(id appid.ID, updates map[string]string) error {
-	s.mux.Lock()
-	defer s.mux.Unlock()
-
-	values, err := s.Get(id)
-	if err != nil {
+	dir := s.appDir(id)
+	// MkdirAll of go-paths-helper is 0755, and a secret is only for this user.
+	if err := os.MkdirAll(dir.String(), dirMode); err != nil {
 		return err
 	}
 	for name, value := range updates {
+		file := dir.Join(name)
 		if value == "" {
-			delete(values, name)
+			if err := file.RemoveAll(); err != nil {
+				return err
+			}
 			continue
 		}
-		values[name] = value
+		if err := fatomic.WriteFile(file.String(), []byte(value), fileMode); err != nil {
+			return err
+		}
+		// renameio keeps the mode a file already has, so the mode is set here.
+		if err := file.Chmod(fileMode); err != nil {
+			return err
+		}
 	}
 
-	file := s.path(id)
-	if len(values) == 0 {
-		return file.RemoveAll()
-	}
-
-	data, err := yaml.Marshal(storeFile{App: id.String(), Version: 1, Values: values})
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(s.dir.String(), dirMode); err != nil {
-		return err
-	}
-	if err := fatomic.WriteFile(file.String(), data, fileMode); err != nil {
-		return err
-	}
-	return os.Chmod(file.String(), fileMode)
+	// The remove fails while the app has a secret left, which is the check we want.
+	_ = dir.Remove()
+	return nil
 }
 
 func (s *Store) Delete(id appid.ID) error {
-	return s.path(id).RemoveAll()
+	return s.appDir(id).RemoveAll()
 }
 
 // Move carries the values of an app to another id, as a rename or an upgrade does.
@@ -182,4 +185,19 @@ func Adopt(store *Store, id appid.ID, arduinoApp *app.ArduinoApp, brickIndex *br
 			slog.String("error", err.Error()))
 	}
 	return nil
+}
+
+// appDir is the directory of an app. The name is a hash, so that an app addressed by
+// path does not overflow the file name limit, and is not in a directory listing.
+func (s *Store) appDir(id appid.ID) *paths.Path {
+	sum := sha256.Sum256([]byte(id.String()))
+	return s.dir.Join(hex.EncodeToString(sum[:]))
+}
+
+var envName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// nameIsValid is the shape of an environment variable name, the only thing a brick
+// declares. The name is a file name here, so nothing else is written or read.
+func nameIsValid(name string) bool {
+	return envName.MatchString(name)
 }

--- a/internal/orchestrator/secrets/secrets.go
+++ b/internal/orchestrator/secrets/secrets.go
@@ -1,0 +1,185 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package secrets stores the value of the variables a brick declares secret, outside
+// the app folder: a release is installed read-only and its app.yaml carries no value.
+package secrets
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"maps"
+	"os"
+	"slices"
+	"sync"
+
+	"github.com/arduino/go-paths-helper"
+	yaml "github.com/goccy/go-yaml"
+
+	"github.com/arduino/arduino-app-cli/internal/fatomic"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+)
+
+// Only the user running the cli reads a secret.
+const (
+	fileMode = 0600
+	dirMode  = 0700
+)
+
+type Store struct {
+	dir *paths.Path
+
+	// A write is read-modify-write, and the daemon serves more than one request.
+	mux sync.Mutex
+}
+
+func NewStore(cfg config.Configuration) *Store {
+	return &Store{dir: cfg.DataDir().Join("secrets")}
+}
+
+// storeFile is one app. The id is written for whoever has to tell the files apart:
+// the name is a hash, so that an app addressed by path does not overflow the file
+// name limit, and does not put that path in a directory listing.
+type storeFile struct {
+	App     string            `yaml:"app"`
+	Version int               `yaml:"version"`
+	Values  map[string]string `yaml:"values"`
+}
+
+func (s *Store) path(id appid.ID) *paths.Path {
+	sum := sha256.Sum256([]byte(id.String()))
+	return s.dir.Join(hex.EncodeToString(sum[:]) + ".yaml")
+}
+
+// Get is the values of an app. An app with no secrets stored is not an error.
+func (s *Store) Get(id appid.ID) (map[string]string, error) {
+	file := s.path(id)
+	data, err := file.ReadFile()
+	if os.IsNotExist(err) {
+		return map[string]string{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// The file is written 0600, but renameio keeps the mode a file already has.
+	if info, err := file.Stat(); err == nil && info.Mode().Perm() != fileMode {
+		slog.Warn("repairing the permissions of a secrets file", slog.String("path", file.String()))
+		if err := os.Chmod(file.String(), fileMode); err != nil {
+			return nil, err
+		}
+	}
+
+	var stored storeFile
+	if err := yaml.Unmarshal(data, &stored); err != nil {
+		return nil, fmt.Errorf("cannot read %s: %w", file, err)
+	}
+	if stored.Values == nil {
+		stored.Values = map[string]string{}
+	}
+	return stored.Values, nil
+}
+
+// Set merges updates into what the app has. A name set to an empty value is removed,
+// and an app left with nothing has no file.
+func (s *Store) Set(id appid.ID, updates map[string]string) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	values, err := s.Get(id)
+	if err != nil {
+		return err
+	}
+	for name, value := range updates {
+		if value == "" {
+			delete(values, name)
+			continue
+		}
+		values[name] = value
+	}
+
+	file := s.path(id)
+	if len(values) == 0 {
+		return file.RemoveAll()
+	}
+
+	data, err := yaml.Marshal(storeFile{App: id.String(), Version: 1, Values: values})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(s.dir.String(), dirMode); err != nil {
+		return err
+	}
+	if err := fatomic.WriteFile(file.String(), data, fileMode); err != nil {
+		return err
+	}
+	return os.Chmod(file.String(), fileMode)
+}
+
+func (s *Store) Delete(id appid.ID) error {
+	return s.path(id).RemoveAll()
+}
+
+// Move carries the values of an app to another id, as a rename or an upgrade does.
+func (s *Store) Move(from, to appid.ID) error {
+	values, err := s.Get(from)
+	if err != nil {
+		return err
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	if err := s.Set(to, values); err != nil {
+		return err
+	}
+	return s.Delete(from)
+}
+
+// Adopt moves the secrets an app keeps in its app.yaml into the store, and blanks the
+// keys there. The api still writes app.yaml, so what it wrote always wins and is
+// copied forward: an edit is never overruled by what the store already had.
+func Adopt(store *Store, id appid.ID, arduinoApp *app.ArduinoApp, brickIndex *bricksindex.BricksIndex) error {
+	brickIndex = brickIndex.WithAppBricks(arduinoApp.LocalBricks)
+
+	found := map[string]string{}
+	blanked := false
+	for i := range arduinoApp.Descriptor.Bricks {
+		brick := &arduinoApp.Descriptor.Bricks[i]
+		brickDef, ok := brickIndex.FindBrickByID(brick.ID)
+		if !ok {
+			continue
+		}
+		for name, value := range brick.Variables {
+			if variable, ok := brickDef.GetVariable(name); !ok || !variable.Secret || value == "" {
+				continue
+			}
+			found[name] = value
+			brick.Variables[name] = ""
+			blanked = true
+		}
+	}
+	if !blanked {
+		return nil
+	}
+
+	if err := store.Set(id, found); err != nil {
+		return err
+	}
+
+	// The value is safe now. An app.yaml the cli cannot write, an example or a
+	// release, keeps its blanked copy for the next start to try again.
+	if err := arduinoApp.Save(); err != nil {
+		slog.Warn("cannot blank the adopted secrets in app.yaml",
+			slog.String("app", id.String()),
+			slog.Any("variables", slices.Sorted(maps.Keys(found))),
+			slog.String("error", err.Error()))
+	}
+	return nil
+}

--- a/internal/orchestrator/secrets/secrets.go
+++ b/internal/orchestrator/secrets/secrets.go
@@ -130,8 +130,8 @@ func (s *Store) Delete(id appid.ID) error {
 	return s.appDir(id).RemoveAll()
 }
 
-// Move carries the values of an app to another id, as a rename or an upgrade does.
-func (s *Store) Move(from, to appid.ID) error {
+// Copy repeats the values of an app under another id, as a clone does.
+func (s *Store) Copy(from, to appid.ID) error {
 	values, err := s.Get(from)
 	if err != nil {
 		return err
@@ -139,7 +139,12 @@ func (s *Store) Move(from, to appid.ID) error {
 	if len(values) == 0 {
 		return nil
 	}
-	if err := s.Set(to, values); err != nil {
+	return s.Set(to, values)
+}
+
+// Move carries the values of an app to another id, as a rename or an upgrade does.
+func (s *Store) Move(from, to appid.ID) error {
+	if err := s.Copy(from, to); err != nil {
 		return err
 	}
 	return s.Delete(from)


### PR DESCRIPTION
### Motivation

The value of a variable a brick declares `secret` lives in `app.yaml`, inside the app folder.
Distributing an app release means also shipping that folder, so a secret cannot be kept there.

### Change description

A secret is now stored outside the app folder, in `<data-dir>/secrets/<hash-of-app-id>/`, one file per variable, `0600` in a `0700` directory.

- New `internal/orchestrator/secrets` package: `Get`/`Set`/`Delete`/`Move`/`Copy`, plus `Adopt`, which moves what the api wrote in `app.yaml` into the store and blanks the keys there.
- Adopt is called every time `StartApp` runs.
- A secret never reaches a template: the build-time environment only references it as`${NAME}`.
- The rendered compose file is the only file holding a resolved secret and is now `0600`.
- The store follows the app folder, which is what its id is made of: delete removes the secrets, rename moves them, clone copies them.

