### PR TITLE
refactor: move docker stuff in dockerhelper

### DIFF
--- a/cmd/arduino-app-cli/daemon/daemon.go
+++ b/cmd/arduino-app-cli/daemon/daemon.go
@@ -8,7 +8,6 @@ package daemon
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -16,11 +15,11 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	"github.com/jub0bs/cors"
-	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
 
 	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/internal/servicelocator"
 	"github.com/arduino/arduino-app-cli/internal/api"
+	"github.com/arduino/arduino-app-cli/internal/dockerhelper"
 	"github.com/arduino/arduino-app-cli/internal/httprecover"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
@@ -165,18 +164,7 @@ func httpHandler(ctx context.Context, cfg config.Configuration, daemonPort, vers
 
 // stopArduinoContainers stops the Arduino containers that start running automatically when the board boots
 func stopArduinoContainers(ctx context.Context, docker command.Cli) error {
-	containers, err := docker.Client().ContainerList(ctx, client.ContainerListOptions{
-		All:     false,
-		Filters: make(client.Filters).Add("label", orchestrator.DockerAppLabel+"=true"),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to list containers: %w", err)
-	}
-	for _, c := range containers.Items {
-		slog.Debug("Stopping container", slog.String("ID", c.ID))
-		if _, err := docker.Client().ContainerStop(ctx, c.ID, client.ContainerStopOptions{}); err != nil {
-			slog.Warn("Failed to stop container", "ID", c.ID, "error", err.Error())
-		}
-	}
-	return nil
+	stopped, err := dockerhelper.StopContainers(ctx, docker.Client(), orchestrator.DockerAppLabel+"=true")
+	slog.Debug("stopped the containers of the apps", slog.Int("containers", stopped))
+	return err
 }

--- a/cmd/arduino-app-cli/internal/servicelocator/servicelocator.go
+++ b/cmd/arduino-app-cli/internal/servicelocator/servicelocator.go
@@ -11,10 +11,9 @@ import (
 	"sync"
 
 	dockerCommand "github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/flags"
-	dockerClient "github.com/moby/moby/client"
 	"go.bug.st/f"
 
+	"github.com/arduino/arduino-app-cli/internal/dockerhelper"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricks"
@@ -54,14 +53,7 @@ var (
 	docker *dockerCommand.DockerCli
 
 	GetDockerClient = sync.OnceValue(func() *dockerCommand.DockerCli {
-		docker = f.Must(dockerCommand.NewDockerCli(
-			dockerCommand.WithAPIClient(
-				f.Must(dockerClient.New(dockerClient.FromEnv)),
-			),
-		))
-		if err := docker.Initialize(flags.NewClientOptions()); err != nil {
-			panic(err)
-		}
+		docker = f.Must(dockerhelper.NewCli())
 		return docker
 	})
 

--- a/cmd/arduino-app-cli/main.go
+++ b/cmd/arduino-app-cli/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/arduino/arduino-app-cli/cmd/arduino-app-cli/version"
 	"github.com/arduino/arduino-app-cli/cmd/feedback"
 	"github.com/arduino/arduino-app-cli/cmd/i18n"
+	"github.com/arduino/arduino-app-cli/internal/dockerhelper"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 	cfg "github.com/arduino/arduino-app-cli/internal/orchestrator/config"
 )
@@ -116,7 +117,7 @@ func main() {
 	}
 
 	if err := run(configuration); err != nil {
-		if errors.Is(err, orchestrator.ErrDockerOutOfSpace) {
+		if errors.Is(err, dockerhelper.ErrOutOfSpace) {
 			// Return a specific error code in case a specific error happened (disk full when pulling docker images).
 			feedback.FatalError(err, orchestrator.ExitCodeDockerOutOfSpace)
 		}

--- a/cmd/arduino-app-cli/system/check.go
+++ b/cmd/arduino-app-cli/system/check.go
@@ -11,9 +11,10 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/versions"
 	"github.com/spf13/cobra"
+
+	"github.com/arduino/arduino-app-cli/internal/dockerhelper"
 
 	"github.com/arduino/arduino-app-cli/cmd/feedback"
 )
@@ -63,13 +64,13 @@ const minEngineAPI = "1.44"
 // checkDockerEngine is the only thing that states the engine we need: the client
 // negotiates whatever version the board offers, older ones included.
 func checkDockerEngine(ctx context.Context, docker command.Cli) (string, error) {
-	engine, err := docker.Client().ServerVersion(ctx, client.ServerVersionOptions{})
+	version, apiVersion, err := dockerhelper.EngineVersion(ctx, docker)
 	if err != nil {
-		return "", fmt.Errorf("cannot reach the docker engine: %w", err)
+		return "", err
 	}
-	detail := fmt.Sprintf("version %s, api %s", engine.Version, engine.APIVersion)
-	if versions.LessThan(engine.APIVersion, minEngineAPI) {
-		return detail, fmt.Errorf("the engine speaks api %s, arduino-app-cli needs api %s or later", engine.APIVersion, minEngineAPI)
+	detail := fmt.Sprintf("version %s, api %s", version, apiVersion)
+	if versions.LessThan(apiVersion, minEngineAPI) {
+		return detail, fmt.Errorf("the engine speaks api %s, arduino-app-cli needs api %s or later", apiVersion, minEngineAPI)
 	}
 	return detail, nil
 }

--- a/cmd/arduino-app-cli/system/system_helper.go
+++ b/cmd/arduino-app-cli/system/system_helper.go
@@ -12,30 +12,12 @@ import (
 
 var _ feedback.Result = (*orchestrator.InitResult)(nil)
 
+// newInitEventCallback writes what `system init` reports. Nothing is dropped here:
+// what reports a progress states it once per percent.
 func newInitEventCallback(printEvent func(feedback.Result)) orchestrator.InitEventCallback {
-	return throttleProgress(func(e *orchestrator.InitResult) {
-		printEvent(e)
-	})
-}
-
-// throttleProgress drops the progress events that would render the same
-// percentage twice in a row for a given label.
-func throttleProgress(next func(*orchestrator.InitResult)) orchestrator.InitEventCallback {
-	lastPct := map[string]int{}
 	return func(event orchestrator.InitEvent) {
-		e := orchestrator.NewInitResult(event)
-		if e == nil {
-			return
+		if result := orchestrator.NewInitResult(event); result != nil {
+			printEvent(result)
 		}
-		if e.Type == orchestrator.InitResultProgress {
-			if e.Total <= 0 {
-				return
-			}
-			if last, ok := lastPct[e.Label]; ok && last == e.Percent {
-				return
-			}
-			lastPct[e.Label] = e.Percent
-		}
-		next(e)
 	}
 }

--- a/cmd/arduino-app-cli/system/system_test.go
+++ b/cmd/arduino-app-cli/system/system_test.go
@@ -14,54 +14,8 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator"
 )
 
-func TestThrottleProgress(t *testing.T) {
-	progress := func(label string, curr, total int64) orchestrator.InitEvent {
-		return orchestrator.InitEvent{
-			Type:     orchestrator.InitProgressEvent,
-			Progress: orchestrator.InitProgress{Label: label, Curr: curr, Total: total},
-		}
-	}
-	logEvt := func(msg string) orchestrator.InitEvent {
-		return orchestrator.InitEvent{Type: orchestrator.InitLogEvent, Message: msg}
-	}
-
-	var got []orchestrator.InitResult
-	cb := throttleProgress(func(e *orchestrator.InitResult) {
-		got = append(got, *e)
-	})
-
-	// Sequence: same integer percentage is collapsed; each new integer step and
-	// every log line passes through.
-	cb(progress("img", 0, 100))   // 0%  -> forwarded
-	cb(progress("img", 4, 100))   // 4%  -> forwarded
-	cb(progress("img", 49, 1000)) // 4%  -> dropped (same integer pct)
-	cb(logEvt("hello"))           //     -> forwarded (logs always pass)
-	cb(progress("img", 5, 100))   // 5%  -> forwarded
-	cb(progress("img", 5, 0))     //     -> dropped (Total <= 0)
-	cb(progress("other", 5, 100)) // 5%  -> forwarded (different label tracked separately)
-	cb(logEvt("done"))            //     -> forwarded
-
-	want := []orchestrator.InitResult{
-		*orchestrator.NewInitResult(progress("img", 0, 100)),
-		*orchestrator.NewInitResult(progress("img", 4, 100)),
-		*orchestrator.NewInitResult(logEvt("hello")),
-		*orchestrator.NewInitResult(progress("img", 5, 100)),
-		*orchestrator.NewInitResult(progress("other", 5, 100)),
-		*orchestrator.NewInitResult(logEvt("done")),
-	}
-
-	if len(got) != len(want) {
-		t.Fatalf("got %d events, want %d:\n got:  %+v\n want: %+v", len(got), len(want), got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("event %d = %+v, want %+v", i, got[i], want[i])
-		}
-	}
-}
-
 // The rendering of a result stream per output format is covered in the feedback
-// package, here we only check that the events reach the stream, throttled.
+// package, here we only check that the events reach the stream.
 func TestNewInitEventCallback(t *testing.T) {
 	var got []feedback.Result
 	cb := newInitEventCallback(func(res feedback.Result) {
@@ -73,12 +27,6 @@ func TestNewInitEventCallback(t *testing.T) {
 		Type:     orchestrator.InitProgressEvent,
 		Progress: orchestrator.InitProgress{Label: "img", Curr: 25, Total: 50},
 	})
-	// Same integer percentage as the previous event, dropped by the throttle.
-	cb(orchestrator.InitEvent{
-		Type:     orchestrator.InitProgressEvent,
-		Progress: orchestrator.InitProgress{Label: "img", Curr: 250, Total: 500},
-	})
-
 	want := []string{"pulling image", "img: 50%"}
 	if len(got) != len(want) {
 		t.Fatalf("got %d results, want %d: %+v", len(got), len(want), got)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/arduino/arduino-cli v1.5.2-0.20260805093225-aa0a9e8f47fd
 	github.com/arduino/go-paths-helper v1.14.0
 	github.com/compose-spec/compose-go/v2 v2.15.0
-	github.com/containerd/errdefs v1.0.0
 	github.com/docker/cli v29.8.0+incompatible
 	github.com/docker/compose/v5 v5.5.1
 	github.com/fatih/color v1.19.0
@@ -118,6 +117,7 @@ require (
 	github.com/containerd/containerd/api v1.11.1 // indirect
 	github.com/containerd/containerd/v2 v2.3.4 // indirect
 	github.com/containerd/continuity v0.5.0 // indirect
+	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v1.0.0-rc.5 // indirect

--- a/internal/dockerhelper/compose.go
+++ b/internal/dockerhelper/compose.go
@@ -125,8 +125,8 @@ func (p *composeProgress) On(events ...api.Resource) {
 	}
 }
 
-// Start and Done say only that an operation began and ended, which the caller knows:
-// what the sdk has to say is in the resources it reports to On.
+// Start and Done say only that an operation began and ended: what the sdk has to say
+// is in the resources it reports to On.
 func (p *composeProgress) Start(context.Context, string) {}
 
 func (p *composeProgress) Done(string, bool) {}

--- a/internal/dockerhelper/compose_test.go
+++ b/internal/dockerhelper/compose_test.go
@@ -10,12 +10,10 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	dockerCommand "github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/flags"
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/moby/moby/api/types/container"
 	dockerClient "github.com/moby/moby/client"
 	"github.com/stretchr/testify/require"
-	"go.bug.st/f"
 )
 
 // TestComposeRoundTrip starts a project on the engine and stops it the way an app is
@@ -143,10 +141,7 @@ func TestRegistryError(t *testing.T) {
 
 func getDockerCli(t *testing.T) dockerCommand.Cli {
 	t.Helper()
-	docker, err := dockerCommand.NewDockerCli(
-		dockerCommand.WithAPIClient(f.Must(dockerClient.New(dockerClient.FromEnv))),
-	)
+	docker, err := NewCli()
 	require.NoError(t, err)
-	require.NoError(t, docker.Initialize(flags.NewClientOptions()))
 	return docker
 }

--- a/internal/dockerhelper/containers.go
+++ b/internal/dockerhelper/containers.go
@@ -1,0 +1,105 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dockerhelper
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/events"
+	dockerClient "github.com/moby/moby/client"
+)
+
+// PruneContainers removes the containers carrying the label, running ones included, and
+// reports how many. A label cannot express everything, so keep has the last word.
+func PruneContainers(ctx context.Context, docker dockerClient.APIClient, label string, keep func(labels map[string]string) bool) (int, error) {
+	containers, err := docker.ContainerList(ctx, dockerClient.ContainerListOptions{
+		All:     true,
+		Filters: make(dockerClient.Filters).Add("label", label),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to list containers: %w", err)
+	}
+
+	var pruned int
+	for _, info := range containers.Items {
+		if keep != nil && !keep(info.Labels) {
+			continue
+		}
+		if _, err := docker.ContainerRemove(ctx, info.ID, dockerClient.ContainerRemoveOptions{
+			Force:         true,
+			RemoveVolumes: true,
+		}); err != nil {
+			return 0, fmt.Errorf("failed to remove container %s: %w", info.ID, err)
+		}
+		pruned++
+	}
+	return pruned, nil
+}
+
+// PruneNetworks removes the networks carrying the label, keep having the last word.
+func PruneNetworks(ctx context.Context, docker dockerClient.APIClient, label string, keep func(labels map[string]string) bool) (int, error) {
+	networks, err := docker.NetworkList(ctx, dockerClient.NetworkListOptions{
+		Filters: make(dockerClient.Filters).Add("label", label),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to list networks: %w", err)
+	}
+
+	var pruned int
+	for _, info := range networks.Items {
+		if keep != nil && !keep(info.Labels) {
+			continue
+		}
+		if _, err := docker.NetworkRemove(ctx, info.ID, dockerClient.NetworkRemoveOptions{}); err != nil {
+			return 0, fmt.Errorf("failed to remove network %s: %w", info.ID, err)
+		}
+		pruned++
+	}
+	return pruned, nil
+}
+
+// Containers lists the containers carrying the label, stopped ones included.
+func Containers(ctx context.Context, docker dockerClient.APIClient, label string) ([]container.Summary, error) {
+	containers, err := docker.ContainerList(ctx, dockerClient.ContainerListOptions{
+		All:     true,
+		Filters: make(dockerClient.Filters).Add("label", label),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list containers: %w", err)
+	}
+	return containers.Items, nil
+}
+
+// StopContainers stops the containers carrying the label.
+func StopContainers(ctx context.Context, docker dockerClient.APIClient, label string) (int, error) {
+	containers, err := Containers(ctx, docker, label)
+	if err != nil {
+		return 0, err
+	}
+
+	var stopped int
+	for _, info := range containers {
+		if _, err := docker.ContainerStop(ctx, info.ID, dockerClient.ContainerStopOptions{}); err != nil {
+			return stopped, fmt.Errorf("failed to stop container %s: %w", info.ID, err)
+		}
+		stopped++
+	}
+	return stopped, nil
+}
+
+// ContainerEvents streams the actions of the containers carrying the label, as
+// `docker events` does: create, start, die, and whatever else the caller names.
+func ContainerEvents(ctx context.Context, docker dockerClient.APIClient, label string, actions ...string) (<-chan events.Message, <-chan error) {
+	stream := docker.Events(ctx, dockerClient.EventsListOptions{
+		Filters: make(dockerClient.Filters).
+			Add("label", label).
+			Add("type", string(events.ContainerEventType)).
+			Add("event", actions...),
+	})
+	return stream.Messages, stream.Err
+}

--- a/internal/dockerhelper/containers_test.go
+++ b/internal/dockerhelper/containers_test.go
@@ -1,0 +1,127 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dockerhelper
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/events"
+	dockerClient "github.com/moby/moby/client"
+	"github.com/stretchr/testify/require"
+)
+
+// A label of this test alone, so a board running it keeps whatever else it has.
+const testLabel = "cc.arduino.app.test"
+
+func TestContainers(t *testing.T) {
+	docker := getDockerCli(t).Client()
+	running := startLabelled(t, docker, "running")
+
+	found, err := Containers(t.Context(), docker, testLabel+"=running")
+	require.NoError(t, err)
+	require.Len(t, found, 1)
+	require.Equal(t, running, found[0].ID)
+	require.Equal(t, container.StateRunning, found[0].State)
+
+	other, err := Containers(t.Context(), docker, testLabel+"=absent")
+	require.NoError(t, err)
+	require.Empty(t, other)
+}
+
+func TestStopContainers(t *testing.T) {
+	docker := getDockerCli(t).Client()
+	id := startLabelled(t, docker, "stop")
+
+	stopped, err := StopContainers(t.Context(), docker, testLabel+"=stop")
+	require.NoError(t, err)
+	require.Equal(t, 1, stopped)
+
+	state, err := docker.ContainerInspect(t.Context(), id, dockerClient.ContainerInspectOptions{})
+	require.NoError(t, err)
+	require.Equal(t, container.StateExited, state.Container.State.Status)
+}
+
+func TestPruneContainers(t *testing.T) {
+	docker := getDockerCli(t).Client()
+	startLabelled(t, docker, "prune")
+	startLabelled(t, docker, "keep")
+
+	// A running container is removed too, and what keep refuses is left alone.
+	pruned, err := PruneContainers(t.Context(), docker, testLabel, func(labels map[string]string) bool {
+		return labels[testLabel] == "prune"
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, pruned)
+
+	left, err := Containers(t.Context(), docker, testLabel)
+	require.NoError(t, err)
+	require.Len(t, left, 1)
+	require.Equal(t, "keep", left[0].Labels[testLabel])
+}
+
+func TestPruneNetworks(t *testing.T) {
+	docker := getDockerCli(t).Client()
+	created, err := docker.NetworkCreate(t.Context(), "arduino-app-cli-test-network", dockerClient.NetworkCreateOptions{
+		Labels: map[string]string{testLabel: "network"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = docker.NetworkRemove(context.WithoutCancel(t.Context()), created.ID, dockerClient.NetworkRemoveOptions{})
+	})
+
+	kept, err := PruneNetworks(t.Context(), docker, testLabel, func(map[string]string) bool { return false })
+	require.NoError(t, err)
+	require.Zero(t, kept)
+
+	pruned, err := PruneNetworks(t.Context(), docker, testLabel, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, pruned)
+}
+
+func TestContainerEvents(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	docker := getDockerCli(t).Client()
+
+	messages, errs := ContainerEvents(ctx, docker, testLabel+"=events", "start", "die")
+	id := startLabelled(t, docker, "events")
+
+	select {
+	case event := <-messages:
+		require.Equal(t, id, event.Actor.ID)
+		require.Equal(t, events.Action("start"), event.Action)
+	case err := <-errs:
+		t.Fatal(err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("no event for a container that started")
+	}
+}
+
+// startLabelled runs a container that stays up until the test removes it.
+func startLabelled(t *testing.T, docker dockerClient.APIClient, label string) string {
+	t.Helper()
+	require.NoError(t, ensureImage(t.Context(), docker, "busybox:latest"))
+
+	created, err := docker.ContainerCreate(t.Context(), dockerClient.ContainerCreateOptions{
+		Config: &container.Config{
+			Image:  "busybox:latest",
+			Cmd:    []string{"sleep", "600"},
+			Labels: map[string]string{testLabel: label},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// The context of a test is canceled before its cleanups run.
+		_, _ = docker.ContainerRemove(context.WithoutCancel(t.Context()), created.ID, dockerClient.ContainerRemoveOptions{Force: true})
+	})
+
+	_, err = docker.ContainerStart(t.Context(), created.ID, dockerClient.ContainerStartOptions{})
+	require.NoError(t, err)
+	return created.ID
+}

--- a/internal/dockerhelper/engine.go
+++ b/internal/dockerhelper/engine.go
@@ -1,0 +1,41 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package dockerhelper is what talks to docker: the engine of the board, through its
+// api, and the images of an app, through the registry they come from. Nothing else in
+// this project states a container, a network or a compose project.
+package dockerhelper
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/flags"
+	"github.com/moby/moby/client"
+)
+
+// NewCli is the docker client this binary talks to the engine with.
+func NewCli() (*command.DockerCli, error) {
+	engine, err := client.New(client.FromEnv)
+	if err != nil {
+		return nil, err
+	}
+	docker, err := command.NewDockerCli(command.WithAPIClient(engine))
+	if err != nil {
+		return nil, err
+	}
+	return docker, docker.Initialize(flags.NewClientOptions())
+}
+
+// EngineVersion is what the engine of this board answers: its version, and the api it
+// speaks after the negotiation.
+func EngineVersion(ctx context.Context, docker command.Cli) (version, apiVersion string, err error) {
+	engine, err := docker.Client().ServerVersion(ctx, client.ServerVersionOptions{})
+	if err != nil {
+		return "", "", fmt.Errorf("cannot reach the docker engine: %w", err)
+	}
+	return engine.Version, engine.APIVersion, nil
+}

--- a/internal/dockerhelper/engine.go
+++ b/internal/dockerhelper/engine.go
@@ -11,15 +11,21 @@ package dockerhelper
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/flags"
 	"github.com/moby/moby/client"
 )
 
 // NewCli is the docker client this binary talks to the engine with.
 func NewCli() (*command.DockerCli, error) {
-	engine, err := client.New(client.FromEnv)
+	// The endpoint comes from the docker context, as it does for `docker` itself, so a
+	// host that keeps its engine elsewhere is reached the same way. It is resolved here
+	// and not on the first call, where the cli exits the process on failure.
+	opts := flags.NewClientOptions()
+	engine, err := command.NewAPIClientFromFlags(opts, config.LoadDefaultConfigFile(io.Discard))
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +33,7 @@ func NewCli() (*command.DockerCli, error) {
 	if err != nil {
 		return nil, err
 	}
-	return docker, docker.Initialize(flags.NewClientOptions())
+	return docker, docker.Initialize(opts)
 }
 
 // EngineVersion is what the engine of this board answers: its version, and the api it

--- a/internal/dockerhelper/images.go
+++ b/internal/dockerhelper/images.go
@@ -12,7 +12,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -60,11 +62,15 @@ func PullImages(ctx context.Context, docker dockerClient.APIClient, images []str
 	totalBytes := sumUniqueLayers(allLayers)
 	slog.Info("total docker images download size", "bytes", totalBytes)
 
-	// The engine may keep its images on another host, and then the space of this one
-	// says nothing: what cannot be checked does not stop a download.
-	if freeSpace, err := dockerFreeSpace(); err != nil {
-		slog.Warn("cannot read the free space of the docker partition", "error", err)
-	} else if uint64(float64(totalBytes)*2.5) > freeSpace {
+	freeSpace, err := dockerFreeSpace(ctx, docker)
+	switch {
+	// The engine keeps its images on another host, and then the space of this one says
+	// nothing: what cannot be checked does not stop a download.
+	case errors.Is(err, errEngineNotLocal):
+		slog.Warn("the docker engine is not local, the free space is not checked", "error", err)
+	case err != nil:
+		return fmt.Errorf("cannot read the free space of the docker root directory: %w", err)
+	case uint64(float64(totalBytes)*2.5) > freeSpace:
 		return ErrOutOfSpace
 	}
 
@@ -89,7 +95,7 @@ func PullImages(ctx context.Context, docker dockerClient.APIClient, images []str
 	return nil
 }
 
-// ListImages reports which images of ImagePrefixes the board already has.
+// ListImages reports every image the engine has, as name:version.
 func ListImages(ctx context.Context, docker dockerClient.APIClient) ([]string, error) {
 	images, err := docker.ImageList(ctx, dockerClient.ImageListOptions{})
 	if err != nil {
@@ -98,13 +104,7 @@ func ListImages(ctx context.Context, docker dockerClient.APIClient) ([]string, e
 
 	result := make([]string, 0, len(images.Items))
 	for _, image := range images.Items {
-		for _, tag := range image.RepoTags {
-			if slices.ContainsFunc(ImagePrefixes, func(p string) bool {
-				return strings.HasPrefix(tag, p)
-			}) {
-				result = append(result, tag)
-			}
-		}
+		result = append(result, image.RepoTags...)
 	}
 
 	return result, nil
@@ -128,19 +128,28 @@ func RemoveImage(ctx context.Context, docker dockerClient.APIClient, imageName s
 	return size, nil
 }
 
-// ImagePrefixes states which images are ours, past ones included: what to pull, and
-// what a cleanup may remove.
-var ImagePrefixes = []string{
-	"ghcr.io/bcmi-labs/",
-	"public.ecr.aws/arduino/",
-	"ghcr.io/arduino/",
-	"influxdb",
-	"artifacts.codelinaro.org/iot-solutions-microservices/",
-}
+// errEngineNotLocal is what an engine reached over the network answers: its disk is not
+// the one of this board.
+var errEngineNotLocal = errors.New("the docker engine does not run on this host")
 
-// dockerFreeSpace is the free space of the partition where docker keeps its images.
-func dockerFreeSpace() (uint64, error) {
-	usage, err := disk.Usage("/var/lib/docker")
+// dockerFreeSpace is the free space of the partition where the engine of this board
+// keeps its images, the directory the engine itself states.
+func dockerFreeSpace(ctx context.Context, docker dockerClient.APIClient) (uint64, error) {
+	if host := docker.DaemonHost(); !strings.HasPrefix(host, "unix://") && !strings.HasPrefix(host, "npipe://") {
+		return 0, fmt.Errorf("%w: %s", errEngineNotLocal, host)
+	}
+
+	info, err := docker.Info(ctx, dockerClient.InfoOptions{})
+	if err != nil {
+		return 0, err
+	}
+	// A desktop engine talks over a local socket but runs in a vm: what it states is a
+	// directory of that vm, and no path of this host.
+	root := info.Info.DockerRootDir
+	if _, err := os.Stat(root); errors.Is(err, fs.ErrNotExist) {
+		return 0, fmt.Errorf("%w: %s is not a directory of this host", errEngineNotLocal, root)
+	}
+	usage, err := disk.Usage(root)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/dockerhelper/images.go
+++ b/internal/dockerhelper/images.go
@@ -60,11 +60,11 @@ func PullImages(ctx context.Context, docker dockerClient.APIClient, images []str
 	totalBytes := sumUniqueLayers(allLayers)
 	slog.Info("total docker images download size", "bytes", totalBytes)
 
-	freeSpace, err := dockerFreeSpace()
-	if err != nil {
-		return err
-	}
-	if uint64(float64(totalBytes)*2.5) > freeSpace {
+	// The engine may keep its images on another host, and then the space of this one
+	// says nothing: what cannot be checked does not stop a download.
+	if freeSpace, err := dockerFreeSpace(); err != nil {
+		slog.Warn("cannot read the free space of the docker partition", "error", err)
+	} else if uint64(float64(totalBytes)*2.5) > freeSpace {
 		return ErrOutOfSpace
 	}
 

--- a/internal/dockerhelper/images.go
+++ b/internal/dockerhelper/images.go
@@ -1,0 +1,239 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dockerhelper
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"slices"
+	"strings"
+	"time"
+
+	dockerClient "github.com/moby/moby/client"
+	"github.com/shirou/gopsutil/v4/disk"
+
+	"github.com/arduino/arduino-app-cli/internal/helpers"
+)
+
+// ErrOutOfSpace is what a download the board has no room for answers.
+var ErrOutOfSpace = errors.New("not enough disk space to pull the docker image")
+
+// images required by the system
+
+// PullImages downloads the images the board has not, as one download: the size comes
+// from the registry, so the percentage is over what is really left to fetch.
+func PullImages(ctx context.Context, docker dockerClient.APIClient, images []string, line func(string), progress func(label string, curr, total int64)) error {
+	if line == nil {
+		line = func(string) {}
+	}
+	if progress == nil {
+		progress = func(string, int64, int64) {}
+	}
+	pulledImages, err := ListImages(ctx, docker)
+	if err != nil {
+		return err
+	}
+	imagesToPull := slices.DeleteFunc(slices.Clone(images), func(image string) bool {
+		return slices.Contains(pulledImages, image)
+	})
+	if len(imagesToPull) == 0 {
+		return nil
+	}
+
+	allLayers := make([]dockerImageLayer, 0, len(imagesToPull))
+	for _, image := range imagesToPull {
+		layers, err := missingLayers(highestVersion(image, pulledImages), image)
+		if err != nil {
+			slog.Warn("Unable to get the new image layers size", "image", image, "error", err)
+		}
+		allLayers = append(allLayers, layers...)
+	}
+	// Shared layers are counted once, so this is the real download size.
+	totalBytes := sumUniqueLayers(allLayers)
+	slog.Info("total docker images download size", "bytes", totalBytes)
+
+	freeSpace, err := dockerFreeSpace()
+	if err != nil {
+		return err
+	}
+	if uint64(float64(totalBytes)*2.5) > freeSpace {
+		return ErrOutOfSpace
+	}
+
+	layerProgress := map[string]int64{}
+	var reported helpers.LastPercent
+	var lastLabel string
+	for i, image := range imagesToPull {
+		line(fmt.Sprintf("Pulling container image %s ...", image))
+		// The percentage stays global (across all images); the label tells the
+		// user which image is currently being pulled.
+		lastLabel = fmt.Sprintf("Pulling image %d/%d (%s)", i+1, len(imagesToPull), imageName(image))
+		if err := pullImage(ctx, docker, image, layerProgress, totalBytes, &reported, func(downloaded int64) {
+			progress(lastLabel, downloaded, totalBytes)
+		}); err != nil {
+			return fmt.Errorf("failed to pull image %s: %w", image, err)
+		}
+	}
+
+	if totalBytes > 0 {
+		progress(lastLabel, totalBytes, totalBytes)
+	}
+	return nil
+}
+
+// ListImages reports which images of ImagePrefixes the board already has.
+func ListImages(ctx context.Context, docker dockerClient.APIClient) ([]string, error) {
+	images, err := docker.ImageList(ctx, dockerClient.ImageListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]string, 0, len(images.Items))
+	for _, image := range images.Items {
+		for _, tag := range image.RepoTags {
+			if slices.ContainsFunc(ImagePrefixes, func(p string) bool {
+				return strings.HasPrefix(tag, p)
+			}) {
+				result = append(result, tag)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func RemoveImage(ctx context.Context, docker dockerClient.APIClient, imageName string) (int64, error) {
+	var size int64
+	if info, err := docker.ImageInspect(ctx, imageName); err != nil {
+		slog.Warn("failed to inspect image", "image", imageName, "error", err)
+	} else {
+		size = info.Size
+	}
+
+	if _, err := docker.ImageRemove(ctx, imageName, dockerClient.ImageRemoveOptions{
+		Force:         true,
+		PruneChildren: true,
+	}); err != nil {
+		return 0, fmt.Errorf("failed to remove image %s: %w", imageName, err)
+	}
+
+	return size, nil
+}
+
+// ImagePrefixes states which images are ours, past ones included: what to pull, and
+// what a cleanup may remove.
+var ImagePrefixes = []string{
+	"ghcr.io/bcmi-labs/",
+	"public.ecr.aws/arduino/",
+	"ghcr.io/arduino/",
+	"influxdb",
+	"artifacts.codelinaro.org/iot-solutions-microservices/",
+}
+
+// dockerFreeSpace is the free space of the partition where docker keeps its images.
+func dockerFreeSpace() (uint64, error) {
+	usage, err := disk.Usage("/var/lib/docker")
+	if err != nil {
+		return 0, err
+	}
+
+	return usage.Free, nil
+}
+
+// updateLayerProgress records the bytes downloaded so far for a single layer
+func updateLayerProgress(layerProgress map[string]int64, status, id string, current int64) int64 {
+	if status == "Downloading" && id != "" {
+		layerProgress[id] = current
+	}
+
+	var downloaded int64
+	for _, c := range layerProgress {
+		downloaded += c
+	}
+	return downloaded
+}
+
+const minDelay = 1 * time.Second
+const maxDelay = 10 * time.Second
+
+func pullImage(ctx context.Context, docker dockerClient.APIClient, imageName string, layerProgress map[string]int64, totalBytes int64, reported *helpers.LastPercent, progress func(downloaded int64)) error {
+	delay := minDelay
+	var out io.ReadCloser
+	var allErr error
+	var lastErr error
+	for range 10 { // 1s, 2s, 4s, 8s, 10s, 10s, 10s, 10s, 10s, 10s
+		out, lastErr = docker.ImagePull(ctx, imageName, dockerClient.ImagePullOptions{})
+		if lastErr == nil {
+			break // Success
+		}
+		allErr = errors.Join(allErr, lastErr)
+
+		if !isTemporaryDockerError(lastErr) {
+			return allErr // Non-retryable error
+		}
+
+		slog.Warn("received 'toomanyrequests' error from Docker registry, retrying", "delay", delay)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+		delay = min(delay*2, maxDelay)
+	}
+	if lastErr != nil {
+		return fmt.Errorf("failed to pull image %s after multiple attempts: %w", imageName, allErr)
+	}
+	defer out.Close()
+
+	scanner := bufio.NewScanner(out)
+	for scanner.Scan() {
+		type Payload struct {
+			Status         string `json:"status"`
+			Progress       string `json:"progress"`
+			ID             string `json:"id"`
+			ProgressDetail struct {
+				Current int64 `json:"current"`
+				Total   int64 `json:"total"`
+			} `json:"progressDetail"`
+		}
+
+		var payload Payload
+		if err := json.Unmarshal(scanner.Bytes(), &payload); err == nil {
+			// Accumulate the downloaded bytes across all layers/images and report
+			// the global download progress.
+			downloaded := min(updateLayerProgress(layerProgress, payload.Status, payload.ID, payload.ProgressDetail.Current), totalBytes)
+			if reported.Moved(downloaded, totalBytes) {
+				progress(downloaded)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func isTemporaryDockerError(err error) bool {
+	errorString := err.Error()
+	transientSubstrings := []string{
+		"toomanyrequests",
+		"Client.Timeout exceeded",
+		"request canceled while waiting for connection",
+	}
+
+	for _, sub := range transientSubstrings {
+		if strings.Contains(errorString, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dockerhelper/images_test.go
+++ b/internal/dockerhelper/images_test.go
@@ -3,9 +3,15 @@
 // SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package orchestrator
+package dockerhelper
 
-import "testing"
+import (
+	"io"
+	"testing"
+
+	dockerClient "github.com/moby/moby/client"
+	"github.com/stretchr/testify/require"
+)
 
 func TestParseDockerImage(t *testing.T) {
 	tests := []struct {
@@ -134,9 +140,9 @@ func TestGetHighestVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetHighestVersion(tt.targetImage, tt.existingImages)
+			got := highestVersion(tt.targetImage, tt.existingImages)
 			if got != tt.expected {
-				t.Errorf("GetHighestVersion() = %q, want %q", got, tt.expected)
+				t.Errorf("highestVersion() = %q, want %q", got, tt.expected)
 			}
 		})
 	}
@@ -217,4 +223,30 @@ func TestImageName(t *testing.T) {
 			t.Errorf("imageName(%q) = %q, want %q", tt.input, got, tt.expected)
 		}
 	}
+}
+
+func TestListImagesAlreadyPulled(t *testing.T) {
+	docker := getDockerCli(t).Client()
+
+	r, err := docker.ImagePull(t.Context(), "ghcr.io/arduino/app-bricks/python-apps-base:0.4.8", dockerClient.ImagePullOptions{})
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, r)
+	r.Close()
+
+	images, err := ListImages(t.Context(), docker)
+	require.NoError(t, err)
+	require.Contains(t, images, "ghcr.io/arduino/app-bricks/python-apps-base:0.4.8")
+}
+
+func TestRemoveImage(t *testing.T) {
+	docker := getDockerCli(t).Client()
+
+	r, err := docker.ImagePull(t.Context(), "ghcr.io/arduino/app-bricks/python-apps-base:0.4.8", dockerClient.ImagePullOptions{})
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, r)
+	r.Close()
+
+	size, err := RemoveImage(t.Context(), docker, "ghcr.io/arduino/app-bricks/python-apps-base:0.4.8")
+	require.NoError(t, err)
+	require.Greater(t, size, int64(1024))
 }

--- a/internal/dockerhelper/registry.go
+++ b/internal/dockerhelper/registry.go
@@ -3,7 +3,10 @@
 // SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package orchestrator
+// What an image is made of, read from the registry and not from the engine: it is how
+// the size of a download is known before it starts.
+
+package dockerhelper
 
 import (
 	"fmt"
@@ -11,51 +14,10 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/shirou/gopsutil/v4/disk"
 	semver "go.bug.st/relaxed-semver"
 )
 
-// Returns the total free disk space in bytes, in the partition where docker stores images.
-func GetDockerFreeSpace() (uint64, error) {
-	usage, err := disk.Usage("/var/lib/docker")
-	if err != nil {
-		return 0, err
-	}
-
-	return usage.Free, nil
-}
-
-// Returns the highest version of a given docker image, from the input list, matching the targetImage.
-func GetHighestVersion(targetImage string, existingImages []string) string {
-	targetBase, _ := parseDockerImage(targetImage)
-
-	var highestVer *semver.Version
-	var highestImg = ""
-
-	for _, img := range existingImages {
-		name, version := parseDockerImage(img)
-
-		if name != targetBase {
-			continue
-		}
-
-		v, err := semver.Parse(version)
-		if err != nil {
-			// Skip any invalid semver tags like "latest".
-			continue
-		}
-
-		if highestVer == nil || !v.LessThan(highestVer) {
-			highestVer = v
-			highestImg = img
-		}
-	}
-
-	// If no matching image is found, an empty string is returned
-	return highestImg
-}
-
-// Splits a docker image in the name and tag/version parts.
+// parseDockerImage splits an image in its name and its tag or version.
 func parseDockerImage(image string) (name string, version string) {
 	if idx := strings.LastIndex(image, "@"); idx != -1 {
 		return image[:idx], image[idx+1:]
@@ -66,16 +28,14 @@ func parseDockerImage(image string) (name string, version string) {
 	return image, ""
 }
 
-// imageName returns the docker image reference without its tag/digest, e.g.
-// "ghcr.io/arduino/app-bricks/python-apps-base" for
-// "ghcr.io/arduino/app-bricks/python-apps-base:0.11.0rc6".
+// imageName is the reference without its tag or digest.
 func imageName(image string) string {
 	name, _ := parseDockerImage(image)
 	return name
 }
 
-// missingLayers returns the layers present in the remote image but not already
-// available locally, i.e. the layers that actually need to be downloaded.
+// missingLayers is what the remote image has and the local one has not: the layers a
+// pull has to download.
 func missingLayers(localRefStr string, remoteRefStr string) ([]dockerImageLayer, error) {
 	localLayers, err := getImageLayers(localRefStr)
 	if err != nil {
@@ -102,9 +62,8 @@ func missingLayers(localRefStr string, remoteRefStr string) ([]dockerImageLayer,
 	return missing, nil
 }
 
-// sumUniqueLayers sums the sizes of the given layers, counting each distinct
-// layer (by digest) only once. Shared layers are downloaded a single time, so
-// this yields the real total number of bytes to download.
+// sumUniqueLayers counts every digest once: a layer shared by two images is downloaded
+// once, so this is the real size of a download.
 func sumUniqueLayers(layers []dockerImageLayer) int64 {
 	uniq := map[string]int64{}
 	for _, l := range layers {
@@ -160,4 +119,34 @@ func getImageLayers(imageName string) ([]dockerImageLayer, error) {
 	}
 
 	return res, nil
+}
+
+// highestVersion is the newest version of the image in the list, or an empty string.
+func highestVersion(targetImage string, existingImages []string) string {
+	targetBase, _ := parseDockerImage(targetImage)
+
+	var highestVer *semver.Version
+	var highestImg = ""
+
+	for _, img := range existingImages {
+		name, version := parseDockerImage(img)
+
+		if name != targetBase {
+			continue
+		}
+
+		v, err := semver.Parse(version)
+		if err != nil {
+			// Skip any invalid semver tags like "latest".
+			continue
+		}
+
+		if highestVer == nil || !v.LessThan(highestVer) {
+			highestVer = v
+			highestImg = img
+		}
+	}
+
+	// If no matching image is found, an empty string is returned
+	return highestImg
 }

--- a/internal/dockerhelper/run.go
+++ b/internal/dockerhelper/run.go
@@ -3,8 +3,6 @@
 // SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// Package dockerhandler provides a thin Docker API wrapper for running a container
-// to completion and streaming its output.
 package dockerhelper
 
 import (
@@ -26,18 +24,20 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// RunOptions is what a container is run with. Only Image is required.
 type RunOptions struct {
-	Image  string
-	Cmd    []string
-	Binds  []string
-	Env    map[string]string
-	Stdout io.Writer
-	Stderr io.Writer
+	Image      string
+	Entrypoint []string
+	Cmd        []string
+	Binds      []string
+	Env        map[string]string
+	Stdout     io.Writer
+	Stderr     io.Writer
 }
 
-// Run creates, starts, and waits for a container to exit, streaming stdout and
-// stderr to the provided writers. The container is always removed on return.
-func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
+// Run is `docker run --rm`: the container is started, waited for and removed, and what
+// it writes reaches the writers. A missing image is downloaded first.
+func Run(ctx context.Context, docker client.APIClient, opts RunOptions) error {
 	if opts.Stdout == nil {
 		opts.Stdout = io.Discard
 	}
@@ -55,7 +55,7 @@ func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
 
 	launchStart := time.Now()
 
-	if err := ensureImage(ctx, cli, opts.Image); err != nil {
+	if err := ensureImage(ctx, docker, opts.Image); err != nil {
 		return err
 	}
 
@@ -69,12 +69,13 @@ func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
 		env = append(env, "HOME=/tmp")
 	}
 
-	resp, err := cli.ContainerCreate(ctx, client.ContainerCreateOptions{
+	resp, err := docker.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Config: &container.Config{
-			Image: opts.Image,
-			Cmd:   opts.Cmd,
-			Env:   env,
-			User:  getCurrentUser(),
+			Image:      opts.Image,
+			Entrypoint: opts.Entrypoint,
+			Cmd:        opts.Cmd,
+			Env:        env,
+			User:       getCurrentUser(),
 		},
 		HostConfig: &container.HostConfig{
 			Binds:      opts.Binds,
@@ -88,10 +89,12 @@ func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
 
 	slog.Debug("creating container", "id", resp.ID, "image", opts.Image, "cmd", opts.Cmd, "env", opts.Env, "binds", opts.Binds)
 
-	wait := cli.ContainerWait(ctx, resp.ID, client.ContainerWaitOptions{Condition: container.WaitConditionNotRunning})
+	// AutoRemove is set, so the status comes with the removal: waiting for the container
+	// to stop races the daemon removing it, and the exit code is lost.
+	wait := docker.ContainerWait(ctx, resp.ID, client.ContainerWaitOptions{Condition: container.WaitConditionRemoved})
 	statusCh, errCh := wait.Result, wait.Error
 
-	attachResp, err := cli.ContainerAttach(ctx, resp.ID, client.ContainerAttachOptions{
+	attachResp, err := docker.ContainerAttach(ctx, resp.ID, client.ContainerAttachOptions{
 		Stream: true,
 		Stdout: true,
 		Stderr: true,
@@ -101,7 +104,7 @@ func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
 	}
 	defer attachResp.Close()
 
-	if _, err := cli.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{}); err != nil {
+	if _, err := docker.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{}); err != nil {
 		return fmt.Errorf("container start: %w", err)
 	}
 	slog.Debug("container launched", "id", resp.ID, "image", opts.Image, "launch_s", time.Since(launchStart).Seconds())
@@ -109,7 +112,7 @@ func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
 	// Stop the container on ctx cancel so the daemon EOFs the attach stream,
 	// which unblocks StdCopy and fires errCh/statusCh.
 	stopOnCancel := context.AfterFunc(ctx, func() {
-		if _, err := cli.ContainerStop(context.Background(), resp.ID, client.ContainerStopOptions{}); err != nil {
+		if _, err := docker.ContainerStop(context.Background(), resp.ID, client.ContainerStopOptions{}); err != nil {
 			slog.Debug("container stop on cancel failed", "id", resp.ID, "err", err)
 		}
 	})
@@ -147,9 +150,7 @@ func Run(ctx context.Context, cli client.APIClient, opts RunOptions) error {
 	return cmp.Or(ctx.Err(), runErr)
 }
 
-// ExitError is returned by Run when the container exits with a non-zero status.
-// Callers can use errors.AsType to inspect the exit code, or IsExitError for
-// a simple boolean check.
+// ExitError is what Run returns for a container that exited non-zero.
 type ExitError struct {
 	Code int64
 }
@@ -158,27 +159,19 @@ func (e *ExitError) Error() string {
 	return fmt.Sprintf("container exited with status %d", e.Code)
 }
 
-// IsExitError reports whether err (or any error wrapped by it) is an *ExitError.
+// IsExitError reports a container that exited non-zero, at any depth of the error.
 func IsExitError(err error) bool {
 	_, ok := errors.AsType[*ExitError](err)
 	return ok
 }
 
-func ensureImage(ctx context.Context, cli client.APIClient, img string) error {
-	if _, err := cli.ImageInspect(ctx, img); err == nil {
+// ensureImage downloads what the board has not, with the disk check and the retry that
+// every other pull has.
+func ensureImage(ctx context.Context, docker client.APIClient, img string) error {
+	if _, err := docker.ImageInspect(ctx, img); err == nil {
 		return nil
 	}
-	slog.Debug("image not found locally, pulling", "image", img)
-	// TODO: we should stream the pull progress to the caller.
-	pullResp, err := cli.ImagePull(ctx, img, client.ImagePullOptions{})
-	if err != nil {
-		return fmt.Errorf("image pull: %w", err)
-	}
-	defer pullResp.Close()
-	if _, err := io.Copy(io.Discard, pullResp); err != nil {
-		return fmt.Errorf("image pull read: %w", err)
-	}
-	return nil
+	return PullImages(ctx, docker, []string{img}, nil, nil)
 }
 
 func getCurrentUser() string {

--- a/internal/dockerhelper/run_test.go
+++ b/internal/dockerhelper/run_test.go
@@ -7,7 +7,6 @@ package dockerhelper
 
 import (
 	"bytes"
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -69,11 +68,6 @@ func TestRun(t *testing.T) {
 func TestPullImages(t *testing.T) {
 	docker := getDockerCli(t).Client()
 	const image = "busybox:latest"
-
-	// What is already pulled is read through the prefixes of our images.
-	previous := ImagePrefixes
-	ImagePrefixes = append(slices.Clone(previous), "busybox")
-	t.Cleanup(func() { ImagePrefixes = previous })
 
 	// Start from a board that does not have it.
 	_, _ = RemoveImage(t.Context(), docker, image)

--- a/internal/dockerhelper/run_test.go
+++ b/internal/dockerhelper/run_test.go
@@ -1,0 +1,110 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dockerhelper
+
+import (
+	"bytes"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRun runs a container to completion the way a model handler and the provisioning
+// are run: the output is what the caller reads, and the exit code is the error.
+func TestRun(t *testing.T) {
+	docker := getDockerCli(t).Client()
+
+	t.Run("the output of the container reaches the writers", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		err := Run(t.Context(), docker, RunOptions{
+			Image:  "busybox:latest",
+			Cmd:    []string{"sh", "-c", "echo out; echo err >&2"},
+			Stdout: &stdout,
+			Stderr: &stderr,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "out\n", stdout.String())
+		require.Equal(t, "err\n", stderr.String())
+	})
+
+	t.Run("the entrypoint is what the caller states", func(t *testing.T) {
+		var stdout bytes.Buffer
+		err := Run(t.Context(), docker, RunOptions{
+			Image:      "busybox:latest",
+			Entrypoint: []string{"/bin/echo", "from the entrypoint"},
+			Stdout:     &stdout,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "from the entrypoint\n", stdout.String())
+	})
+
+	t.Run("a container that fails is an error stating its code", func(t *testing.T) {
+		err := Run(t.Context(), docker, RunOptions{
+			Image: "busybox:latest",
+			Cmd:   []string{"sh", "-c", "exit 3"},
+		})
+		require.Error(t, err)
+		require.True(t, IsExitError(err), err)
+		require.ErrorContains(t, err, "3")
+	})
+
+	t.Run("the environment reaches the container, with a writable home", func(t *testing.T) {
+		var stdout bytes.Buffer
+		err := Run(t.Context(), docker, RunOptions{
+			Image:  "busybox:latest",
+			Cmd:    []string{"sh", "-c", "echo $A_VARIABLE $HOME"},
+			Env:    map[string]string{"A_VARIABLE": "a-value"},
+			Stdout: &stdout,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "a-value /tmp\n", stdout.String())
+	})
+}
+
+// TestPullImages downloads what the board has not, and says how far it got.
+func TestPullImages(t *testing.T) {
+	docker := getDockerCli(t).Client()
+	const image = "busybox:latest"
+
+	// What is already pulled is read through the prefixes of our images.
+	previous := ImagePrefixes
+	ImagePrefixes = append(slices.Clone(previous), "busybox")
+	t.Cleanup(func() { ImagePrefixes = previous })
+
+	// Start from a board that does not have it.
+	_, _ = RemoveImage(t.Context(), docker, image)
+
+	var lines []string
+	var last int64
+	var label string
+	var total int64
+	require.NoError(t, PullImages(t.Context(), docker, []string{image},
+		func(line string) { lines = append(lines, line) },
+		func(l string, curr, tot int64) {
+			require.GreaterOrEqual(t, curr, last, "the download only moves forward")
+			last, label, total = curr, l, tot
+		},
+	))
+
+	require.Contains(t, lines[0], image)
+	require.Contains(t, label, "1/1")
+	require.Equal(t, total, last, "the last report is the whole download")
+
+	// The image is there now, so there is nothing to say and nothing to fetch.
+	lines = nil
+	require.NoError(t, PullImages(t.Context(), docker, []string{image},
+		func(line string) { lines = append(lines, line) }, nil))
+	require.Empty(t, lines)
+}
+
+// TestEngineVersion asks the engine what it is: the board must speak api 1.44 or later.
+func TestEngineVersion(t *testing.T) {
+	version, apiVersion, err := EngineVersion(t.Context(), getDockerCli(t))
+	require.NoError(t, err)
+	require.NotEmpty(t, version)
+	require.NotEmpty(t, apiVersion)
+}

--- a/internal/e2e/daemon/ai_models_handler_test.go
+++ b/internal/e2e/daemon/ai_models_handler_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -30,9 +29,7 @@ func TestModelHandlerDownloadFlow(t *testing.T) {
 	// The API takes the encoded form; modelID stays plain for the messages below.
 	encodedID := models.EncodeModelID(modelID)
 
-	modelsDir, err := paths.MkTempDir("", "models")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = modelsDir.RemoveAll() })
+	modelsDir := e2e.MkTempDir(t, "models")
 
 	httpClient, daemonAddr := GetHttpclientAndAddr(t, e2e.WithModelsDir(modelsDir), e2e.WithBoardName("ventunoq"))
 	requestEditor := func(_ context.Context, _ *http.Request) error { return nil }

--- a/internal/e2e/daemon/ai_models_test.go
+++ b/internal/e2e/daemon/ai_models_test.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/require"
 
 	"github.com/arduino/arduino-app-cli/internal/api/models"
@@ -59,8 +58,7 @@ func TestAIModelList(t *testing.T) {
 func TestAIModelDetails(t *testing.T) {
 	skipWithoutModelsImage(t)
 
-	customModelDir, err := paths.MkTempDir("", "custom-models")
-	require.NoError(t, err)
+	customModelDir := e2e.MkTempDir(t, "custom-models")
 
 	httpClient := GetHttpclient(t, e2e.WithCustomModelDir(customModelDir), e2e.WithBoardName("unoq"))
 
@@ -171,8 +169,7 @@ func TestAIModelDetails(t *testing.T) {
 func TestAIModelDelete(t *testing.T) {
 	skipWithoutModelsImage(t)
 
-	customModelDir, err := paths.MkTempDir("", "custom-models")
-	require.NoError(t, err)
+	customModelDir := e2e.MkTempDir(t, "custom-models")
 
 	httpClient := GetHttpclient(t, e2e.WithCustomModelDir(customModelDir), e2e.WithBoardName("unoq"))
 

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -64,14 +65,12 @@ func WithBoardName(name string) ArduinoAppCLIOption {
 }
 
 func NewArduinoAppCLI(t *testing.T, opts ...ArduinoAppCLIOption) *ArduinoAppCLI {
-	rootDir, err := paths.MkTempDir("", "app-cli")
-	require.NoError(t, err)
+	rootDir := MkTempDir(t, "app-cli")
 	appDir := rootDir.Join("ArduinoApps")
 	dataDir := rootDir.Join("data")
 	originalTestDataDir := FindRepositoryRootPath(t).Join("internal", "e2e", "daemon", "testdata")
 	if originalTestDataDir.Exist() {
-		require.NoError(t, os.CopyFS(dataDir.String(), os.DirFS(originalTestDataDir.String())))
-		require.NoError(t, err, "failed to copy testdata to temp dir")
+		require.NoError(t, os.CopyFS(dataDir.String(), os.DirFS(originalTestDataDir.String())), "failed to copy testdata to temp dir")
 	}
 	require.NoError(t, dataDir.Join("models").MkdirAll())
 
@@ -216,4 +215,19 @@ func (cli *ArduinoAppCLI) CleanUp() {
 	}
 
 	cli.t.NoError(cli.appDir.Parent().RemoveAll())
+}
+
+// MkTempDir is a directory the docker engine can bind-mount. Where the engine runs in
+// a vm of its own, as on a mac, the temporary directory of the host is not shared with
+// it and a bind mount of it is an empty directory owned by root.
+func MkTempDir(t *testing.T, prefix string) *paths.Path {
+	t.Helper()
+	base := ""
+	if runtime.GOOS != "linux" {
+		base = os.Getenv("HOME")
+	}
+	dir, err := paths.MkTempDir(base, prefix)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dir.RemoveAll() })
+	return dir
 }

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetHostIP(t *testing.T) {
@@ -187,4 +188,25 @@ func TestArduinoCLITaskProgressToString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLastPercent(t *testing.T) {
+	var reported LastPercent
+
+	require.True(t, reported.Moved(1, 100), "the first percent is worth reporting")
+	require.False(t, reported.Moved(1, 100), "the same percent is reported once")
+	require.False(t, reported.Moved(19, 1000), "and so is a different total that rounds to it")
+	require.True(t, reported.Moved(2, 100), "a new percent is worth reporting")
+	require.True(t, reported.Moved(100, 100), "the end of the download is too")
+
+	// A download of an unknown size has no percentage to report.
+	var unknown LastPercent
+	require.False(t, unknown.Moved(10, 0))
+	require.False(t, unknown.Moved(10, -1))
+
+	// What starts again starts from zero.
+	var restarted LastPercent
+	require.True(t, restarted.Moved(50, 100))
+	restarted = 0
+	require.True(t, restarted.Moved(50, 100))
 }

--- a/internal/helpers/progress.go
+++ b/internal/helpers/progress.go
@@ -1,0 +1,22 @@
+// This file is part of arduino-app-cli.
+//
+// SPDX-FileCopyrightText: Arduino s.r.l. and/or its affiliated companies
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package helpers
+
+// LastPercent drops what would report the same percentage twice: a download is
+// reported by the chunk, and read by the percent.
+type LastPercent int
+
+func (last *LastPercent) Moved(curr, total int64) bool {
+	if total <= 0 {
+		return false
+	}
+	percent := LastPercent(curr * 100 / total)
+	if percent == *last {
+		return false
+	}
+	*last = percent
+	return true
+}

--- a/internal/orchestrator/app_status.go
+++ b/internal/orchestrator/app_status.go
@@ -14,21 +14,16 @@ import (
 	"github.com/arduino/go-paths-helper"
 	"github.com/docker/cli/cli/command"
 	"github.com/moby/moby/api/types/events"
-	"github.com/moby/moby/client"
 
+	"github.com/arduino/arduino-app-cli/internal/dockerhelper"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/appid"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
 )
 
 func AppStatusEvents(ctx context.Context, cfg config.Configuration, docker command.Cli, idProvider *appid.Provider) iter.Seq2[AppInfo, error] {
-	stream := docker.Client().Events(ctx, client.EventsListOptions{
-		Filters: make(client.Filters).
-			Add("label", DockerAppLabel+"=true").
-			Add("type", string(events.ContainerEventType)).
-			Add("event", "create", "start", "stop", "die", "restart", "destroy", "delete"),
-	})
-	chanMsg, chanError := stream.Messages, stream.Err
+	chanMsg, chanError := dockerhelper.ContainerEvents(ctx, docker.Client(), DockerAppLabel+"=true",
+		"create", "start", "stop", "die", "restart", "destroy", "delete")
 
 	return func(yield func(AppInfo, error) bool) {
 		for {

--- a/internal/orchestrator/helpers.go
+++ b/internal/orchestrator/helpers.go
@@ -18,6 +18,7 @@ import (
 	dockerClient "github.com/moby/moby/client"
 	"go.bug.st/f"
 
+	"github.com/arduino/arduino-app-cli/internal/dockerhelper"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
 	"github.com/arduino/arduino-app-cli/internal/platform"
@@ -96,17 +97,14 @@ func getAppsStatus(
 	ctx context.Context,
 	docker dockerClient.APIClient,
 ) ([]AppStatusInfo, error) {
-	containers, err := docker.ContainerList(ctx, dockerClient.ContainerListOptions{
-		All:     true,
-		Filters: make(dockerClient.Filters).Add("label", DockerAppLabel+"=true"),
-	})
+	containers, err := dockerhelper.Containers(ctx, docker, DockerAppLabel+"=true")
 	if err != nil {
-		return nil, fmt.Errorf("failed to list containers: %w", err)
+		return nil, err
 	}
-	if len(containers.Items) == 0 {
+	if len(containers) == 0 {
 		return nil, nil
 	}
-	return parseAppStatus(containers.Items), nil
+	return parseAppStatus(containers), nil
 }
 
 func getAppStatus(
@@ -114,22 +112,19 @@ func getAppStatus(
 	docker dockerClient.APIClient,
 	app app.ArduinoApp,
 ) (AppStatusInfo, error) {
-	containers, err := docker.ContainerList(ctx, dockerClient.ContainerListOptions{
-		All:     true,
-		Filters: make(dockerClient.Filters).Add("label", DockerAppPathLabel+"="+app.FullPath.String()),
-	})
+	containers, err := dockerhelper.Containers(ctx, docker, DockerAppPathLabel+"="+app.FullPath.String())
 	if err != nil {
-		return AppStatusInfo{}, fmt.Errorf("failed to list containers: %w", err)
+		return AppStatusInfo{}, err
 	}
 
-	if len(containers.Items) == 0 {
+	if len(containers) == 0 {
 		return AppStatusInfo{
 			AppPath: app.FullPath,
 			Status:  StatusUninitialized,
 		}, nil
 	}
 
-	appInfo := parseAppStatus(containers.Items)
+	appInfo := parseAppStatus(containers)
 	if len(appInfo) == 0 {
 		return AppStatusInfo{}, fmt.Errorf("no app status found for app at path %s", app.FullPath)
 	}
@@ -160,17 +155,14 @@ func getRunningApp(
 // getAppServicesFromContainers reads the services of an app from its containers. The
 // compose file is not a source: an update removes the brick files that it includes.
 func getAppServicesFromContainers(ctx context.Context, docker dockerClient.APIClient, app app.ArduinoApp) ([]string, error) {
-	containers, err := docker.ContainerList(ctx, dockerClient.ContainerListOptions{
-		All:     true,
-		Filters: make(dockerClient.Filters).Add("label", DockerAppPathLabel+"="+app.FullPath.String()),
-	})
+	containers, err := dockerhelper.Containers(ctx, docker, DockerAppPathLabel+"="+app.FullPath.String())
 	if err != nil {
-		return nil, fmt.Errorf("failed to list containers: %w", err)
+		return nil, err
 	}
 
 	const dockerComposeServiceLabel = "com.docker.compose.service"
-	services := make([]string, 0, len(containers.Items))
-	for _, info := range containers.Items {
+	services := make([]string, 0, len(containers))
+	for _, info := range containers {
 		if name := info.Labels[dockerComposeServiceLabel]; name != "" && !slices.Contains(services, name) {
 			services = append(services, name)
 		}

--- a/internal/orchestrator/modelsindex/handlers_index.go
+++ b/internal/orchestrator/modelsindex/handlers_index.go
@@ -522,6 +522,8 @@ func deleteInternalModel(ctx context.Context, cli client.APIClient, model AIMode
 		Binds:  ResolveVarsSlice(handler.Volumes, envVars),
 		Env:    envVars,
 		Stdout: io.Discard,
-		Stderr: io.Discard,
+		Stderr: f.NewCallbackWriter(func(line string) {
+			slog.Debug("handler stderr", "line", line)
+		}),
 	})
 }

--- a/internal/orchestrator/modelsindex/models_index.go
+++ b/internal/orchestrator/modelsindex/models_index.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"maps"
 	"slices"
@@ -541,7 +540,9 @@ func (m *ModelsIndex) runDownload(ctx context.Context, cli client.APIClient, mod
 				publish(e)
 			})
 		}),
-		Stderr: io.Discard,
+		Stderr: f.NewCallbackWriter(func(line string) {
+			slog.Debug("handler stderr", "line", line)
+		}),
 	})
 	// The reported event comes first: a handler that prints one usually exits non-zero
 	// too, and the caller has already seen it. The exit is kept for the log.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"os/user"
 	"slices"
 	"sync"
 
@@ -228,25 +227,12 @@ func StartApp(
 				images = append(images, service.Image)
 			}
 		}
-		// The pull reports every chunk of every layer: one message per percent is enough.
-		reported := -1
-		if err := PullAppImages(ctx, docker, images, func(event InitEvent) {
-			switch event.Type {
-			case InitProgressEvent:
-				if event.Progress.Total <= 0 {
-					return
-				}
+		if err := dockerhelper.PullImages(ctx, docker.Client(), images,
+			func(line string) { cb(StreamMessage{data: line}) },
+			func(label string, curr, total int64) {
 				// Downloading the images is from 20% to 80% of the start of an app.
-				percent := 20 + int(event.Progress.Curr*60/event.Progress.Total)
-				if percent == reported {
-					return
-				}
-				reported = percent
-				cb(StreamMessage{progress: &Progress{Name: event.Progress.Label, Progress: float32(percent)}})
-			default:
-				cb(StreamMessage{data: event.Message})
-			}
-		}); err != nil {
+				cb(StreamMessage{progress: &Progress{Name: label, Progress: 20 + float32(curr*60/total)}})
+			}); err != nil {
 			return err
 		}
 
@@ -945,19 +931,6 @@ func editAppDefaults(userApp *app.ArduinoApp, isDefault bool, cfg config.Configu
 		}
 	}
 	return nil
-}
-
-func getCurrentUser() string {
-	userInfo := f.Must(user.Current())
-	uid := userInfo.Uid
-	gid := userInfo.Gid
-
-	// If exist use arduino group to avoid permission issue on files /var/lib/arduino-app-cli in.
-	if gInfo, err := user.LookupGroup("arduino"); err == nil {
-		gid = gInfo.Gid
-	}
-
-	return uid + ":" + gid
 }
 
 func compileUploadSketch(

--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -7,18 +7,15 @@ package orchestrator
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/arduino/go-paths-helper"
 	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli/command"
-	"github.com/moby/moby/api/types/container"
-	dockerClient "github.com/moby/moby/client"
 
+	"github.com/arduino/arduino-app-cli/internal/dockerhelper"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
@@ -150,63 +147,14 @@ func (p *Provision) Render(
 	return prj, nil
 }
 
-func (p *Provision) init(
-	srcPath string,
-) error {
-	containerCfg := &container.Config{
+func (p *Provision) init(srcPath string) error {
+	return dockerhelper.Run(context.Background(), p.docker.Client(), dockerhelper.RunOptions{
 		Image: p.pythonImage,
-		User:  getCurrentUser(),
-		Entrypoint: []string{
-			"/bin/bash",
-			"-c",
-			fmt.Sprintf("%s && %s",
-				"arduino-bricks-list-modules -o /app/bricks-list.yaml -m /app/models-list.yaml",
-				"arduino-bricks-list-modules --provision-compose -o /app",
-			),
-		},
-	}
-	containerHostCfg := &container.HostConfig{
-		Binds:      []string{srcPath + ":/app"},
-		AutoRemove: true,
-	}
-	createOptions := dockerClient.ContainerCreateOptions{Config: containerCfg, HostConfig: containerHostCfg}
-	resp, err := p.docker.Client().ContainerCreate(context.Background(), createOptions)
-	if err != nil {
-		if errors.Is(err, errdefs.ErrNotFound) {
-			if err := pullBasePythonContainer(context.Background(), p.docker, p.pythonImage); err != nil {
-				return fmt.Errorf("provisioning failed to pull base image: %w", err)
-			}
-			// Now that we have pulled the container we recreate it
-			resp, err = p.docker.Client().ContainerCreate(context.Background(), createOptions)
-		}
-		if err != nil {
-			return fmt.Errorf("provisiong failed to create container: %w", err)
-		}
-	}
-
-	slog.Debug("provisioning container created", slog.String("container_id", resp.ID))
-
-	wait := p.docker.Client().ContainerWait(context.Background(), resp.ID, dockerClient.ContainerWaitOptions{Condition: container.WaitConditionNextExit})
-	waitCh, errCh := wait.Result, wait.Error
-	if _, err := p.docker.Client().ContainerStart(context.Background(), resp.ID, dockerClient.ContainerStartOptions{}); err != nil {
-		return fmt.Errorf("provisioning failed to start container: %w", err)
-	}
-	slog.Debug("provisioning container started", slog.String("container_id", resp.ID))
-
-	select {
-	case result := <-waitCh:
-		if result.Error != nil {
-			return fmt.Errorf("provisioning failed: %v", result.Error.Message)
-		}
-	case err := <-errCh:
-		return fmt.Errorf("provisioning failed: %w", err)
-	}
-	return nil
-}
-
-func pullBasePythonContainer(ctx context.Context, docker command.Cli, pythonImage string) error {
-	return pullImage(ctx, docker.Client(), pythonImage, map[string]int64{}, 0, "pulling the base image", func(event InitEvent) {
-		slog.Debug("Pulling container", slog.String("image", pythonImage), slog.String("line", event.Message))
+		Entrypoint: []string{"/bin/bash", "-c", fmt.Sprintf("%s && %s",
+			"arduino-bricks-list-modules -o /app/bricks-list.yaml -m /app/models-list.yaml",
+			"arduino-bricks-list-modules --provision-compose -o /app",
+		)},
+		Binds: []string{srcPath + ":/app"},
 	})
 }
 

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -6,9 +6,7 @@
 package orchestrator
 
 import (
-	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,7 +14,6 @@ import (
 	"os"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/arduino/arduino-cli/commands"
 	rpc "github.com/arduino/arduino-cli/rpc/cc/arduino/cli/commands/v1"
@@ -24,11 +21,12 @@ import (
 	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
-	dockerClient "github.com/moby/moby/client"
 	"github.com/sirupsen/logrus"
 	"go.bug.st/f"
 
 	"github.com/arduino/arduino-app-cli/cmd/feedback"
+	"github.com/arduino/arduino-app-cli/internal/dockerhelper"
+	"github.com/arduino/arduino-app-cli/internal/helpers"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/app"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/config"
@@ -36,8 +34,6 @@ import (
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 	"github.com/arduino/arduino-app-cli/internal/platform"
 )
-
-var ErrDockerOutOfSpace = errors.New("not enough disk space to pull the docker image")
 
 const ExitCodeDockerOutOfSpace = 80
 
@@ -128,196 +124,24 @@ func SystemInit(ctx context.Context, cfg config.Configuration, platform platform
 
 func downloadSupportedImages(ctx context.Context, cfg config.Configuration, brickindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, modelsIndex *modelsindex.ModelsIndex, docker *command.DockerCli, eventCB InitEventCallback) error {
 	eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceDocker, Message: "Pulling the latest docker images ..."})
-	imagesToPreinstall := []string{cfg.PythonImage}
 	brickImages, err := getAllSupportedBrickImages(brickindex, servicesindex)
 	if err != nil {
 		return err
 	}
-
 	handlerImages := modelsIndex.Handlers.GetDockerImages()
 
+	imagesToPreinstall := make([]string, 0, 1+len(brickImages)+len(handlerImages))
+	imagesToPreinstall = append(imagesToPreinstall, cfg.PythonImage)
 	imagesToPreinstall = append(imagesToPreinstall, brickImages...)
 	imagesToPreinstall = append(imagesToPreinstall, handlerImages...)
 
-	pulledImages, err := listImagesAlreadyPulled(ctx, docker.Client())
-	if err != nil {
-		return err
-	}
-
-	// Filter out container images that are already pulled
-	imagesToPreinstall = slices.DeleteFunc(imagesToPreinstall, func(v string) bool {
-		return slices.Contains(pulledImages, v)
-	})
-
-	imagesToPull := make([]string, 0, len(imagesToPreinstall))
-	allLayers := make([]dockerImageLayer, 0, len(imagesToPreinstall))
-	for _, image := range imagesToPreinstall {
-		previousExistingImage := GetHighestVersion(image, pulledImages)
-		layers, err := missingLayers(previousExistingImage, image)
-		if err != nil {
-			slog.Warn("Unable to get the new image layers size", "image", image, "error", err)
-		}
-		var bytes int64
-		for _, l := range layers {
-			bytes += l.Size
-		}
-		imagesToPull = append(imagesToPull, image)
-		allLayers = append(allLayers, layers...)
-		slog.Info("docker image to download", "image", image, "bytes", bytes)
-	}
-	totalBytes := sumUniqueLayers(allLayers)
-	slog.Info("total docker images download size", "bytes", totalBytes)
-
-	// Check that there is enough disk space for all the layers to download.
-	// Shared layers are counted once, so this is the real download size.
-	freeSpace, err := GetDockerFreeSpace()
-	if err != nil {
-		return err
-	}
-	if uint64(float64(totalBytes)*2.5) > freeSpace {
-		return ErrDockerOutOfSpace
-	}
-
-	layerProgress := map[string]int64{}
-	var lastLabel string
-	for i, image := range imagesToPull {
-		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceDocker, Message: fmt.Sprintf("Pulling container image %s ...", image)})
-		// The percentage stays global (across all images); the label tells the
-		// user which image is currently being pulled.
-		lastLabel = fmt.Sprintf("Pulling image %d/%d (%s)", i+1, len(imagesToPull), imageName(image))
-		if err := pullImage(ctx, docker.Client(), image, layerProgress, totalBytes, lastLabel, eventCB); err != nil {
-			return fmt.Errorf("failed to pull image %s: %w", image, err)
-		}
-	}
-
-	if totalBytes > 0 && len(imagesToPull) > 0 {
-		eventCB(InitEvent{Type: InitProgressEvent, Source: InitSourceDocker, Progress: InitProgress{Label: lastLabel, Curr: totalBytes, Total: totalBytes}})
-	}
-
-	return nil
-}
-
-const minDelay = 1 * time.Second
-const maxDelay = 10 * time.Second
-
-// updateLayerProgress records the bytes downloaded so far for a single layer
-func updateLayerProgress(layerProgress map[string]int64, status, id string, current int64) int64 {
-	if status == "Downloading" && id != "" {
-		layerProgress[id] = current
-	}
-
-	var downloaded int64
-	for _, c := range layerProgress {
-		downloaded += c
-	}
-	return downloaded
-}
-
-func pullImage(ctx context.Context, docker dockerClient.APIClient, imageName string, layerProgress map[string]int64, totalBytes int64, progressLabel string, eventCB InitEventCallback) error {
-	delay := minDelay
-	var out io.ReadCloser
-	var allErr error
-	var lastErr error
-	for range 10 { // 1s, 2s, 4s, 8s, 10s, 10s, 10s, 10s, 10s, 10s
-		out, lastErr = docker.ImagePull(ctx, imageName, dockerClient.ImagePullOptions{})
-		if lastErr == nil {
-			break // Success
-		}
-		allErr = errors.Join(allErr, lastErr)
-
-		if !isTemporaryDockerError(lastErr) {
-			return allErr // Non-retryable error
-		}
-
-		eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceDocker, Message: fmt.Sprintf("received 'toomanyrequests' error from Docker registry, retrying in %s ...", delay)})
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(delay):
-		}
-		delay = min(delay*2, maxDelay)
-	}
-	if lastErr != nil {
-		return fmt.Errorf("failed to pull image %s after multiple attempts: %w", imageName, allErr)
-	}
-	defer out.Close()
-
-	scanner := bufio.NewScanner(out)
-	for scanner.Scan() {
-		type Payload struct {
-			Status         string `json:"status"`
-			Progress       string `json:"progress"`
-			ID             string `json:"id"`
-			ProgressDetail struct {
-				Current int64 `json:"current"`
-				Total   int64 `json:"total"`
-			} `json:"progressDetail"`
-		}
-
-		var payload Payload
-		if err := json.Unmarshal(scanner.Bytes(), &payload); err == nil {
-			// Accumulate the downloaded bytes across all layers/images and report
-			// the global download progress.
-			downloaded := updateLayerProgress(layerProgress, payload.Status, payload.ID, payload.ProgressDetail.Current)
-			if totalBytes > 0 {
-				if downloaded > totalBytes {
-					downloaded = totalBytes
-				}
-				eventCB(InitEvent{Type: InitProgressEvent, Source: InitSourceDocker, Progress: InitProgress{Label: progressLabel, Curr: downloaded, Total: totalBytes}})
-			}
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return err
-	}
-	return nil
-}
-func isTemporaryDockerError(err error) bool {
-	errorString := err.Error()
-	transientSubstrings := []string{
-		"toomanyrequests",
-		"Client.Timeout exceeded",
-		"request canceled while waiting for connection",
-	}
-
-	for _, sub := range transientSubstrings {
-		if strings.Contains(errorString, sub) {
-			return true
-		}
-	}
-	return false
-}
-
-// List of prefixes used to identify current or past Arduino images. Used both during 'system init' and during cleanup.
-var imagePrefixes = []string{
-	"ghcr.io/bcmi-labs/",
-	"public.ecr.aws/arduino/",
-	"ghcr.io/arduino/",
-	"influxdb",
-	"artifacts.codelinaro.org/iot-solutions-microservices/",
-}
-
-// Lists all the local docker images that could have been, or are downloaded by Arduino.
-// This is used both to avoid pulling already existing images and cleaning up unused old Arduino images.
-func listImagesAlreadyPulled(ctx context.Context, docker dockerClient.APIClient) ([]string, error) {
-	images, err := docker.ImageList(ctx, dockerClient.ImageListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	result := make([]string, 0, len(images.Items))
-	for _, image := range images.Items {
-		for _, tag := range image.RepoTags {
-			if slices.ContainsFunc(imagePrefixes, func(p string) bool {
-				return strings.HasPrefix(tag, p)
-			}) {
-				result = append(result, tag)
-			}
-		}
-	}
-
-	return result, nil
+	return dockerhelper.PullImages(ctx, docker.Client(), imagesToPreinstall,
+		func(line string) {
+			eventCB(InitEvent{Type: InitLogEvent, Source: InitSourceDocker, Message: line})
+		},
+		func(label string, curr, total int64) {
+			eventCB(InitEvent{Type: InitProgressEvent, Source: InitSourceDocker, Progress: InitProgress{Label: label, Curr: curr, Total: total}})
+		})
 }
 
 func getAllSupportedBrickImages(bricksIndex *bricksindex.BricksIndex, servicesIndex *servicesindex.ServicesIndex) ([]string, error) {
@@ -371,12 +195,12 @@ func extractImagesFromCompose(composeFile *paths.Path) ([]string, error) {
 		return nil, err
 	}
 	for _, v := range prj.Services {
-		if slices.ContainsFunc(imagePrefixes, func(p string) bool {
+		if slices.ContainsFunc(dockerhelper.ImagePrefixes, func(p string) bool {
 			return strings.HasPrefix(v.Image, p)
 		}) {
 			result = append(result, v.Image)
 		} else {
-			slog.Warn("skipping image that does not match known prefixes", "image", v.Image, "prefixes", imagePrefixes)
+			slog.Warn("skipping image that does not match known prefixes", "image", v.Image, "prefixes", dockerhelper.ImagePrefixes)
 		}
 	}
 	return result, nil
@@ -414,12 +238,16 @@ func SystemCleanup(ctx context.Context, cfg config.Configuration, bricksindex *b
 	}
 
 	// Remove dangling stuff
-	if count, err := removeDanglingContainers(ctx, docker.Client()); err != nil {
+	if count, err := dockerhelper.PruneContainers(ctx, docker.Client(), DockerAppLabel+"=true", nil); err != nil {
 		feedback.Warnf("failed to remove dangling containers - %v", err)
 	} else {
 		result.ContainersRemoved = count
 	}
-	if count, err := removeDanglingNetworks(ctx, docker.Client()); err != nil {
+	// A project of ours is a slug of the path of an app, which the label states.
+	const composeProjectLabel = "com.docker.compose.project"
+	if count, err := dockerhelper.PruneNetworks(ctx, docker.Client(), composeProjectLabel, func(labels map[string]string) bool {
+		return strings.Contains(labels[composeProjectLabel], "arduino-app-cli")
+	}); err != nil {
 		feedback.Warnf("failed to remove dangling networks - %v", err)
 	} else {
 		result.NetworksRemoved = count
@@ -432,7 +260,7 @@ func SystemCleanup(ctx context.Context, cfg config.Configuration, bricksindex *b
 	}
 	slog.Debug("images that must stay", "imagesMustStay", imagesMustStay)
 
-	allImages, err := listImagesAlreadyPulled(ctx, docker.Client())
+	allImages, err := dockerhelper.ListImages(ctx, docker.Client())
 	if err != nil {
 		return result, err
 	}
@@ -444,7 +272,7 @@ func SystemCleanup(ctx context.Context, cfg config.Configuration, bricksindex *b
 	slog.Info("images to remove", "imagesToRemove", imagesToRemove)
 
 	for _, image := range imagesToRemove {
-		imageSize, err := removeImage(ctx, docker.Client(), image)
+		imageSize, err := dockerhelper.RemoveImage(ctx, docker.Client(), image)
 		if err != nil {
 			feedback.Warnf("failed to remove image %s - %v", image, err)
 			continue
@@ -456,25 +284,6 @@ func SystemCleanup(ctx context.Context, cfg config.Configuration, bricksindex *b
 	return result, nil
 }
 
-func removeImage(ctx context.Context, docker dockerClient.APIClient, imageName string) (int64, error) {
-	var size int64
-	if info, err := docker.ImageInspect(ctx, imageName); err != nil {
-		feedback.Warnf("failed to inspect image %s - %v", imageName, err)
-	} else {
-		size = info.Size
-	}
-
-	if _, err := docker.ImageRemove(ctx, imageName, dockerClient.ImageRemoveOptions{
-		Force:         true,
-		PruneChildren: true,
-	}); err != nil {
-		return 0, fmt.Errorf("failed to remove image %s: %w", imageName, err)
-	}
-
-	return size, nil
-}
-
-// images required by the system
 func getRequiredImages(cfg config.Configuration, bricksindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, modelsIndex *modelsindex.ModelsIndex) ([]string, error) {
 	bricksContainers, err := getAllSupportedBrickImages(bricksindex, servicesindex)
 	if err != nil {
@@ -489,53 +298,6 @@ func getRequiredImages(cfg config.Configuration, bricksindex *bricksindex.Bricks
 	requiredImages = append(requiredImages, handlerImages...)
 
 	return requiredImages, nil
-}
-
-func removeDanglingContainers(ctx context.Context, docker dockerClient.APIClient) (int, error) {
-	containers, err := docker.ContainerList(ctx, dockerClient.ContainerListOptions{
-		All:     true,
-		Filters: make(dockerClient.Filters).Add("label", DockerAppLabel+"=true"),
-	})
-	if err != nil {
-		return 0, fmt.Errorf("failed to list containers: %w", err)
-	}
-
-	var counter int
-	for _, info := range containers.Items {
-		if _, err := docker.ContainerRemove(ctx, info.ID, dockerClient.ContainerRemoveOptions{
-			Force:         true,
-			RemoveVolumes: true,
-		}); err != nil {
-			return 0, fmt.Errorf("failed to remove container %s: %w", info.ID, err)
-		}
-		counter++
-	}
-
-	return counter, nil
-}
-
-func removeDanglingNetworks(ctx context.Context, docker dockerClient.APIClient) (int, error) {
-	const dockerComposeProjectLabel = "com.docker.compose.project"
-
-	networks, err := docker.NetworkList(ctx, dockerClient.NetworkListOptions{
-		Filters: make(dockerClient.Filters).Add("label", dockerComposeProjectLabel),
-	})
-	if err != nil {
-		return 0, fmt.Errorf("failed to list networks: %w", err)
-	}
-
-	var counter int
-	for _, info := range networks.Items {
-		if !strings.Contains(info.Labels[dockerComposeProjectLabel], "arduino-app-cli") {
-			continue
-		}
-		if _, err := docker.NetworkRemove(ctx, info.ID, dockerClient.NetworkRemoveOptions{}); err != nil {
-			return 0, fmt.Errorf("failed to remove network %s: %w", info.ID, err)
-		}
-		counter++
-	}
-
-	return counter, nil
 }
 
 func installPlatformPackage(ctx context.Context, plat platform.Platform, eventCB InitEventCallback) error {
@@ -592,19 +354,21 @@ func downloadLibsAndPlatformsUsedInExamples(ctx context.Context, cfg config.Conf
 
 	// Download progress CB
 	currLabel := ""
-	totalSize := int64(0)
+	var reported helpers.LastPercent
 	downloadProgressCB := func(curr *rpc.DownloadProgress) {
 		if start := curr.GetStart(); start != nil {
 			currLabel = start.GetLabel()
+			reported = 0
 		}
-		if update := curr.GetUpdate(); update != nil {
-			totalSize = update.GetTotalSize()
-			eventCB(InitEvent{Type: InitProgressEvent, Source: InitSourceArduino, Progress: InitProgress{
-				Label: currLabel,
-				Curr:  update.GetDownloaded(),
-				Total: totalSize,
-			}})
+		update := curr.GetUpdate()
+		if update == nil || !reported.Moved(update.GetDownloaded(), update.GetTotalSize()) {
+			return
 		}
+		eventCB(InitEvent{Type: InitProgressEvent, Source: InitSourceArduino, Progress: InitProgress{
+			Label: currLabel,
+			Curr:  update.GetDownloaded(),
+			Total: update.GetTotalSize(),
+		}})
 	}
 
 	// Force-update of the Arduino Libraries index
@@ -712,47 +476,5 @@ func downloadSketchLibsUsedInApp(ctx context.Context, appPath *paths.Path, platf
 		return fmt.Errorf("could not initialize sketch %s: %w", sketchPath.String(), err)
 	}
 
-	return nil
-}
-
-// PullAppImages downloads what an app needs before it is started, the way the system
-// init does: the size is read from the registry, so the percentage is over what is left.
-func PullAppImages(ctx context.Context, docker command.Cli, images []string, eventCB InitEventCallback) error {
-	pulledImages, err := listImagesAlreadyPulled(ctx, docker.Client())
-	if err != nil {
-		return err
-	}
-	imagesToPull := slices.DeleteFunc(slices.Clone(images), func(image string) bool {
-		return slices.Contains(pulledImages, image)
-	})
-	if len(imagesToPull) == 0 {
-		return nil
-	}
-
-	var allLayers []dockerImageLayer
-	for _, image := range imagesToPull {
-		layers, err := missingLayers(GetHighestVersion(image, pulledImages), image)
-		if err != nil {
-			slog.Warn("Unable to get the new image layers size", "image", image, "error", err)
-		}
-		allLayers = append(allLayers, layers...)
-	}
-	totalBytes := sumUniqueLayers(allLayers)
-
-	freeSpace, err := GetDockerFreeSpace()
-	if err != nil {
-		return err
-	}
-	if uint64(float64(totalBytes)*2.5) > freeSpace {
-		return ErrDockerOutOfSpace
-	}
-
-	layerProgress := map[string]int64{}
-	for i, image := range imagesToPull {
-		label := fmt.Sprintf("Pulling image %d/%d (%s)", i+1, len(imagesToPull), imageName(image))
-		if err := pullImage(ctx, docker.Client(), image, layerProgress, totalBytes, label, eventCB); err != nil {
-			return fmt.Errorf("failed to pull image %s: %w", image, err)
-		}
-	}
 	return nil
 }

--- a/internal/orchestrator/system.go
+++ b/internal/orchestrator/system.go
@@ -195,15 +195,26 @@ func extractImagesFromCompose(composeFile *paths.Path) ([]string, error) {
 		return nil, err
 	}
 	for _, v := range prj.Services {
-		if slices.ContainsFunc(dockerhelper.ImagePrefixes, func(p string) bool {
-			return strings.HasPrefix(v.Image, p)
-		}) {
+		if isOurImage(v.Image) {
 			result = append(result, v.Image)
 		} else {
-			slog.Warn("skipping image that does not match known prefixes", "image", v.Image, "prefixes", dockerhelper.ImagePrefixes)
+			slog.Warn("skipping image that is not one of ours", "image", v.Image)
 		}
 	}
 	return result, nil
+}
+
+// isOurImage states if an image is one of ours, past ones included: what to pull, and
+// what a cleanup may remove.
+func isOurImage(image string) bool {
+	prefixes := []string{
+		"ghcr.io/bcmi-labs/",
+		"public.ecr.aws/arduino/",
+		"ghcr.io/arduino/",
+		"influxdb",
+		"artifacts.codelinaro.org/iot-solutions-microservices/",
+	}
+	return slices.ContainsFunc(prefixes, func(p string) bool { return strings.HasPrefix(image, p) })
 }
 
 type SystemCleanupResult struct {
@@ -266,9 +277,7 @@ func SystemCleanup(ctx context.Context, cfg config.Configuration, bricksindex *b
 	}
 	slog.Debug("all images already pulled", "allImages", allImages)
 
-	imagesToRemove := slices.DeleteFunc(allImages, func(v string) bool {
-		return slices.Contains(imagesMustStay, v)
-	})
+	imagesToRemove := removableImages(allImages, imagesMustStay)
 	slog.Info("images to remove", "imagesToRemove", imagesToRemove)
 
 	for _, image := range imagesToRemove {
@@ -282,6 +291,13 @@ func SystemCleanup(ctx context.Context, cfg config.Configuration, bricksindex *b
 	}
 
 	return result, nil
+}
+
+// removableImages is what a cleanup may delete: our images, minus the ones in use.
+func removableImages(allImages, imagesMustStay []string) []string {
+	return slices.DeleteFunc(slices.Clone(allImages), func(image string) bool {
+		return !isOurImage(image) || slices.Contains(imagesMustStay, image)
+	})
 }
 
 func getRequiredImages(cfg config.Configuration, bricksindex *bricksindex.BricksIndex, servicesindex *servicesindex.ServicesIndex, modelsIndex *modelsindex.ModelsIndex) ([]string, error) {

--- a/internal/orchestrator/system_test.go
+++ b/internal/orchestrator/system_test.go
@@ -6,63 +6,20 @@
 package orchestrator
 
 import (
-	"io"
 	"testing"
 
 	"github.com/arduino/go-paths-helper"
-	dockerCommand "github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/flags"
-	dockerClient "github.com/moby/moby/client"
 	"github.com/stretchr/testify/require"
-	"go.bug.st/f"
 
+	"github.com/arduino/arduino-app-cli/internal/dockerhelper"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 )
 
-func TestListImagesAlreadyPulled(t *testing.T) {
-	docker := getDockerClient(t)
-
-	r, err := docker.ImagePull(t.Context(), "ghcr.io/arduino/app-bricks/python-apps-base:0.4.8", dockerClient.ImagePullOptions{})
-	require.NoError(t, err)
-	_, _ = io.Copy(io.Discard, r)
-	r.Close()
-
-	images, err := listImagesAlreadyPulled(t.Context(), docker)
-	require.NoError(t, err)
-	require.Contains(t, images, "ghcr.io/arduino/app-bricks/python-apps-base:0.4.8")
-}
-
-func TestRemoveImage(t *testing.T) {
-	docker := getDockerClient(t)
-
-	r, err := docker.ImagePull(t.Context(), "ghcr.io/arduino/app-bricks/python-apps-base:0.4.8", dockerClient.ImagePullOptions{})
-	require.NoError(t, err)
-	_, _ = io.Copy(io.Discard, r)
-	r.Close()
-
-	size, err := removeImage(t.Context(), docker, "ghcr.io/arduino/app-bricks/python-apps-base:0.4.8")
-	require.NoError(t, err)
-	require.Greater(t, size, int64(1024))
-}
-
-func getDockerClient(t *testing.T) dockerClient.APIClient {
-	t.Helper()
-	d, err := dockerCommand.NewDockerCli(
-		dockerCommand.WithAPIClient(
-			f.Must(dockerClient.New(dockerClient.FromEnv)),
-		),
-	)
-	require.NoError(t, err)
-	err = d.Initialize(flags.NewClientOptions())
-	require.NoError(t, err)
-	return d.Client()
-}
-
 func TestExtractImagesFromCompose(t *testing.T) {
-	oldPrefixes := imagePrefixes
-	imagePrefixes = []string{"ghcr.io/bcmi-labs/", "public.ecr.aws/arduino/", "ghcr.io/arduino/", "influxdb"}
-	defer func() { imagePrefixes = oldPrefixes }()
+	oldPrefixes := dockerhelper.ImagePrefixes
+	dockerhelper.ImagePrefixes = []string{"ghcr.io/bcmi-labs/", "public.ecr.aws/arduino/", "ghcr.io/arduino/", "influxdb"}
+	defer func() { dockerhelper.ImagePrefixes = oldPrefixes }()
 
 	tests := []struct {
 		name           string

--- a/internal/orchestrator/system_test.go
+++ b/internal/orchestrator/system_test.go
@@ -6,21 +6,17 @@
 package orchestrator
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/require"
 
-	"github.com/arduino/arduino-app-cli/internal/dockerhelper"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/bricksindex"
 	"github.com/arduino/arduino-app-cli/internal/orchestrator/servicesindex"
 )
 
 func TestExtractImagesFromCompose(t *testing.T) {
-	oldPrefixes := dockerhelper.ImagePrefixes
-	dockerhelper.ImagePrefixes = []string{"ghcr.io/bcmi-labs/", "public.ecr.aws/arduino/", "ghcr.io/arduino/", "influxdb"}
-	defer func() { dockerhelper.ImagePrefixes = oldPrefixes }()
-
 	tests := []struct {
 		name           string
 		composePath    *paths.Path
@@ -133,6 +129,49 @@ func TestGetAllSupportedBrickImages(t *testing.T) {
 			got, err := getAllSupportedBrickImages(bIndex, services)
 			require.NoError(t, err)
 			require.ElementsMatch(t, tt.expectedImages, got)
+		})
+	}
+}
+
+func TestRemovableImages(t *testing.T) {
+	tests := []struct {
+		name           string
+		allImages      []string
+		imagesMustStay []string
+		expectedImages []string
+	}{
+		{
+			name:           "an image that is not ours is never removed",
+			allImages:      []string{"alpine:latest", "postgres:16"},
+			expectedImages: []string{},
+		},
+		{
+			name:           "our images that nothing uses are removed",
+			allImages:      []string{"ghcr.io/arduino/app-bricks/genie-service:1.0.0", "influxdb:2.7"},
+			expectedImages: []string{"ghcr.io/arduino/app-bricks/genie-service:1.0.0", "influxdb:2.7"},
+		},
+		{
+			name:           "our images in use stay",
+			allImages:      []string{"ghcr.io/arduino/a:1.0", "ghcr.io/arduino/b:1.0", "alpine:latest"},
+			imagesMustStay: []string{"ghcr.io/arduino/a:1.0"},
+			expectedImages: []string{"ghcr.io/arduino/b:1.0"},
+		},
+		{
+			name:           "another version of an image in use is removed",
+			allImages:      []string{"ghcr.io/arduino/a:1.0", "ghcr.io/arduino/a:2.0"},
+			imagesMustStay: []string{"ghcr.io/arduino/a:2.0"},
+			expectedImages: []string{"ghcr.io/arduino/a:1.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := slices.Clone(tt.allImages)
+
+			got := removableImages(tt.allImages, tt.imagesMustStay)
+
+			require.ElementsMatch(t, tt.expectedImages, got)
+			require.Equal(t, before, tt.allImages, "the list of the caller is not touched")
 		})
 	}
 }


### PR DESCRIPTION
### Motivation

Move all Docker utilities into the dockerhelper module.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [x] PR addresses a single concern.
- [x] PR title and description are properly filled.
- [x] Changes will be merged in `main`.
- [x] Changes are covered by tests.
- [x] Logging is meaningful in case of troubleshooting.
