### PR TITLE
chore: bump runner to 0.13.0rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,20 @@ For guidance on installation and development, see the [User documentation].
 `arduino-app-cli` drives model downloads through the `models-downloader` container from
 [app-bricks-py], declared per handler in `models-handlers.yaml`, which ships in the
 app-bricks wheel the `RUNNER_VERSION` in `Taskfile.yml` pins. The Go side reads what that
-container prints, so some features need a minimum image:
+container prints and the runners serve models under names the Go side derives itself, so
+the two move together: a model downloaded ad hoc needs a `models-downloader` and a
+`llamacpp-runner` from the same release.
 
-| Feature                                                      | Needs                                                                                   | Why                                                                                                                                                                                                               |
-| ------------------------------------------------------------ | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `POST /v1/models`, which downloads a model no entry declares | a `models-downloader` reporting `model_id` on its download events ([app-bricks-py#416]) | The downloader names the model after the file that arrives. Without that field the model installs, but the endpoint cannot say which one it is, so the stream ends with an error event instead of the model.      |
-| Listing a model no `models-list.yaml` entry declares         | a `models-downloader` reporting `model_origin` and `download_metadata` in its listing   | An undeclared model is reconstructed from its on-disk record. An older image reports neither, so nothing is appended and only declared models are listed.                                                         |
-| Running an undeclared model, once installed                  | `llamacpp-runner` and `llamacpp-npu-runner` from the same release ([app-bricks-py#415]) | The runners regenerate `models.ini` at startup. An older one sections an undeclared model by its bare filename while its id carries the repository path, so `arduino:llm` cannot find it among the served models. |
+`RUNNER_VERSION` is `0.13.0rc1`, the first release that carries both halves:
+
+| Needs                                                                        | Since                | Why                                                                                                                                                                                                                 |
+| ---------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `models-downloader` reporting `model_id` on its download events              | [app-bricks-py#416]  | The downloader names the model after the file that arrives. Without that field the model installs, but `POST /v1/models` cannot say which one it is, so the stream ends with an error event instead of the model.   |
+| `models-downloader` reporting `model_origin` and `download_metadata` listing | [app-bricks-py#416]  | A model no `models-list.yaml` entry declares is reconstructed from its on-disk record. An older image reports neither, so only declared models are listed.                                                          |
+| `llamacpp-runner` and `llamacpp-npu-runner` naming by download record        | [app-bricks-py#415]  | The runners regenerate `models.ini` at startup. An older one sections a model by its bare filename while its id carries the repository path, so `arduino:llm` cannot find it among the served models.               |
+
+Releases are tagged `bricks/<version>`; up to and including 0.12.0 they were tagged
+`release/<version>`.
 
 ## Quickstart
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,7 +9,7 @@ vars:
   GOIMPORTS_VERSION: v0.42.0
   DPRINT_VERSION: 0.48.0
   EXAMPLE_VERSION: "0.12.1"
-  RUNNER_VERSION: "0.12.0"
+  RUNNER_VERSION: "0.13.0rc1"
   VERSION: # if version is not passed we hack the semver by encoding the commit as pre-release
     sh: echo "${VERSION:-0.0.0-$(git rev-parse --short HEAD)}"
 
@@ -198,7 +198,8 @@ tasks:
       - |
           set -e
           echo "Runner version set as: {{ .RUNNER_VERSION }}"
-          gh release download -R arduino/app-bricks-py "release/{{.SEMVER_TAG}}" -p '*.whl' -D "{{.TMPDIR}}" --clobber
+          # Tagged "bricks/<version>" since 0.13.0rc1; earlier releases used "release/<version>".
+          gh release download -R arduino/app-bricks-py "bricks/{{.SEMVER_TAG}}" -p '*.whl' -D "{{.TMPDIR}}" --clobber
           unzip -o "{{.TMPDIR}}/arduino_app_bricks-{{.SEMVER_TAG}}-py3-none-any.whl" -d "{{.TMPDIR}}/extract"
           # Wipe any previous versions so the destination contains exactly one.
           rm -rf "{{.DEST}}" && mkdir -p "{{.DEST}}"
@@ -290,7 +291,7 @@ tasks:
       - adb shell chmod +x {{.BOARD_PATH}}
       - adb forward tcp:{{.DLV_PORT}} tcp:{{.DLV_PORT}}
       - adb forward tcp:{{.APP_PORT}} tcp:{{.APP_PORT}}
-      - adb shell "/home/arduino/go/bin/dlv --listen=:{{.DLV_PORT}} --headless --api-version=2 exec {{.BOARD_PATH}} -- daemon --port {{.APP_PORT}} --log-level debug"
+      - adb shell "/home/arduino/go/bin/dlv --listen=:{{.DLV_PORT}} --headless --api-version=2 --accept-multiclient exec {{.BOARD_PATH}} -- daemon --port {{.APP_PORT}} --log-level debug"
 
   board:debug-cli:
     desc: 'Build a debug binary, deploy to board and start dlv headless for a one-shot CLI command. Invoke as: CLI_ARGS="app start ..." task board:debug-cli'
@@ -307,7 +308,7 @@ tasks:
       - adb push {{.DEBUG_BINARY}} {{.BOARD_PATH}}
       - adb shell chmod +x {{.BOARD_PATH}}
       - adb forward tcp:{{.DLV_PORT}} tcp:{{.DLV_PORT}}
-      - adb shell "DOCKER_REGISTRY_BASE=${DOCKER_REGISTRY_BASE:-ghcr.io/arduino/} /home/arduino/go/bin/dlv --listen=:{{.DLV_PORT}} --headless --api-version=2 exec {{.BOARD_PATH}} -- ${CLI_ARGS:-app list}"
+      - adb shell "DOCKER_REGISTRY_BASE=${DOCKER_REGISTRY_BASE:-ghcr.io/arduino/} /home/arduino/go/bin/dlv --listen=:{{.DLV_PORT}} --headless --api-version=2 --accept-multiclient exec {{.BOARD_PATH}} -- ${CLI_ARGS:-app list}"
 
   bump:runner-version:
     desc: Update the RunnerVersion constant in config.go to match RUNNER_VERSION.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -198,7 +198,6 @@ tasks:
       - |
           set -e
           echo "Runner version set as: {{ .RUNNER_VERSION }}"
-          # Tagged "bricks/<version>" since 0.13.0rc1; earlier releases used "release/<version>".
           gh release download -R arduino/app-bricks-py "bricks/{{.SEMVER_TAG}}" -p '*.whl' -D "{{.TMPDIR}}" --clobber
           unzip -o "{{.TMPDIR}}/arduino_app_bricks-{{.SEMVER_TAG}}-py3-none-any.whl" -d "{{.TMPDIR}}/extract"
           # Wipe any previous versions so the destination contains exactly one.

--- a/internal/orchestrator/config/config.go
+++ b/internal/orchestrator/config/config.go
@@ -22,7 +22,7 @@ import (
 )
 
 // runnerVersion do not edit, this is generate with `task bump:runner-version`
-var RunnerVersion = "0.12.0"
+var RunnerVersion = "0.13.0rc1"
 
 type Configuration struct {
 	appsDir                          *paths.Path


### PR DESCRIPTION
Stacked on #593, which needs a models-downloader and llamacpp runners that #593 could not
point at: at the time no release carried them, so `RUNNER_VERSION` stayed at 0.12.0 and the
Hugging Face download path could not work on a stock board. [bricks/0.13.0rc1] is the first
release that carries both, so this bumps to it.

## What it changes

`RUNNER_VERSION` and the `RunnerVersion` constant move to `0.13.0rc1`. The asset download
follows the tag rename: app-bricks-py tagged releases `release/<version>` up to 0.12.0 and
tags them `bricks/<version>` from this one, so `bricks/0.13.0rc1` does not resolve under the
old prefix. The README dependency table now names the release instead of two unmerged PRs.

## Why this release

Verified against the published images rather than the changelog, which does not list either
PR — both merged on 2026-08-31, before the rc, and are ancestors of the tag.

`models-downloader:0.13.0rc1` reports `model_id` on download events and `model_origin` plus
`download_metadata` in its listing ([#416]). `llamacpp-runner:0.13.0rc1` replaces
`generate_models_ini.py` with `configure-llamacpp.py`, whose `gguf_model_name` returns the
models-dir-relative path when the download record says `model_origin: user` and the file
stem otherwise ([#415]) — the same rule as `modelNameFromID` on the Go side.

That last part is what made the bump blocking. `llamacpp-runner:0.12.1` sections `models.ini`
by `gguf_file.stem`, and it regenerates the file at startup, so on 0.12.x the first app start
rewrote a downloaded model's section from its qualified id to the bare filename. The model
listed as installed and `arduino:llm` could not find it.

## Testing

`task download-runner-assets` resolves `bricks/0.13.0rc1` and unpacks a `models-handlers.yaml`
pointing at `models-downloader:0.13.0rc1`. Build is clean and the suite passes except the
Docker- and daemon-dependent tests, which fail identically on the base branch on a host with
no Docker.

Still to do on hardware, and the reason this is an rc: start an `arduino:llm` app against a
model downloaded ad hoc and confirm `models.ini` keeps the qualified section across the
restart.

[bricks/0.13.0rc1]: https://github.com/arduino/app-bricks-py/releases/tag/bricks%2F0.13.0rc1
[#415]: https://github.com/arduino/app-bricks-py/pull/415
[#416]: https://github.com/arduino/app-bricks-py/pull/416