### PR TITLE
fix: use project name instead of compose file path

### DIFF
--- a/cmd/arduino-app-cli/app/logs.go
+++ b/cmd/arduino-app-cli/app/logs.go
@@ -37,7 +37,7 @@ func newLogsCmd(cfg config.Configuration) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return logsHandler(cmd.Context(), app, &tail, follow, all)
+			return logsHandler(cmd.Context(), app, cfg, &tail, follow, all)
 		},
 		ValidArgsFunction: completion.ApplicationNames(cfg),
 	}
@@ -47,27 +47,28 @@ func newLogsCmd(cfg config.Configuration) *cobra.Command {
 	return cmd
 }
 
-func logsHandler(ctx context.Context, app app.ArduinoApp, tail *uint64, follow, all bool) error {
+func logsHandler(ctx context.Context, app app.ArduinoApp, cfg config.Configuration, tail *uint64, follow, all bool) error {
 	stdout, _, err := feedback.DirectStreams()
 	if err != nil {
 		feedback.Fatal(err.Error(), feedback.ErrBadArgument)
 		return nil
 	}
 
-	cfg := orchestrator.AppLogsRequest{
+	req := orchestrator.AppLogsRequest{
 		ShowAppLogs: true,
 		Follow:      follow,
 		Tail:        tail,
 	}
 	if all {
-		cfg.ShowServicesLogs = true
+		req.ShowServicesLogs = true
 	}
 	logsIter, err := orchestrator.AppLogs(
 		ctx,
 		app,
-		cfg,
+		req,
 		servicelocator.GetDockerClient(),
 		servicelocator.GetBricksIndex(),
+		cfg,
 	)
 	if err != nil {
 		feedback.Fatal(err.Error(), feedback.ErrGeneric)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -73,7 +73,7 @@ func NewHTTPRouter(
 	mux.Handle("GET /v1/apps/events", handlers.HandlerAppStatus(dockerClient, idProvider, bricksIndex, cfg, platform))
 	mux.Handle("GET /v1/apps/{appID}", handlers.HandleAppDetails(dockerClient, bricksIndex, idProvider, cfg))
 	mux.Handle("PATCH /v1/apps/{appID}", handlers.HandleAppDetailsEdits(dockerClient, bricksIndex, idProvider, cfg))
-	mux.Handle("GET /v1/apps/{appID}/logs", handlers.HandleAppLogs(dockerClient, idProvider, bricksIndex))
+	mux.Handle("GET /v1/apps/{appID}/logs", handlers.HandleAppLogs(dockerClient, idProvider, bricksIndex, cfg))
 	mux.Handle("POST /v1/apps/{appID}/start", handlers.HandleAppStart(dockerClient, provisioner, modelsIndex, bricksIndex, servicesIndex, idProvider, cfg, platform))
 	mux.Handle("POST /v1/apps/{appID}/stop", handlers.HandleAppStop(dockerClient, idProvider, platform, cfg))
 	mux.Handle("POST /v1/apps/{appID}/clone", handlers.HandleAppClone(idProvider, cfg))

--- a/internal/api/handlers/app_logs.go
+++ b/internal/api/handlers/app_logs.go
@@ -19,6 +19,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
 	"github.com/arduino/arduino-app-cli/internal/render"
 )
 
@@ -26,6 +27,7 @@ func HandleAppLogs(
 	dockerClient command.Cli,
 	idProvider *appid.Provider,
 	bricksIndex *bricksindex.BricksIndex,
+	cfg config.Configuration,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := idProvider.IDFromBase64(r.PathValue("appID"))
@@ -83,7 +85,7 @@ func HandleAppLogs(
 			BrickID string `json:"brick_id,omitempty"`
 			Message string `json:"message"`
 		}
-		messagesIter, err := orchestrator.AppLogs(r.Context(), app, appLogsRequest, dockerClient, bricksIndex)
+		messagesIter, err := orchestrator.AppLogs(r.Context(), app, appLogsRequest, dockerClient, bricksIndex, cfg)
 		if err != nil {
 			sseStream.SendError(render.SSEErrorData{
 				Code:    render.InternalServiceErr,

--- a/internal/orchestrator/helpers.go
+++ b/internal/orchestrator/helpers.go
@@ -160,6 +160,28 @@ func getRunningApp(
 	return &app, nil
 }
 
+// getAppComposeServices are the compose services docker has for the app. Read from the
+// container labels, never from the compose file: an update replaces the assets that the
+// file the app was started from includes.
+func getAppComposeServices(ctx context.Context, docker dockerClient.APIClient, app app.ArduinoApp) ([]string, error) {
+	containers, err := docker.ContainerList(ctx, container.ListOptions{
+		All:     true,
+		Filters: filters.NewArgs(filters.Arg("label", DockerAppPathLabel+"="+app.FullPath.String())),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list containers: %w", err)
+	}
+
+	const dockerComposeServiceLabel = "com.docker.compose.service"
+	services := make([]string, 0, len(containers))
+	for _, info := range containers {
+		if name := info.Labels[dockerComposeServiceLabel]; name != "" && !slices.Contains(services, name) {
+			services = append(services, name)
+		}
+	}
+	return services, nil
+}
+
 func getAppComposeProjectNameFromApp(app app.ArduinoApp, cfg config.Configuration) (string, error) {
 	composeProjectName, err := app.FullPath.RelFrom(cfg.AppsDir())
 	if err != nil {

--- a/internal/orchestrator/helpers.go
+++ b/internal/orchestrator/helpers.go
@@ -160,10 +160,9 @@ func getRunningApp(
 	return &app, nil
 }
 
-// getAppComposeServices are the compose services docker has for the app. Read from the
-// container labels, never from the compose file: an update replaces the assets that the
-// file the app was started from includes.
-func getAppComposeServices(ctx context.Context, docker dockerClient.APIClient, app app.ArduinoApp) ([]string, error) {
+// getAppServicesFromContainers returns the app compose services from the container labels.
+// The compose file is not a source: an update removes the brick files that it includes.
+func getAppServicesFromContainers(ctx context.Context, docker dockerClient.APIClient, app app.ArduinoApp) ([]string, error) {
 	containers, err := docker.ContainerList(ctx, container.ListOptions{
 		All:     true,
 		Filters: filters.NewArgs(filters.Arg("label", DockerAppPathLabel+"="+app.FullPath.String())),

--- a/internal/orchestrator/logs.go
+++ b/internal/orchestrator/logs.go
@@ -51,18 +51,18 @@ func AppLogs(
 		return helpers.EmptyIter[LogMessage](), nil
 	}
 
+	services, err := getAppServicesFromContainers(ctx, dockerCli.Client(), app)
+	if err != nil {
+		return nil, err
+	}
+	// No container, so the app was never started
+	if len(services) == 0 {
+		return helpers.EmptyIter[LogMessage](), nil
+	}
+
 	projectName, err := getAppComposeProjectNameFromApp(app, cfg)
 	if err != nil {
 		return nil, err
-	}
-
-	// In case the app was never started
-	services, err := getAppComposeServices(ctx, dockerCli.Client(), app)
-	if err != nil {
-		return nil, err
-	}
-	if len(services) == 0 {
-		return helpers.EmptyIter[LogMessage](), nil
 	}
 
 	bricksIndex = bricksIndex.WithAppBricks(app.LocalBricks)
@@ -94,24 +94,27 @@ func AppLogs(
 		}
 	}
 
-	filteredServices := services
 	if req.ShowAppLogs && !req.ShowServicesLogs {
-		filteredServices = []string{"main"}
+		services = []string{"main"}
 	} else if req.ShowServicesLogs && !req.ShowAppLogs {
-		filteredServices = f.Filter(filteredServices, f.NotEquals("main"))
+		services = f.Filter(services, f.NotEquals("main"))
+	}
+	// An empty service list makes docker compose show all the containers of the project
+	if len(services) == 0 {
+		return helpers.EmptyIter[LogMessage](), nil
 	}
 
 	backend := compose.NewComposeService(dockerCli).(commands.Backend)
 	return func(yield func(LogMessage) bool) {
 		opts := api.LogOptions{
 			Follow:     req.Follow,
-			Services:   filteredServices,
+			Services:   services,
 			Timestamps: false,
 		}
 		if req.Tail != nil {
 			opts.Tail = fmt.Sprintf("%d", *req.Tail)
 		}
-		err = backend.Logs(
+		err := backend.Logs(
 			ctx,
 			projectName,
 			NewDockerLogConsumer(ctx, yield, serviceToBrickMapping),

--- a/internal/orchestrator/logs.go
+++ b/internal/orchestrator/logs.go
@@ -10,13 +10,10 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
 
-	"github.com/compose-spec/compose-go/v2/loader"
-	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
 	commands "github.com/docker/compose/v2/cmd/compose"
 	"github.com/docker/compose/v2/pkg/api"
@@ -26,6 +23,7 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/helpers"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
+	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
 )
 
 type AppLogsRequest struct {
@@ -47,13 +45,23 @@ func AppLogs(
 	req AppLogsRequest,
 	dockerCli command.Cli,
 	bricksIndex *bricksindex.BricksIndex,
+	cfg config.Configuration,
 ) (iter.Seq[LogMessage], error) {
 	if app.MainPythonFile == nil {
 		return helpers.EmptyIter[LogMessage](), nil
 	}
 
-	mainCompose := app.AppComposeFilePath()
-	if mainCompose.NotExist() {
+	projectName, err := getAppComposeProjectNameFromApp(app, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// In case the app was never started
+	services, err := getAppComposeServices(ctx, dockerCli.Client(), app)
+	if err != nil {
+		return nil, err
+	}
+	if len(services) == 0 {
 		return helpers.EmptyIter[LogMessage](), nil
 	}
 
@@ -77,29 +85,16 @@ func AppLogs(
 			continue
 		}
 
-		services, err := extractServicesFromComposeFile(composeFilePath)
+		brickServices, err := extractServicesFromComposeFile(composeFilePath)
 		if err != nil {
 			return helpers.EmptyIter[LogMessage](), err
 		}
-		for _, s := range services {
+		for _, s := range brickServices {
 			serviceToBrickMapping[s.name] = brick.ID
 		}
 	}
 
-	prj, err := loader.LoadWithContext(
-		ctx,
-		types.ConfigDetails{
-			ConfigFiles: []types.ConfigFile{{Filename: mainCompose.String()}},
-			WorkingDir:  app.ProvisioningStateDir().String(),
-			Environment: types.NewMapping(os.Environ()),
-		},
-		loader.WithSkipValidation, //TODO: check if there is a bug on docker compose upstream
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	filteredServices := prj.ServiceNames()
+	filteredServices := services
 	if req.ShowAppLogs && !req.ShowServicesLogs {
 		filteredServices = []string{"main"}
 	} else if req.ShowServicesLogs && !req.ShowAppLogs {
@@ -109,7 +104,6 @@ func AppLogs(
 	backend := compose.NewComposeService(dockerCli).(commands.Backend)
 	return func(yield func(LogMessage) bool) {
 		opts := api.LogOptions{
-			Project:    prj,
 			Follow:     req.Follow,
 			Services:   filteredServices,
 			Timestamps: false,
@@ -119,7 +113,7 @@ func AppLogs(
 		}
 		err = backend.Logs(
 			ctx,
-			prj.Name,
+			projectName,
 			NewDockerLogConsumer(ctx, yield, serviceToBrickMapping),
 			opts,
 		)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -368,30 +368,34 @@ func stopAppWithCmd(ctx context.Context, docker command.Cli, platform platform.P
 	}
 
 	if app.MainPythonFile != nil {
-		mainCompose := app.AppComposeFilePath()
-		// In case the app was never started
-		if mainCompose.Exist() {
-			args := []string{
-				"docker",
-				"compose",
-				"-f", mainCompose.String(),
-				cmd,
-				fmt.Sprintf("--timeout=%d", DefaultDockerStopTimeoutSeconds),
-			}
-			if cmd == "down" {
-				args = append(args, "--volumes", "--remove-orphans")
-			}
+		// Stopped by project name, never by the compose file: the file the app was
+		// started from includes the asset dir of its version, which an update removes.
+		// Compose works from the container labels here, and exits 0 when the project
+		// has no container, which is the case when the app was never started.
+		projectName, err := getAppComposeProjectNameFromApp(app, cfg)
+		if err != nil {
+			return err
+		}
+		args := []string{
+			"docker",
+			"compose",
+			"--project-name", projectName,
+			cmd,
+			fmt.Sprintf("--timeout=%d", DefaultDockerStopTimeoutSeconds),
+		}
+		if cmd == "down" {
+			args = append(args, "--volumes", "--remove-orphans")
+		}
 
-			process, err := paths.NewProcess(nil, args...)
-			if err != nil {
-				return err
-			}
+		process, err := paths.NewProcess(nil, args...)
+		if err != nil {
+			return err
+		}
 
-			process.RedirectStderrTo(callbackWriter)
-			process.RedirectStdoutTo(callbackWriter)
-			if err := process.RunWithinContext(ctx); err != nil {
-				return err
-			}
+		process.RedirectStderrTo(callbackWriter)
+		process.RedirectStdoutTo(callbackWriter)
+		if err := process.RunWithinContext(ctx); err != nil {
+			return err
 		}
 	}
 	cb(StreamMessage{progress: &Progress{Name: "", Progress: 100.0}})

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -368,10 +368,8 @@ func stopAppWithCmd(ctx context.Context, docker command.Cli, platform platform.P
 	}
 
 	if app.MainPythonFile != nil {
-		// Stopped by project name, never by the compose file: the file the app was
-		// started from includes the asset dir of its version, which an update removes.
-		// Compose works from the container labels here, and exits 0 when the project
-		// has no container, which is the case when the app was never started.
+		// The project name stops the compose project without its compose file, which
+		// an update can remove or change.
 		projectName, err := getAppComposeProjectNameFromApp(app, cfg)
 		if err != nil {
 			return err


### PR DESCRIPTION
### Motivation

The app CLI cannot operate on apps that are missing the generated Compose files in the .cache directory. 

### Change description

By using the project name, we can always get logs and stop the application, also after a full removal of the .cache folder.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
