### PR TITLE
bump bricks and example to 0.13.0rc1

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,8 +8,8 @@ vars:
   GOLANGCI_LINT_VERSION: v2.11.4
   GOIMPORTS_VERSION: v0.42.0
   DPRINT_VERSION: 0.48.0
-  EXAMPLE_VERSION: "0.12.1"
-  RUNNER_VERSION: "0.12.0"
+  EXAMPLE_VERSION: "0.13.0rc1"
+  RUNNER_VERSION: "0.13.0rc1"
   VERSION: # if version is not passed we hack the semver by encoding the commit as pre-release
     sh: echo "${VERSION:-0.0.0-$(git rev-parse --short HEAD)}"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -198,7 +198,7 @@ tasks:
       - |
           set -e
           echo "Runner version set as: {{ .RUNNER_VERSION }}"
-          gh release download -R arduino/app-bricks-py "release/{{.SEMVER_TAG}}" -p '*.whl' -D "{{.TMPDIR}}" --clobber
+          gh release download -R arduino/app-bricks-py "bricks/{{.SEMVER_TAG}}" -p '*.whl' -D "{{.TMPDIR}}" --clobber
           unzip -o "{{.TMPDIR}}/arduino_app_bricks-{{.SEMVER_TAG}}-py3-none-any.whl" -d "{{.TMPDIR}}/extract"
           # Wipe any previous versions so the destination contains exactly one.
           rm -rf "{{.DEST}}" && mkdir -p "{{.DEST}}"

--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -22,7 +22,7 @@ import (
 )
 
 // runnerVersion do not edit, this is generate with `task bump:runner-version`
-var RunnerVersion = "0.12.0"
+var RunnerVersion = "0.13.0rc1"
 
 type Configuration struct {
 	appsDir                          *paths.Path


### PR DESCRIPTION
### Motivation

WIRE team released a new bricks/example RC (0.13.0rc1)

Bricks:
https://github.com/arduino/app-bricks-py/releases/tag/bricks%2F0.13.0rc1

Examples:
https://github.com/arduino/app-bricks-examples/releases/tag/0.13.0rc1

### Change description

- EXAMPLE_VERSION: "0.12.1" to version "0.13.0rc1"
- RUNNER_VERSION: "0.12.0" to RUNNER_VERSION: "0.13.0rc1"
- task bump:runner-version

### Additional Notes


The new RC is tagged `bricks/0.13.0rc1`, while every previous one used the `release/` 
Wire team just restructured the pipeline. so we need to update our task command for bricks dowload. 


### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
