### PR TITLE
fix: correctly start services for custom model

### DIFF
--- a/internal/orchestrator/bricksindex/bricks_index.go
+++ b/internal/orchestrator/bricksindex/bricks_index.go
@@ -12,7 +12,6 @@ import (
 	"iter"
 	"log/slog"
 	"os"
-	"path"
 	"slices"
 	"strings"
 
@@ -82,6 +81,7 @@ type RequiresService struct {
 }
 
 type RequiresServiceMatch struct {
+	// A glob on the model id, where "*" is the only wildcard.
 	Model *string `yaml:"model,omitempty"`
 }
 
@@ -220,13 +220,45 @@ func (b Brick) GetMatchingService(brick BrickInstance) ([]string, error) {
 			services = append(services, r.ID)
 			continue
 		}
-		if ok, err := path.Match(*r.When.Model, brick.Model); err != nil {
+		if ok, err := matchString(*r.When.Model, brick.Model); err != nil {
 			return services, fmt.Errorf("invalid pattern in requires_services.when.model: %w", err)
 		} else if ok {
 			services = append(services, r.ID)
 		}
 	}
 	return services, nil
+}
+
+// matchString is a glob match of pattern against s, with "*" as the only wildcard. Unlike
+// path.Match, "*" matches "/" too, which a model id can contain.
+func matchString(pattern, s string) (bool, error) {
+	if strings.ContainsAny(pattern, `?[]\`) {
+		return false, fmt.Errorf(`%q: "*" is the only wildcard`, pattern)
+	}
+
+	parts := strings.Split(pattern, "*")
+	if len(parts) == 1 {
+		return pattern == s, nil
+	}
+
+	// The part before the first "*" and the one after the last are anchored to the ends.
+	first := parts[0]
+	last := parts[len(parts)-1]
+	if !strings.HasPrefix(s, first) || !strings.HasSuffix(s, last) {
+		return false, nil
+	}
+
+	rest := s[len(first):]
+	for _, part := range parts[1 : len(parts)-1] {
+		i := strings.Index(rest, part)
+		if i == -1 {
+			return false, nil
+		}
+		rest = rest[i+len(part):]
+	}
+
+	// The two anchors must not share characters: "a*a" does not match "a".
+	return len(rest) >= len(last), nil
 }
 
 type YamlBricksIndex struct {

--- a/internal/orchestrator/bricksindex/bricks_index_test.go
+++ b/internal/orchestrator/bricksindex/bricks_index_test.go
@@ -563,6 +563,15 @@ func TestGetMatchingService(t *testing.T) {
 			wantServices:  []string{},
 		},
 		{
+			name: "model downloaded by link matches its runner pattern",
+			requiresServices: []RequiresService{
+				{ID: "arduino:llamacpp", When: &RequiresServiceMatch{Model: new("llamacpp:*")}},
+				{ID: "arduino:genie", When: &RequiresServiceMatch{Model: new("genie:*")}},
+			},
+			brickInstance: BrickInstance{Model: "llamacpp:unsloth/Qwen3.5-0.8B-GGUF/Qwen3.5-0.8B-Q8_0"},
+			wantServices:  []string{"arduino:llamacpp"},
+		},
+		{
 			name: "invalid pattern returns error",
 			requiresServices: []RequiresService{
 				{ID: "service-k", When: &RequiresServiceMatch{Model: new("[invalid")}},
@@ -582,6 +591,159 @@ func TestGetMatchingService(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.wantServices, got)
 			}
+		})
+	}
+}
+
+func TestMatchString(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		s       string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "exact match",
+			pattern: "genie:mini",
+			s:       "genie:mini",
+			want:    true,
+		},
+		{
+			name:    "exact non-match",
+			pattern: "genie:",
+			s:       "genie:mini",
+		},
+		{
+			name:    "trailing wildcard",
+			pattern: "genie:*",
+			s:       "genie:mini",
+			want:    true,
+		},
+		{
+			name:    "trailing wildcard, nothing left",
+			pattern: "genie:*",
+			s:       "genie:",
+			want:    true,
+		},
+		{
+			name:    "trailing wildcard, wrong prefix",
+			pattern: "genie:*",
+			s:       "llamacpp:mini",
+		},
+		{
+			name:    "wildcard crosses the slash",
+			pattern: "llamacpp:*",
+			s:       "llamacpp:unsloth/Qwen3.5-0.8B-GGUF/Qwen3.5-0.8B-Q8_0",
+			want:    true,
+		},
+		{
+			name:    "leading wildcard",
+			pattern: "*-Q8_0",
+			s:       "llamacpp:unsloth/repo/model-Q8_0",
+			want:    true,
+		},
+		{
+			name:    "leading wildcard, wrong suffix",
+			pattern: "*-Q8_0",
+			s:       "llamacpp:unsloth/repo/model-Q4_0",
+		},
+		{
+			name:    "wildcard in the middle",
+			pattern: "llamacpp:*Q8_0",
+			s:       "llamacpp:unsloth/repo/model-Q8_0",
+			want:    true,
+		},
+		{
+			name:    "prefix fails",
+			pattern: "genie:*-Q8_0",
+			s:       "llamacpp:model-Q8_0",
+		},
+		{
+			name:    "suffix fails",
+			pattern: "genie:*-Q8_0",
+			s:       "genie:model-Q4_0",
+		},
+		{
+			name:    "both ends fail",
+			pattern: "genie:*-Q8_0",
+			s:       "llamacpp:model-Q4_0",
+		},
+		{
+			name:    "several wildcards",
+			pattern: "*:*/repo/*-Q8_0",
+			s:       "llamacpp:unsloth/repo/model-Q8_0",
+			want:    true,
+		},
+		{
+			name:    "several wildcards, wrong order",
+			pattern: "*repo*unsloth*",
+			s:       "llamacpp:unsloth/repo/model",
+		},
+		{
+			name:    "lone wildcard",
+			pattern: "*",
+			s:       "llamacpp:unsloth/repo/model",
+			want:    true,
+		},
+		{
+			name:    "lone wildcard, empty string",
+			pattern: "*",
+			s:       "",
+			want:    true,
+		},
+		{
+			name:    "ends overlap",
+			pattern: "a*a",
+			s:       "a",
+		},
+		{
+			name:    "ends touch",
+			pattern: "a*a",
+			s:       "aa",
+			want:    true,
+		},
+		{
+			name:    "empty pattern",
+			pattern: "",
+			s:       "genie:mini",
+		},
+		{
+			name:    "question mark",
+			pattern: "genie:min?",
+			s:       "genie:mini",
+			wantErr: true,
+		},
+		{
+			name:    "character class",
+			pattern: "genie:[mp]*",
+			s:       "genie:mini",
+			wantErr: true,
+		},
+		{
+			name:    "closing bracket",
+			pattern: "genie:mini]",
+			s:       "genie:mini]",
+			wantErr: true,
+		},
+		{
+			name:    "escape",
+			pattern: `genie:\*`,
+			s:       "genie:*",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := matchString(tt.pattern, tt.s)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.False(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
### Motivation

Custom download models contain `/` in their ID, which are interpreted by `path.Match` as a globbing stop, so those models don't match any service to start.

### Change description

Implement a simpler implementation of `path.Match` that ignores `/` and uses only `*` for globbing. 

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [x] PR addresses a single concern.
- [x] PR title and description are properly filled.
- [x] Changes will be merged in `main`.
- [x] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
