### PR TITLE
feat(cli): add 'app ps' command to show live app status

### DIFF
--- a/cmd/arduino-app-cli/app/app.go
+++ b/cmd/arduino-app-cli/app/app.go
@@ -29,6 +29,7 @@ func NewAppCmd(cfg config.Configuration) *cobra.Command {
 	appCmd.AddCommand(newRestartCmd(cfg))
 	appCmd.AddCommand(newLogsCmd(cfg))
 	appCmd.AddCommand(newListCmd(cfg))
+	appCmd.AddCommand(newPsCmd(cfg))
 	appCmd.AddCommand(newCacheCleanCmd(cfg))
 	appCmd.AddCommand(newExportCmd(cfg))
 	appCmd.AddCommand(newImportCmd(cfg))

--- a/cmd/arduino-app-cli/app/ps.go
+++ b/cmd/arduino-app-cli/app/ps.go
@@ -1,0 +1,105 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package app
+
+import (
+	"context"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+
+	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/internal/cmdutil"
+	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/internal/servicelocator"
+	"github.com/arduino/arduino-app-cli/cmd/feedback"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
+	"github.com/arduino/arduino-app-cli/internal/tablestyle"
+)
+
+// psVisibleStatuses are the statuses shown by default, i.e. any app that has
+// been initialized at least once and is not currently stopped.
+var psVisibleStatuses = map[orchestrator.Status]bool{
+	orchestrator.StatusStarting: true,
+	orchestrator.StatusRunning:  true,
+	orchestrator.StatusStopping: true,
+	orchestrator.StatusFailed:   true,
+}
+
+func newPsCmd(cfg config.Configuration) *cobra.Command {
+	var showAll bool
+
+	cmd := &cobra.Command{
+		Use:   "ps",
+		Short: "List the status of the Arduino apps on the board",
+		Long: "List the Arduino apps that have been initialized at least once, and their live status.\n" +
+			"By default, only starting, running, stopping and failed apps are shown. Use --all to also " +
+			"include stopped apps. Apps that have never been started are never shown; use 'app list' to " +
+			"browse the full catalog instead.",
+		Run: func(cmd *cobra.Command, args []string) {
+			psHandler(cmd.Context(), cfg, showAll)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&showAll, "all", "a", false, "Also show stopped apps")
+	return cmd
+}
+
+func psHandler(ctx context.Context, cfg config.Configuration, showAll bool) {
+	res, err := orchestrator.ListApps(ctx,
+		servicelocator.GetDockerClient(),
+		orchestrator.ListAppRequest{
+			ShowExamples:                   true,
+			ShowApps:                       true,
+			IncludeNonStandardLocationApps: true,
+		},
+		servicelocator.GetAppIDProvider(),
+		servicelocator.GetBricksIndex(),
+		cfg,
+		servicelocator.GetPlatform(),
+	)
+	if err != nil {
+		feedback.Fatal(err.Error(), feedback.ErrGeneric)
+	}
+
+	feedback.PrintResult(appPsResult{
+		Apps: filterAppsByStatus(res.Apps, showAll),
+	})
+}
+
+// filterAppsByStatus keeps only apps that have been initialized at least once
+// (i.e. excludes StatusUninitialized), showing stopped apps only if showAll is set.
+func filterAppsByStatus(apps []orchestrator.AppInfo, showAll bool) []orchestrator.AppInfo {
+	res := make([]orchestrator.AppInfo, 0, len(apps))
+	for _, a := range apps {
+		if psVisibleStatuses[a.Status] || (showAll && a.Status == orchestrator.StatusStopped) {
+			res = append(res, a)
+		}
+	}
+	return res
+}
+
+type appPsResult struct {
+	Apps []orchestrator.AppInfo `json:"apps"`
+}
+
+func (r appPsResult) String() string {
+	t := table.NewWriter()
+	t.SetStyle(tablestyle.CustomCleanStyle)
+	t.AppendHeader(table.Row{"ID", "NAME", "STATUS"})
+
+	for _, app := range r.Apps {
+		t.AppendRow(table.Row{
+			cmdutil.IDToAlias(app.ID),
+			app.Name,
+			app.Status,
+		})
+	}
+	return t.Render()
+}
+
+func (r appPsResult) Data() any {
+	return r
+}

--- a/cmd/arduino-app-cli/app/ps_test.go
+++ b/cmd/arduino-app-cli/app/ps_test.go
@@ -1,0 +1,51 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/arduino/arduino-app-cli/internal/orchestrator"
+)
+
+func TestFilterAppsByStatus(t *testing.T) {
+	appWithStatus := func(name string, status orchestrator.Status) orchestrator.AppInfo {
+		return orchestrator.AppInfo{Name: name, Status: status}
+	}
+
+	apps := []orchestrator.AppInfo{
+		appWithStatus("starting-app", orchestrator.StatusStarting),
+		appWithStatus("running-app", orchestrator.StatusRunning),
+		appWithStatus("stopping-app", orchestrator.StatusStopping),
+		appWithStatus("failed-app", orchestrator.StatusFailed),
+		appWithStatus("stopped-app", orchestrator.StatusStopped),
+		appWithStatus("never-started-app", orchestrator.StatusUninitialized),
+	}
+
+	t.Run("default excludes stopped and uninitialized apps", func(t *testing.T) {
+		got := filterAppsByStatus(apps, false)
+		names := namesOf(got)
+		assert.ElementsMatch(t, []string{"starting-app", "running-app", "stopping-app", "failed-app"}, names)
+	})
+
+	t.Run("--all includes stopped but never uninitialized apps", func(t *testing.T) {
+		got := filterAppsByStatus(apps, true)
+		names := namesOf(got)
+		assert.ElementsMatch(t, []string{
+			"starting-app", "running-app", "stopping-app", "failed-app", "stopped-app",
+		}, names)
+	})
+}
+
+func namesOf(apps []orchestrator.AppInfo) []string {
+	names := make([]string, 0, len(apps))
+	for _, a := range apps {
+		names = append(names, a.Name)
+	}
+	return names
+}


### PR DESCRIPTION
### Motivation

`app list` currently mixes two different concerns: browsing the app catalog (examples and user apps) and showing live status (running, stopped, failed, etc). As the catalog grew with `core-and-foundational` and `bricks` examples, the command became cluttered and hard to use, as reported in #586.

Needs a dedicated way to see only the apps that are actually live on the board as outlined in the issue for enhancement, without the catalog noise, similar to `docker ps`.

### Change description

I added a new `app ps` command that shows only apps that have been initialized at least once.

By default it shows apps with status `starting`, `running`, `stopping`, or `failed`. I added an `--all` / `-a` flag that also includes `stopped` apps. Apps that have never been started (`uninitialized`) are never shown, in any combination of flags.

The table output is `ID`, `NAME`, `STATUS`.

Implementation notes:
- I reused the existing `orchestrator.ListApps` with `ShowExamples: true`, `ShowApps: true`, `IncludeNonStandardLocationApps: true`, then filtered the results client-side by status. I didn't change the orchestrator layer, since `ListAppRequest.StatusFilter` only supports a single exact status match and `app ps` needs to match a set of statuses.
- I registered the command in `app.go`.
- I added `ps_test.go` covering the default filter and the `--all` filter, including the case where `uninitialized` apps must be excluded in both.

This PR does not touch `app list`. That refactor (splitting status out of `app list` into a pure catalog view) is the second half of the split proposed in #586, and will follow in a separate PR.

### Demo

Local smoke test against a Linux-only (no-sketch) app, showing the full lifecycle: nothing shown before start, `running` after start, hidden by default after stop, and reappearing under `--all`.

<img width="729" height="598" alt="Screenshot From 2026-09-01 03-42-49" src="https://github.com/user-attachments/assets/c4a64f58-d1f9-4a92-80fe-197ea13999d2" />

### Additional Notes

Refs #586

This adds a new user-facing command; a follow-up doc update in arduino/docs-content may be needed to document `app ps` in the CLI reference.

### Reviewer checklist
- [x] PR addresses a single concern.
- [x] PR title and description are properly filled.
- [x] Changes will be merged in `main`.
- [x] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.